### PR TITLE
AIチャットのMarkdownリンク描画を修正

### DIFF
--- a/src/components/AiChatWidget.astro
+++ b/src/components/AiChatWidget.astro
@@ -262,7 +262,7 @@ const phoneParts = SITE.phone.split('-')
 
       function appendInlineMarkdown(parent, text) {
         const pattern =
-          /(\[([^\]]+)\]\(([^)\s]+)\)|\*\*([^*]+)\*\*|__([^_]+)__|`([^`]+)`|\*([^*]+)\*|_([^_]+)_)/g
+          /(\[([^\]]+)\]\(\s*([^)]+?)\s*\)|\*\*([^*]+)\*\*|__([^_]+)__|`([^`]+)`|\*([^*]+)\*|_([^_]+)_)/g
         let index = 0
         let match
 
@@ -273,11 +273,12 @@ const phoneParts = SITE.phone.split('-')
             )
           }
 
-          if (match[2] && isSafeMarkdownHref(match[3])) {
+          const href = String(match[3] || '').trim()
+          if (match[2] && isSafeMarkdownHref(href)) {
             const link = document.createElement('a')
-            link.href = match[3]
+            link.href = href
             link.rel = 'noopener noreferrer'
-            if (/^https?:\/\//i.test(match[3])) {
+            if (/^https?:\/\//i.test(href)) {
               link.target = '_blank'
             }
             link.textContent = match[2]


### PR DESCRIPTION
## 概要

AIチャットの回答に `[サービス一覧]( /services/ )` のような、URLの前後に空白が入ったMarkdownリンクが含まれると、そのまま文字列として表示される問題を修正しました。

## 変更内容

- AIチャットのインラインMarkdown解析で、リンクURL前後の空白を許容するようにしました。
- 実際にDOMへ設定する `href` はtrim済みのURLにしました。
- 既存の安全なリンク判定は維持しています。

## 確認内容

- `node -e` で以下のリンク表記が同じURLとして抽出されることを確認
  - `[サービス一覧]( /services/ )`
  - `[サービス一覧](/services/)`
  - `[LINE]( https://lin.ee/DjIrdqj )`
- `npx prettier --check src/components/AiChatWidget.astro`
- `git diff --check -- src/components/AiChatWidget.astro`
- `npm run build`
- Browserプラグインは `windows sandbox failed: spawn setup refresh` で起動できなかったため、通常のPlaywright + Edgeにフォールバック
- ローカルpreview `http://127.0.0.1:5432/contact/` で `/api/ai-contact` の応答を `詳しくは[サービス一覧]( /services/ )をご覧ください。` に差し替え、チャット内で `サービス一覧` が `/services/` へのリンクとして描画され、元のMarkdown文字列が残らないことを確認