### PR TITLE
[codex] 著者情報を多言語で充実化

### DIFF
--- a/src/content/authors/gui.json
+++ b/src/content/authors/gui.json
@@ -3,51 +3,114 @@
   "name": "Gui",
   "avatar": "",
   "avatarImage": "",
-  "bio": "Acecore 代表。システム開発・Web制作・インフラ運用からIT教育まで幅広く手がけるエンジニア。\n技術で人と組織の課題を解きほぐすのが好き。",
+  "bio": "Acecore 代表。Webサイト制作、Astro/Cloudflare Pages を使った静的サイト構築、業務システム開発、インフラ運用、IT教育を横断して担当するエンジニア。\n要件整理から設計・実装・公開後の改善まで一貫して関わり、技術と運用の両面から人と組織の課題を解きほぐすことを大切にしている。",
   "url": "https://acecore.net/about/",
   "github": "https://github.com/acecore-systems",
   "twitter": "https://x.com/acecorenet",
-  "skills": ["システム開発", "Web制作", "インフラ運用", "IT教育"],
+  "skills": [
+    "システム開発",
+    "Web制作",
+    "Astro/Cloudflare",
+    "インフラ運用",
+    "AI活用支援",
+    "IT教育"
+  ],
   "i18n": {
     "en": {
       "name": "Gui",
-      "bio": "CEO of Acecore. A versatile engineer covering system development, web production, infrastructure operations, and IT education.\nEnjoys solving organizational and human challenges through technology.",
-      "skills": ["System development", "Web production", "Infrastructure operations", "IT education"]
+      "bio": "CEO of Acecore. An engineer working across website production, static site development with Astro and Cloudflare Pages, business system development, infrastructure operations, and IT education.\nInvolved from requirements and design through implementation and post-launch improvement, with a focus on solving human and organizational challenges from both technical and operational perspectives.",
+      "skills": [
+        "System development",
+        "Web production",
+        "Astro/Cloudflare",
+        "Infrastructure operations",
+        "AI enablement",
+        "IT education"
+      ]
     },
     "zh-cn": {
       "name": "Gui",
-      "bio": "Acecore 代表。从系统开发、Web制作、基础设施运维到IT教育，涉猎广泛的工程师。\n喜欢用技术解决人和组织的课题。",
-      "skills": ["系统开发", "Web制作", "基础设施运维", "IT教育"]
+      "bio": "Acecore 代表。负责 Web 制作、使用 Astro 与 Cloudflare Pages 的静态站点构建、业务系统开发、基础设施运维以及 IT 教育等多个领域的工程师。\n从需求整理、设计、实现到上线后的持续改进都会参与，重视从技术和运营两个角度解决人和组织面临的问题。",
+      "skills": [
+        "系统开发",
+        "Web制作",
+        "Astro/Cloudflare",
+        "基础设施运维",
+        "AI应用支持",
+        "IT教育"
+      ]
     },
     "es": {
       "name": "Gui",
-      "bio": "CEO de Acecore. Un ingeniero versátil que abarca desarrollo de sistemas, producción web, operaciones de infraestructura y educación en TI.\nDisfruta resolviendo desafíos organizacionales y humanos a través de la tecnología.",
-      "skills": ["Desarrollo de sistemas", "Producción web", "Operaciones de infraestructura", "Educación en TI"]
+      "bio": "CEO de Acecore. Ingeniero que trabaja en producción web, creación de sitios estáticos con Astro y Cloudflare Pages, desarrollo de sistemas empresariales, operaciones de infraestructura y educación en TI.\nParticipa desde la definición de requisitos y el diseño hasta la implementación y la mejora posterior al lanzamiento, con foco en resolver desafíos humanos y organizacionales desde la tecnología y la operación.",
+      "skills": [
+        "Desarrollo de sistemas",
+        "Producción web",
+        "Astro/Cloudflare",
+        "Operaciones de infraestructura",
+        "Uso de IA",
+        "Educación en TI"
+      ]
     },
     "pt": {
       "name": "Gui",
-      "bio": "CEO da Acecore. Engenheiro versátil que trabalha com desenvolvimento de sistemas, produção web, operações de infraestrutura e educação em TI.\nGosta de resolver desafios organizacionais e humanos por meio da tecnologia.",
-      "skills": ["Desenvolvimento de sistemas", "Produção web", "Operações de infraestrutura", "Educação em TI"]
+      "bio": "CEO da Acecore. Engenheiro que atua em produção web, criação de sites estáticos com Astro e Cloudflare Pages, desenvolvimento de sistemas de negócio, operações de infraestrutura e educação em TI.\nParticipa desde o levantamento de requisitos e o design até a implementação e a melhoria pós-lançamento, com foco em resolver desafios humanos e organizacionais pelos lados técnico e operacional.",
+      "skills": [
+        "Desenvolvimento de sistemas",
+        "Produção web",
+        "Astro/Cloudflare",
+        "Operações de infraestrutura",
+        "Uso de IA",
+        "Educação em TI"
+      ]
     },
     "fr": {
       "name": "Gui",
-      "bio": "PDG d'Acecore. Ingénieur polyvalent couvrant le développement de systèmes, la production web, les opérations d'infrastructure et l'enseignement informatique.\nAime résoudre les défis organisationnels et humains grâce à la technologie.",
-      "skills": ["Développement de systèmes", "Production web", "Opérations d'infrastructure", "Enseignement informatique"]
+      "bio": "PDG d'Acecore. Ingénieur intervenant sur la production web, la création de sites statiques avec Astro et Cloudflare Pages, le développement de systèmes métier, les opérations d'infrastructure et l'enseignement informatique.\nParticipe de la clarification des besoins et de la conception jusqu'à la mise en œuvre et l'amélioration après lancement, avec l'objectif de résoudre les défis humains et organisationnels par la technique et l'exploitation.",
+      "skills": [
+        "Développement de systèmes",
+        "Production web",
+        "Astro/Cloudflare",
+        "Opérations d'infrastructure",
+        "Usage de l'IA",
+        "Enseignement informatique"
+      ]
     },
     "ko": {
       "name": "Gui",
-      "bio": "Acecore 대표. 시스템 개발, 웹 제작, 인프라 운영부터 IT 교육까지 폭넓게 다루는 엔지니어.\n기술로 사람과 조직의 과제를 풀어가는 것을 좋아합니다.",
-      "skills": ["시스템 개발", "웹 제작", "인프라 운영", "IT 교육"]
+      "bio": "Acecore 대표. 웹 제작, Astro/Cloudflare Pages 기반 정적 사이트 구축, 업무 시스템 개발, 인프라 운영, IT 교육을 폭넓게 담당하는 엔지니어입니다.\n요구사항 정리와 설계부터 구현, 공개 이후 개선까지 함께하며 기술과 운영 양쪽에서 사람과 조직의 과제를 풀어가는 것을 중요하게 생각합니다.",
+      "skills": [
+        "시스템 개발",
+        "웹 제작",
+        "Astro/Cloudflare",
+        "인프라 운영",
+        "AI 활용 지원",
+        "IT 교육"
+      ]
     },
     "de": {
       "name": "Gui",
-      "bio": "CEO von Acecore. Ein vielseitiger Ingenieur, der Systementwicklung, Webproduktion, Infrastrukturbetrieb und IT-Bildung abdeckt.\nLöst gerne organisatorische und menschliche Herausforderungen durch Technologie.",
-      "skills": ["Systementwicklung", "Webproduktion", "Infrastrukturbetrieb", "IT-Bildung"]
+      "bio": "CEO von Acecore. Ingenieur mit Schwerpunkt auf Webproduktion, statischen Websites mit Astro und Cloudflare Pages, Entwicklung von Geschäftssystemen, Infrastrukturbetrieb und IT-Bildung.\nBegleitet Projekte von Anforderungen und Design bis zur Umsetzung und Verbesserung nach dem Launch und löst menschliche sowie organisatorische Herausforderungen aus technischer und betrieblicher Perspektive.",
+      "skills": [
+        "Systementwicklung",
+        "Webproduktion",
+        "Astro/Cloudflare",
+        "Infrastrukturbetrieb",
+        "KI-Nutzung",
+        "IT-Bildung"
+      ]
     },
     "ru": {
       "name": "Gui",
-      "bio": "Генеральный директор Acecore. Универсальный инженер, охватывающий разработку систем, веб-производство, управление инфраструктурой и IT-образование.\nЛюбит решать организационные и человеческие задачи с помощью технологий.",
-      "skills": ["Разработка систем", "Веб-производство", "Управление инфраструктурой", "IT-образование"]
+      "bio": "Генеральный директор Acecore. Инженер, работающий с веб-производством, статическими сайтами на Astro и Cloudflare Pages, разработкой бизнес-систем, эксплуатацией инфраструктуры и IT-образованием.\nУчаствует в проектах от уточнения требований и проектирования до реализации и улучшений после запуска, помогая решать человеческие и организационные задачи с технической и операционной стороны.",
+      "skills": [
+        "Разработка систем",
+        "Веб-производство",
+        "Astro/Cloudflare",
+        "Эксплуатация инфраструктуры",
+        "Использование ИИ",
+        "IT-образование"
+      ]
     }
   }
 }

--- a/src/content/authors/gui.json
+++ b/src/content/authors/gui.json
@@ -3,111 +3,138 @@
   "name": "Gui",
   "avatar": "",
   "avatarImage": "",
-  "bio": "Acecore 代表。Webサイト制作、Astro/Cloudflare Pages を使った静的サイト構築、業務システム開発、インフラ運用、IT教育を横断して担当するエンジニア。\n要件整理から設計・実装・公開後の改善まで一貫して関わり、技術と運用の両面から人と組織の課題を解きほぐすことを大切にしている。",
+  "bio": "Acecore 代表。業務システム開発、Web制作、DB/インフラ、品質保証、現場機器連携、GitHub運用まで横断して扱うエンジニア。\nC#/.NET を軸に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども扱い、要件整理から設計・実装・テスト・導入・運用改善まで一気通貫で対応する。\n公開GitHubでは Astro/Cloudflare Pages のサイト運用、Microfeed系プロジェクト、ドキュメント/コミュニティ系リポジトリの整備にも関わっている。",
   "url": "https://acecore.net/about/",
   "github": "https://github.com/acecore-systems",
   "twitter": "https://x.com/acecorenet",
   "skills": [
     "システム開発",
     "Web制作",
-    "Astro/Cloudflare",
-    "インフラ運用",
+    "C#/.NET",
+    "DB・インフラ",
+    "GitHub運用",
+    "品質保証",
+    "現場機器連携",
     "AI活用支援",
     "IT教育"
   ],
   "i18n": {
     "en": {
       "name": "Gui",
-      "bio": "CEO of Acecore. An engineer working across website production, static site development with Astro and Cloudflare Pages, business system development, infrastructure operations, and IT education.\nInvolved from requirements and design through implementation and post-launch improvement, with a focus on solving human and organizational challenges from both technical and operational perspectives.",
+      "bio": "CEO of Acecore. An engineer working across business systems, web production, databases and infrastructure, quality assurance, on-site device integration, and GitHub-based development workflows.\nUses C#/.NET as a core stack while also handling PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server, and takes projects from requirements and design through implementation, testing, deployment, and operational improvement.\nPublic GitHub work includes Astro/Cloudflare Pages sites, Microfeed-related projects, and documentation/community repositories.",
       "skills": [
         "System development",
+        "C#/.NET",
         "Web production",
-        "Astro/Cloudflare",
-        "Infrastructure operations",
+        "Databases/infrastructure",
+        "GitHub workflows",
+        "Quality assurance",
+        "Device integration",
         "AI enablement",
         "IT education"
       ]
     },
     "zh-cn": {
       "name": "Gui",
-      "bio": "Acecore 代表。负责 Web 制作、使用 Astro 与 Cloudflare Pages 的静态站点构建、业务系统开发、基础设施运维以及 IT 教育等多个领域的工程师。\n从需求整理、设计、实现到上线后的持续改进都会参与，重视从技术和运营两个角度解决人和组织面临的问题。",
+      "bio": "Acecore 代表。横跨业务系统开发、Web 制作、数据库与基础设施、质量保证、现场设备联动以及基于 GitHub 的开发流程的工程师。\n以 C#/.NET 为主要技术栈，同时也使用 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，从需求整理、设计、实现、测试、导入到运维改进都能一贯对应。\n公开 GitHub 上也参与 Astro/Cloudflare Pages 网站、Microfeed 相关项目以及文档/社区类仓库的维护。",
       "skills": [
         "系统开发",
+        "C#/.NET",
         "Web制作",
-        "Astro/Cloudflare",
-        "基础设施运维",
+        "数据库/基础设施",
+        "GitHub流程",
+        "质量保证",
+        "设备联动",
         "AI应用支持",
         "IT教育"
       ]
     },
     "es": {
       "name": "Gui",
-      "bio": "CEO de Acecore. Ingeniero que trabaja en producción web, creación de sitios estáticos con Astro y Cloudflare Pages, desarrollo de sistemas empresariales, operaciones de infraestructura y educación en TI.\nParticipa desde la definición de requisitos y el diseño hasta la implementación y la mejora posterior al lanzamiento, con foco en resolver desafíos humanos y organizacionales desde la tecnología y la operación.",
+      "bio": "CEO de Acecore. Ingeniero que trabaja en sistemas empresariales, producción web, bases de datos e infraestructura, aseguramiento de calidad, integración con dispositivos en sitio y flujos de desarrollo basados en GitHub.\nUsa C#/.NET como stack principal, pero también trabaja con PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, cubriendo desde requisitos y diseño hasta implementación, pruebas, despliegue y mejora operativa.\nSu trabajo público en GitHub incluye sitios con Astro/Cloudflare Pages, proyectos relacionados con Microfeed y repositorios de documentación/comunidad.",
       "skills": [
         "Desarrollo de sistemas",
+        "C#/.NET",
         "Producción web",
-        "Astro/Cloudflare",
-        "Operaciones de infraestructura",
+        "Bases de datos/infraestructura",
+        "Flujos de GitHub",
+        "Aseguramiento de calidad",
+        "Integración de dispositivos",
         "Uso de IA",
         "Educación en TI"
       ]
     },
     "pt": {
       "name": "Gui",
-      "bio": "CEO da Acecore. Engenheiro que atua em produção web, criação de sites estáticos com Astro e Cloudflare Pages, desenvolvimento de sistemas de negócio, operações de infraestrutura e educação em TI.\nParticipa desde o levantamento de requisitos e o design até a implementação e a melhoria pós-lançamento, com foco em resolver desafios humanos e organizacionais pelos lados técnico e operacional.",
+      "bio": "CEO da Acecore. Engenheiro que atua em sistemas de negócio, produção web, bancos de dados e infraestrutura, garantia de qualidade, integração com dispositivos em campo e fluxos de desenvolvimento baseados em GitHub.\nUsa C#/.NET como stack principal, mas também trabalha com PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, cobrindo requisitos, design, implementação, testes, implantação e melhoria operacional.\nO trabalho público no GitHub inclui sites com Astro/Cloudflare Pages, projetos relacionados ao Microfeed e repositórios de documentação/comunidade.",
       "skills": [
         "Desenvolvimento de sistemas",
+        "C#/.NET",
         "Produção web",
-        "Astro/Cloudflare",
-        "Operações de infraestrutura",
+        "Bancos de dados/infraestrutura",
+        "Fluxos de GitHub",
+        "Garantia de qualidade",
+        "Integração de dispositivos",
         "Uso de IA",
         "Educação em TI"
       ]
     },
     "fr": {
       "name": "Gui",
-      "bio": "PDG d'Acecore. Ingénieur intervenant sur la production web, la création de sites statiques avec Astro et Cloudflare Pages, le développement de systèmes métier, les opérations d'infrastructure et l'enseignement informatique.\nParticipe de la clarification des besoins et de la conception jusqu'à la mise en œuvre et l'amélioration après lancement, avec l'objectif de résoudre les défis humains et organisationnels par la technique et l'exploitation.",
+      "bio": "PDG d'Acecore. Ingénieur intervenant sur les systèmes métier, la production web, les bases de données et l'infrastructure, l'assurance qualité, l'intégration d'équipements sur site et les flux de développement basés sur GitHub.\nTravaille principalement avec C#/.NET, tout en utilisant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, de la clarification des besoins et de la conception jusqu'à l'implémentation, aux tests, au déploiement et à l'amélioration opérationnelle.\nSon travail public sur GitHub comprend des sites Astro/Cloudflare Pages, des projets liés à Microfeed et des dépôts de documentation/communauté.",
       "skills": [
         "Développement de systèmes",
+        "C#/.NET",
         "Production web",
-        "Astro/Cloudflare",
-        "Opérations d'infrastructure",
+        "Bases de données/infrastructure",
+        "Flux GitHub",
+        "Assurance qualité",
+        "Intégration d'équipements",
         "Usage de l'IA",
         "Enseignement informatique"
       ]
     },
     "ko": {
       "name": "Gui",
-      "bio": "Acecore 대표. 웹 제작, Astro/Cloudflare Pages 기반 정적 사이트 구축, 업무 시스템 개발, 인프라 운영, IT 교육을 폭넓게 담당하는 엔지니어입니다.\n요구사항 정리와 설계부터 구현, 공개 이후 개선까지 함께하며 기술과 운영 양쪽에서 사람과 조직의 과제를 풀어가는 것을 중요하게 생각합니다.",
+      "bio": "Acecore 대표. 업무 시스템 개발, 웹 제작, DB/인프라, 품질 보증, 현장 장비 연동, GitHub 기반 개발 흐름까지 폭넓게 다루는 엔지니어입니다.\nC#/.NET을 중심으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 다루며, 요구사항 정리와 설계부터 구현, 테스트, 도입, 운영 개선까지 일관되게 대응합니다.\n공개 GitHub에서는 Astro/Cloudflare Pages 사이트 운영, Microfeed 관련 프로젝트, 문서/커뮤니티 계열 저장소 정비에도 참여하고 있습니다.",
       "skills": [
         "시스템 개발",
+        "C#/.NET",
         "웹 제작",
-        "Astro/Cloudflare",
-        "인프라 운영",
+        "DB/인프라",
+        "GitHub 워크플로",
+        "품질 보증",
+        "장비 연동",
         "AI 활용 지원",
         "IT 교육"
       ]
     },
     "de": {
       "name": "Gui",
-      "bio": "CEO von Acecore. Ingenieur mit Schwerpunkt auf Webproduktion, statischen Websites mit Astro und Cloudflare Pages, Entwicklung von Geschäftssystemen, Infrastrukturbetrieb und IT-Bildung.\nBegleitet Projekte von Anforderungen und Design bis zur Umsetzung und Verbesserung nach dem Launch und löst menschliche sowie organisatorische Herausforderungen aus technischer und betrieblicher Perspektive.",
+      "bio": "CEO von Acecore. Ingenieur für Geschäftssysteme, Webproduktion, Datenbanken und Infrastruktur, Qualitätssicherung, Integration von Geräten vor Ort und GitHub-basierte Entwicklungsabläufe.\nArbeitet hauptsächlich mit C#/.NET, aber auch mit PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, von Anforderungen und Design bis Implementierung, Tests, Einführung und operativer Verbesserung.\nÖffentliche GitHub-Arbeiten umfassen Astro/Cloudflare-Pages-Websites, Microfeed-bezogene Projekte sowie Dokumentations- und Community-Repositories.",
       "skills": [
         "Systementwicklung",
+        "C#/.NET",
         "Webproduktion",
-        "Astro/Cloudflare",
-        "Infrastrukturbetrieb",
+        "Datenbanken/Infrastruktur",
+        "GitHub-Workflows",
+        "Qualitätssicherung",
+        "Geräteintegration",
         "KI-Nutzung",
         "IT-Bildung"
       ]
     },
     "ru": {
       "name": "Gui",
-      "bio": "Генеральный директор Acecore. Инженер, работающий с веб-производством, статическими сайтами на Astro и Cloudflare Pages, разработкой бизнес-систем, эксплуатацией инфраструктуры и IT-образованием.\nУчаствует в проектах от уточнения требований и проектирования до реализации и улучшений после запуска, помогая решать человеческие и организационные задачи с технической и операционной стороны.",
+      "bio": "Генеральный директор Acecore. Инженер, работающий с бизнес-системами, веб-разработкой, базами данных и инфраструктурой, обеспечением качества, интеграцией оборудования на местах и GitHub-ориентированными процессами разработки.\nОсновной стек — C#/.NET, но также использует PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, сопровождая проекты от требований и проектирования до реализации, тестирования, внедрения и операционных улучшений.\nПубличная работа на GitHub включает сайты на Astro/Cloudflare Pages, проекты, связанные с Microfeed, а также репозитории документации и сообщества.",
       "skills": [
         "Разработка систем",
+        "C#/.NET",
         "Веб-производство",
-        "Astro/Cloudflare",
-        "Эксплуатация инфраструктуры",
+        "Базы данных/инфраструктура",
+        "GitHub-процессы",
+        "Обеспечение качества",
+        "Интеграция устройств",
         "Использование ИИ",
         "IT-образование"
       ]

--- a/src/content/authors/gui.json
+++ b/src/content/authors/gui.json
@@ -3,7 +3,7 @@
   "name": "Gui",
   "avatar": "",
   "avatarImage": "",
-  "bio": "Acecore 代表。業務システム開発、Web制作、DB/インフラ、品質保証、現場機器連携、GitHub運用まで横断して扱うエンジニア。\nC#/.NET を軸に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども扱い、要件整理から設計・実装・テスト・導入・運用改善まで一気通貫で対応する。\n公開GitHubでは Astro/Cloudflare Pages のサイト運用、Microfeed系プロジェクト、ドキュメント/コミュニティ系リポジトリの整備にも関わっている。",
+  "bio": "Acecore 代表。業務システム開発、Web制作、DB/インフラ、品質保証、現場機器連携、GitHub運用、生成AI活用まで横断して扱うエンジニア。\nC#/.NET を軸に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども扱い、要件整理から設計・実装・テスト・導入・運用改善まで一気通貫で対応する。\nAIは開発補助に留めず、多言語翻訳フロー、問い合わせAIチャット、Playwrightを使ったモンキーテスト、調査・事務作業の整理まで、実際の運用に組み込んでいる。",
   "url": "https://acecore.net/about/",
   "github": "https://github.com/acecore-systems",
   "twitter": "https://x.com/acecorenet",
@@ -13,129 +13,138 @@
     "C#/.NET",
     "DB・インフラ",
     "GitHub運用",
+    "生成AI活用",
+    "AIワークフロー設計",
     "品質保証",
     "現場機器連携",
-    "AI活用支援",
     "IT教育"
   ],
   "i18n": {
     "en": {
       "name": "Gui",
-      "bio": "CEO of Acecore. An engineer working across business systems, web production, databases and infrastructure, quality assurance, on-site device integration, and GitHub-based development workflows.\nUses C#/.NET as a core stack while also handling PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server, and takes projects from requirements and design through implementation, testing, deployment, and operational improvement.\nPublic GitHub work includes Astro/Cloudflare Pages sites, Microfeed-related projects, and documentation/community repositories.",
+      "bio": "CEO of Acecore. An engineer working across business systems, web production, databases and infrastructure, quality assurance, on-site device integration, GitHub-based development workflows, and practical generative AI adoption.\nUses C#/.NET as a core stack while also handling PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server, and takes projects from requirements and design through implementation, testing, deployment, and operational improvement.\nUses AI beyond coding assistance, incorporating it into multilingual translation workflows, inquiry chatbots, Playwright-based monkey testing, research, and back-office task organization.",
       "skills": [
         "System development",
         "C#/.NET",
         "Web production",
         "Databases/infrastructure",
         "GitHub workflows",
+        "Generative AI",
+        "AI workflow design",
         "Quality assurance",
         "Device integration",
-        "AI enablement",
         "IT education"
       ]
     },
     "zh-cn": {
       "name": "Gui",
-      "bio": "Acecore 代表。横跨业务系统开发、Web 制作、数据库与基础设施、质量保证、现场设备联动以及基于 GitHub 的开发流程的工程师。\n以 C#/.NET 为主要技术栈，同时也使用 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，从需求整理、设计、实现、测试、导入到运维改进都能一贯对应。\n公开 GitHub 上也参与 Astro/Cloudflare Pages 网站、Microfeed 相关项目以及文档/社区类仓库的维护。",
+      "bio": "Acecore 代表。横跨业务系统开发、Web 制作、数据库与基础设施、质量保证、现场设备联动、基于 GitHub 的开发流程以及生成式 AI 实务应用的工程师。\n以 C#/.NET 为主要技术栈，同时也使用 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，从需求整理、设计、实现、测试、导入到运维改进都能一贯对应。\nAI 不只用于编码辅助，也实际用于多语言翻译流程、咨询 AI 聊天、基于 Playwright 的猴子测试、调查和后台事务整理。",
       "skills": [
         "系统开发",
         "C#/.NET",
         "Web制作",
         "数据库/基础设施",
         "GitHub流程",
+        "生成式AI",
+        "AI工作流设计",
         "质量保证",
         "设备联动",
-        "AI应用支持",
         "IT教育"
       ]
     },
     "es": {
       "name": "Gui",
-      "bio": "CEO de Acecore. Ingeniero que trabaja en sistemas empresariales, producción web, bases de datos e infraestructura, aseguramiento de calidad, integración con dispositivos en sitio y flujos de desarrollo basados en GitHub.\nUsa C#/.NET como stack principal, pero también trabaja con PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, cubriendo desde requisitos y diseño hasta implementación, pruebas, despliegue y mejora operativa.\nSu trabajo público en GitHub incluye sitios con Astro/Cloudflare Pages, proyectos relacionados con Microfeed y repositorios de documentación/comunidad.",
+      "bio": "CEO de Acecore. Ingeniero que trabaja en sistemas empresariales, producción web, bases de datos e infraestructura, aseguramiento de calidad, integración con dispositivos en sitio, flujos de desarrollo basados en GitHub y adopción práctica de IA generativa.\nUsa C#/.NET como stack principal, pero también trabaja con PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, cubriendo desde requisitos y diseño hasta implementación, pruebas, despliegue y mejora operativa.\nUsa la IA más allá de la asistencia al código, incorporándola en flujos de traducción multilingüe, chatbots de consulta, pruebas tipo monkey con Playwright, investigación y organización de tareas administrativas.",
       "skills": [
         "Desarrollo de sistemas",
         "C#/.NET",
         "Producción web",
         "Bases de datos/infraestructura",
         "Flujos de GitHub",
+        "IA generativa",
+        "Diseño de flujos de IA",
         "Aseguramiento de calidad",
         "Integración de dispositivos",
-        "Uso de IA",
         "Educación en TI"
       ]
     },
     "pt": {
       "name": "Gui",
-      "bio": "CEO da Acecore. Engenheiro que atua em sistemas de negócio, produção web, bancos de dados e infraestrutura, garantia de qualidade, integração com dispositivos em campo e fluxos de desenvolvimento baseados em GitHub.\nUsa C#/.NET como stack principal, mas também trabalha com PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, cobrindo requisitos, design, implementação, testes, implantação e melhoria operacional.\nO trabalho público no GitHub inclui sites com Astro/Cloudflare Pages, projetos relacionados ao Microfeed e repositórios de documentação/comunidade.",
+      "bio": "CEO da Acecore. Engenheiro que atua em sistemas de negócio, produção web, bancos de dados e infraestrutura, garantia de qualidade, integração com dispositivos em campo, fluxos de desenvolvimento baseados em GitHub e adoção prática de IA generativa.\nUsa C#/.NET como stack principal, mas também trabalha com PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, cobrindo requisitos, design, implementação, testes, implantação e melhoria operacional.\nUsa IA além da assistência de código, incorporando-a em fluxos de tradução multilíngue, chatbots de atendimento, testes monkey com Playwright, pesquisa e organização de tarefas administrativas.",
       "skills": [
         "Desenvolvimento de sistemas",
         "C#/.NET",
         "Produção web",
         "Bancos de dados/infraestrutura",
         "Fluxos de GitHub",
+        "IA generativa",
+        "Design de fluxos de IA",
         "Garantia de qualidade",
         "Integração de dispositivos",
-        "Uso de IA",
         "Educação em TI"
       ]
     },
     "fr": {
       "name": "Gui",
-      "bio": "PDG d'Acecore. Ingénieur intervenant sur les systèmes métier, la production web, les bases de données et l'infrastructure, l'assurance qualité, l'intégration d'équipements sur site et les flux de développement basés sur GitHub.\nTravaille principalement avec C#/.NET, tout en utilisant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, de la clarification des besoins et de la conception jusqu'à l'implémentation, aux tests, au déploiement et à l'amélioration opérationnelle.\nSon travail public sur GitHub comprend des sites Astro/Cloudflare Pages, des projets liés à Microfeed et des dépôts de documentation/communauté.",
+      "bio": "PDG d'Acecore. Ingénieur intervenant sur les systèmes métier, la production web, les bases de données et l'infrastructure, l'assurance qualité, l'intégration d'équipements sur site, les flux de développement basés sur GitHub et l'adoption concrète de l'IA générative.\nTravaille principalement avec C#/.NET, tout en utilisant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, de la clarification des besoins et de la conception jusqu'à l'implémentation, aux tests, au déploiement et à l'amélioration opérationnelle.\nUtilise l'IA au-delà de l'assistance au code, en l'intégrant aux flux de traduction multilingue, aux chatbots de demande, aux tests monkey avec Playwright, à la recherche et à l'organisation de tâches administratives.",
       "skills": [
         "Développement de systèmes",
         "C#/.NET",
         "Production web",
         "Bases de données/infrastructure",
         "Flux GitHub",
+        "IA générative",
+        "Conception de flux IA",
         "Assurance qualité",
         "Intégration d'équipements",
-        "Usage de l'IA",
         "Enseignement informatique"
       ]
     },
     "ko": {
       "name": "Gui",
-      "bio": "Acecore 대표. 업무 시스템 개발, 웹 제작, DB/인프라, 품질 보증, 현장 장비 연동, GitHub 기반 개발 흐름까지 폭넓게 다루는 엔지니어입니다.\nC#/.NET을 중심으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 다루며, 요구사항 정리와 설계부터 구현, 테스트, 도입, 운영 개선까지 일관되게 대응합니다.\n공개 GitHub에서는 Astro/Cloudflare Pages 사이트 운영, Microfeed 관련 프로젝트, 문서/커뮤니티 계열 저장소 정비에도 참여하고 있습니다.",
+      "bio": "Acecore 대표. 업무 시스템 개발, 웹 제작, DB/인프라, 품질 보증, 현장 장비 연동, GitHub 기반 개발 흐름, 생성형 AI 실무 활용까지 폭넓게 다루는 엔지니어입니다.\nC#/.NET을 중심으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 다루며, 요구사항 정리와 설계부터 구현, 테스트, 도입, 운영 개선까지 일관되게 대응합니다.\nAI를 코딩 보조에만 쓰지 않고 다국어 번역 흐름, 문의 AI 챗봇, Playwright 기반 몽키 테스트, 조사와 사무 작업 정리까지 실제 운영에 통합하고 있습니다.",
       "skills": [
         "시스템 개발",
         "C#/.NET",
         "웹 제작",
         "DB/인프라",
         "GitHub 워크플로",
+        "생성형 AI",
+        "AI 워크플로 설계",
         "품질 보증",
         "장비 연동",
-        "AI 활용 지원",
         "IT 교육"
       ]
     },
     "de": {
       "name": "Gui",
-      "bio": "CEO von Acecore. Ingenieur für Geschäftssysteme, Webproduktion, Datenbanken und Infrastruktur, Qualitätssicherung, Integration von Geräten vor Ort und GitHub-basierte Entwicklungsabläufe.\nArbeitet hauptsächlich mit C#/.NET, aber auch mit PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, von Anforderungen und Design bis Implementierung, Tests, Einführung und operativer Verbesserung.\nÖffentliche GitHub-Arbeiten umfassen Astro/Cloudflare-Pages-Websites, Microfeed-bezogene Projekte sowie Dokumentations- und Community-Repositories.",
+      "bio": "CEO von Acecore. Ingenieur für Geschäftssysteme, Webproduktion, Datenbanken und Infrastruktur, Qualitätssicherung, Integration von Geräten vor Ort, GitHub-basierte Entwicklungsabläufe und praktische Einführung generativer KI.\nArbeitet hauptsächlich mit C#/.NET, aber auch mit PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, von Anforderungen und Design bis Implementierung, Tests, Einführung und operativer Verbesserung.\nNutzt KI nicht nur als Coding-Hilfe, sondern integriert sie in mehrsprachige Übersetzungsabläufe, Anfrage-Chatbots, Monkey-Tests mit Playwright, Recherche und die Organisation administrativer Aufgaben.",
       "skills": [
         "Systementwicklung",
         "C#/.NET",
         "Webproduktion",
         "Datenbanken/Infrastruktur",
         "GitHub-Workflows",
+        "Generative KI",
+        "KI-Workflow-Design",
         "Qualitätssicherung",
         "Geräteintegration",
-        "KI-Nutzung",
         "IT-Bildung"
       ]
     },
     "ru": {
       "name": "Gui",
-      "bio": "Генеральный директор Acecore. Инженер, работающий с бизнес-системами, веб-разработкой, базами данных и инфраструктурой, обеспечением качества, интеграцией оборудования на местах и GitHub-ориентированными процессами разработки.\nОсновной стек — C#/.NET, но также использует PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, сопровождая проекты от требований и проектирования до реализации, тестирования, внедрения и операционных улучшений.\nПубличная работа на GitHub включает сайты на Astro/Cloudflare Pages, проекты, связанные с Microfeed, а также репозитории документации и сообщества.",
+      "bio": "Генеральный директор Acecore. Инженер, работающий с бизнес-системами, веб-разработкой, базами данных и инфраструктурой, обеспечением качества, интеграцией оборудования, GitHub-ориентированными процессами разработки и практическим внедрением генеративного ИИ.\nОсновной стек — C#/.NET, но также использует PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, сопровождая проекты от требований и проектирования до реализации, тестирования, внедрения и операционных улучшений.\nИспользует ИИ не только как помощника в кодинге, но и в многоязычных переводческих процессах, чатботах для обращений, monkey-тестировании с Playwright, исследованиях и организации административных задач.",
       "skills": [
         "Разработка систем",
         "C#/.NET",
         "Веб-производство",
         "Базы данных/инфраструктура",
         "GitHub-процессы",
+        "Генеративный ИИ",
+        "Проектирование ИИ-процессов",
         "Обеспечение качества",
         "Интеграция устройств",
-        "Использование ИИ",
         "IT-образование"
       ]
     }

--- a/src/content/authors/gui.json
+++ b/src/content/authors/gui.json
@@ -3,149 +3,149 @@
   "name": "Gui",
   "avatar": "",
   "avatarImage": "",
-  "bio": "Acecore 代表。業務システム開発、Web制作、DB/インフラ、品質保証、現場機器連携、GitHub運用、生成AI活用まで横断して扱うエンジニア。\nC#/.NET を軸に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども扱い、要件整理から設計・実装・テスト・導入・運用改善まで一気通貫で対応する。\nAIは開発補助に留めず、多言語翻訳フロー、問い合わせAIチャット、Playwrightを使ったモンキーテスト、調査・事務作業の整理まで、実際の運用に組み込んでいる。",
+  "bio": "Acecore 代表。業務システム、Web、DB/インフラ、品質保証、AI活用を、単発の作業ではなく事業課題の整理から設計・導入後の改善までつなげて推進している。\nC#/.NET を軸にした実装力を土台に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども踏まえ、要件整理、技術選定、品質基準、GitHubベースの開発運用まで一体で設計する。\n生成AIは単なる作業効率化ではなく、多言語翻訳、問い合わせAIチャット、Playwrightによるテスト自動化、調査・事務整理に組み込み、小規模チームでも速く確かな成果を出すための実務基盤として活用している。",
   "url": "https://acecore.net/about/",
   "github": "https://github.com/acecore-systems",
   "twitter": "https://x.com/acecorenet",
   "skills": [
-    "システム開発",
-    "Web制作",
+    "事業課題整理",
+    "技術選定",
+    "システム設計",
     "C#/.NET",
-    "DB・インフラ",
-    "GitHub運用",
+    "DB・インフラ設計",
+    "GitHub開発運用",
     "生成AI活用",
     "AIワークフロー設計",
-    "品質保証",
-    "現場機器連携",
-    "IT教育"
+    "品質設計",
+    "現場連携"
   ],
   "i18n": {
     "en": {
       "name": "Gui",
-      "bio": "CEO of Acecore. An engineer working across business systems, web production, databases and infrastructure, quality assurance, on-site device integration, GitHub-based development workflows, and practical generative AI adoption.\nUses C#/.NET as a core stack while also handling PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server, and takes projects from requirements and design through implementation, testing, deployment, and operational improvement.\nUses AI beyond coding assistance, incorporating it into multilingual translation workflows, inquiry chatbots, Playwright-based monkey testing, research, and back-office task organization.",
+      "bio": "CEO of Acecore. Leads business systems, web, databases and infrastructure, quality assurance, and AI adoption as connected business initiatives, from clarifying problems to design, rollout, and post-launch improvement.\nBuilds on hands-on C#/.NET capability while also covering PHP/JavaScript, SQL Server/PostgreSQL/MySQL, and Linux/Windows Server, designing requirements, technology choices, quality standards, and GitHub-based development operations as one coherent workflow.\nUses generative AI not just for task efficiency, but as an operational foundation for multilingual translation, inquiry chatbots, Playwright-based test automation, research, and back-office organization so small teams can deliver faster with confidence.",
       "skills": [
-        "System development",
+        "Business problem framing",
+        "Technology selection",
+        "System design",
         "C#/.NET",
-        "Web production",
-        "Databases/infrastructure",
-        "GitHub workflows",
+        "Database/infrastructure design",
+        "GitHub development operations",
         "Generative AI",
         "AI workflow design",
-        "Quality assurance",
-        "Device integration",
-        "IT education"
+        "Quality design",
+        "On-site integration"
       ]
     },
     "zh-cn": {
       "name": "Gui",
-      "bio": "Acecore 代表。横跨业务系统开发、Web 制作、数据库与基础设施、质量保证、现场设备联动、基于 GitHub 的开发流程以及生成式 AI 实务应用的工程师。\n以 C#/.NET 为主要技术栈，同时也使用 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，从需求整理、设计、实现、测试、导入到运维改进都能一贯对应。\nAI 不只用于编码辅助，也实际用于多语言翻译流程、咨询 AI 聊天、基于 Playwright 的猴子测试、调查和后台事务整理。",
+      "bio": "Acecore 代表。从业务课题梳理到设计、导入和上线后的改进，统筹推进业务系统、Web、数据库/基础设施、质量保证以及 AI 应用，而不是只处理单项作业。\n以 C#/.NET 的实际开发能力为基础，同时理解 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，将需求整理、技术选型、质量标准和基于 GitHub 的开发运营作为整体流程来设计。\n生成式 AI 不只是用于提高作业效率，也被纳入多语言翻译、咨询 AI 聊天、基于 Playwright 的测试自动化、调查和后台事务整理，作为小团队快速而可靠交付的业务基础。",
       "skills": [
-        "系统开发",
+        "业务课题梳理",
+        "技术选型",
+        "系统设计",
         "C#/.NET",
-        "Web制作",
-        "数据库/基础设施",
-        "GitHub流程",
+        "数据库/基础设施设计",
+        "GitHub开发运营",
         "生成式AI",
         "AI工作流设计",
-        "质量保证",
-        "设备联动",
-        "IT教育"
+        "质量设计",
+        "现场联动"
       ]
     },
     "es": {
       "name": "Gui",
-      "bio": "CEO de Acecore. Ingeniero que trabaja en sistemas empresariales, producción web, bases de datos e infraestructura, aseguramiento de calidad, integración con dispositivos en sitio, flujos de desarrollo basados en GitHub y adopción práctica de IA generativa.\nUsa C#/.NET como stack principal, pero también trabaja con PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, cubriendo desde requisitos y diseño hasta implementación, pruebas, despliegue y mejora operativa.\nUsa la IA más allá de la asistencia al código, incorporándola en flujos de traducción multilingüe, chatbots de consulta, pruebas tipo monkey con Playwright, investigación y organización de tareas administrativas.",
+      "bio": "CEO de Acecore. Lidera sistemas de negocio, web, bases de datos e infraestructura, calidad y adopción de IA como iniciativas conectadas al negocio, desde la definición del problema hasta el diseño, la puesta en marcha y la mejora posterior.\nSe apoya en capacidad práctica con C#/.NET y también cubre PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, diseñando requisitos, selección tecnológica, estándares de calidad y operaciones de desarrollo basadas en GitHub como un flujo coherente.\nUsa la IA generativa no solo para mejorar la eficiencia, sino como una base operativa para traducción multilingüe, chatbots de consulta, automatización de pruebas con Playwright, investigación y organización administrativa, ayudando a equipos pequeños a entregar más rápido y con confianza.",
       "skills": [
-        "Desarrollo de sistemas",
+        "Definición de problemas de negocio",
+        "Selección tecnológica",
+        "Diseño de sistemas",
         "C#/.NET",
-        "Producción web",
-        "Bases de datos/infraestructura",
-        "Flujos de GitHub",
+        "Diseño de bases de datos/infraestructura",
+        "Operaciones de desarrollo en GitHub",
         "IA generativa",
         "Diseño de flujos de IA",
-        "Aseguramiento de calidad",
-        "Integración de dispositivos",
-        "Educación en TI"
+        "Diseño de calidad",
+        "Integración en sitio"
       ]
     },
     "pt": {
       "name": "Gui",
-      "bio": "CEO da Acecore. Engenheiro que atua em sistemas de negócio, produção web, bancos de dados e infraestrutura, garantia de qualidade, integração com dispositivos em campo, fluxos de desenvolvimento baseados em GitHub e adoção prática de IA generativa.\nUsa C#/.NET como stack principal, mas também trabalha com PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, cobrindo requisitos, design, implementação, testes, implantação e melhoria operacional.\nUsa IA além da assistência de código, incorporando-a em fluxos de tradução multilíngue, chatbots de atendimento, testes monkey com Playwright, pesquisa e organização de tarefas administrativas.",
+      "bio": "CEO da Acecore. Lidera sistemas de negócio, web, bancos de dados e infraestrutura, qualidade e adoção de IA como iniciativas conectadas ao negócio, da definição do problema ao design, implantação e melhoria após o lançamento.\nParte de capacidade prática em C#/.NET e também cobre PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, desenhando requisitos, escolhas tecnológicas, padrões de qualidade e operações de desenvolvimento baseadas em GitHub como um fluxo único.\nUsa IA generativa não apenas para eficiência de tarefas, mas como base operacional para tradução multilíngue, chatbots de atendimento, automação de testes com Playwright, pesquisa e organização administrativa, ajudando equipes pequenas a entregar mais rápido e com confiança.",
       "skills": [
-        "Desenvolvimento de sistemas",
+        "Definição de problemas de negócio",
+        "Seleção tecnológica",
+        "Design de sistemas",
         "C#/.NET",
-        "Produção web",
-        "Bancos de dados/infraestrutura",
-        "Fluxos de GitHub",
+        "Design de bancos de dados/infraestrutura",
+        "Operações de desenvolvimento no GitHub",
         "IA generativa",
         "Design de fluxos de IA",
-        "Garantia de qualidade",
-        "Integração de dispositivos",
-        "Educação em TI"
+        "Design de qualidade",
+        "Integração em campo"
       ]
     },
     "fr": {
       "name": "Gui",
-      "bio": "PDG d'Acecore. Ingénieur intervenant sur les systèmes métier, la production web, les bases de données et l'infrastructure, l'assurance qualité, l'intégration d'équipements sur site, les flux de développement basés sur GitHub et l'adoption concrète de l'IA générative.\nTravaille principalement avec C#/.NET, tout en utilisant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, de la clarification des besoins et de la conception jusqu'à l'implémentation, aux tests, au déploiement et à l'amélioration opérationnelle.\nUtilise l'IA au-delà de l'assistance au code, en l'intégrant aux flux de traduction multilingue, aux chatbots de demande, aux tests monkey avec Playwright, à la recherche et à l'organisation de tâches administratives.",
+      "bio": "PDG d'Acecore. Pilote les systèmes métier, le web, les bases de données et l'infrastructure, la qualité et l'adoption de l'IA comme des initiatives reliées aux enjeux de l'entreprise, de la clarification des problèmes à la conception, au déploiement et à l'amélioration continue.\nS'appuie sur une capacité pratique en C#/.NET tout en couvrant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, afin de concevoir les besoins, les choix technologiques, les standards de qualité et les opérations de développement basées sur GitHub comme un flux cohérent.\nUtilise l'IA générative non seulement pour gagner en efficacité, mais comme socle opérationnel pour la traduction multilingue, les chatbots de demande, l'automatisation des tests avec Playwright, la recherche et l'organisation administrative, afin d'aider les petites équipes à livrer plus vite avec confiance.",
       "skills": [
-        "Développement de systèmes",
+        "Cadrage des enjeux métier",
+        "Choix technologiques",
+        "Conception de systèmes",
         "C#/.NET",
-        "Production web",
-        "Bases de données/infrastructure",
-        "Flux GitHub",
+        "Conception bases de données/infrastructure",
+        "Opérations de développement GitHub",
         "IA générative",
         "Conception de flux IA",
-        "Assurance qualité",
-        "Intégration d'équipements",
-        "Enseignement informatique"
+        "Conception de la qualité",
+        "Intégration terrain"
       ]
     },
     "ko": {
       "name": "Gui",
-      "bio": "Acecore 대표. 업무 시스템 개발, 웹 제작, DB/인프라, 품질 보증, 현장 장비 연동, GitHub 기반 개발 흐름, 생성형 AI 실무 활용까지 폭넓게 다루는 엔지니어입니다.\nC#/.NET을 중심으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 다루며, 요구사항 정리와 설계부터 구현, 테스트, 도입, 운영 개선까지 일관되게 대응합니다.\nAI를 코딩 보조에만 쓰지 않고 다국어 번역 흐름, 문의 AI 챗봇, Playwright 기반 몽키 테스트, 조사와 사무 작업 정리까지 실제 운영에 통합하고 있습니다.",
+      "bio": "Acecore 대표. 업무 시스템, 웹, DB/인프라, 품질, AI 활용을 단순 작업이 아니라 사업 과제 정리부터 설계, 도입 후 개선까지 이어지는 흐름으로 추진합니다.\nC#/.NET 기반의 실무 구현력을 바탕으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 고려하며, 요구사항 정리, 기술 선택, 품질 기준, GitHub 기반 개발 운영을 하나의 흐름으로 설계합니다.\n생성형 AI는 단순한 작업 효율화가 아니라 다국어 번역, 문의 AI 챗봇, Playwright 기반 테스트 자동화, 조사와 사무 정리에 통합해 소규모 팀도 빠르고 확실하게 성과를 낼 수 있는 업무 기반으로 활용하고 있습니다.",
       "skills": [
-        "시스템 개발",
+        "사업 과제 정리",
+        "기술 선택",
+        "시스템 설계",
         "C#/.NET",
-        "웹 제작",
-        "DB/인프라",
-        "GitHub 워크플로",
+        "DB/인프라 설계",
+        "GitHub 개발 운영",
         "생성형 AI",
         "AI 워크플로 설계",
-        "품질 보증",
-        "장비 연동",
-        "IT 교육"
+        "품질 설계",
+        "현장 연동"
       ]
     },
     "de": {
       "name": "Gui",
-      "bio": "CEO von Acecore. Ingenieur für Geschäftssysteme, Webproduktion, Datenbanken und Infrastruktur, Qualitätssicherung, Integration von Geräten vor Ort, GitHub-basierte Entwicklungsabläufe und praktische Einführung generativer KI.\nArbeitet hauptsächlich mit C#/.NET, aber auch mit PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, von Anforderungen und Design bis Implementierung, Tests, Einführung und operativer Verbesserung.\nNutzt KI nicht nur als Coding-Hilfe, sondern integriert sie in mehrsprachige Übersetzungsabläufe, Anfrage-Chatbots, Monkey-Tests mit Playwright, Recherche und die Organisation administrativer Aufgaben.",
+      "bio": "CEO von Acecore. Steuert Geschäftssysteme, Web, Datenbanken und Infrastruktur, Qualität und KI-Einsatz als zusammenhängende Geschäftsinitiativen, von der Klärung der Probleme über Design und Einführung bis zur Verbesserung nach dem Launch.\nBaut auf praktischer C#/.NET-Kompetenz auf und berücksichtigt zugleich PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, um Anforderungen, Technologieauswahl, Qualitätsstandards und GitHub-basierte Entwicklungsabläufe als kohärenten Prozess zu gestalten.\nNutzt generative KI nicht nur zur Effizienzsteigerung einzelner Aufgaben, sondern als operative Grundlage für mehrsprachige Übersetzung, Anfrage-Chatbots, Testautomatisierung mit Playwright, Recherche und administrative Organisation, damit kleine Teams schneller und verlässlicher liefern können.",
       "skills": [
-        "Systementwicklung",
+        "Geschäftsproblem-Analyse",
+        "Technologieauswahl",
+        "Systemdesign",
         "C#/.NET",
-        "Webproduktion",
-        "Datenbanken/Infrastruktur",
-        "GitHub-Workflows",
+        "Datenbank-/Infrastrukturdesign",
+        "GitHub-Entwicklungsbetrieb",
         "Generative KI",
         "KI-Workflow-Design",
-        "Qualitätssicherung",
-        "Geräteintegration",
-        "IT-Bildung"
+        "Qualitätsdesign",
+        "Vor-Ort-Integration"
       ]
     },
     "ru": {
       "name": "Gui",
-      "bio": "Генеральный директор Acecore. Инженер, работающий с бизнес-системами, веб-разработкой, базами данных и инфраструктурой, обеспечением качества, интеграцией оборудования, GitHub-ориентированными процессами разработки и практическим внедрением генеративного ИИ.\nОсновной стек — C#/.NET, но также использует PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, сопровождая проекты от требований и проектирования до реализации, тестирования, внедрения и операционных улучшений.\nИспользует ИИ не только как помощника в кодинге, но и в многоязычных переводческих процессах, чатботах для обращений, monkey-тестировании с Playwright, исследованиях и организации административных задач.",
+      "bio": "Генеральный директор Acecore. Руководит бизнес-системами, вебом, базами данных и инфраструктурой, качеством и внедрением ИИ как связанными бизнес-инициативами: от прояснения задач до проектирования, запуска и дальнейшего улучшения.\nОпирается на практическую экспертизу C#/.NET и также учитывает PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, проектируя требования, технологический выбор, стандарты качества и GitHub-ориентированные процессы разработки как единую систему.\nИспользует генеративный ИИ не только для повышения эффективности отдельных задач, а как операционную основу для многоязычного перевода, чатботов для обращений, автоматизации тестирования с Playwright, исследований и организации административной работы, чтобы небольшие команды могли быстрее и надежнее достигать результата.",
       "skills": [
-        "Разработка систем",
+        "Формулирование бизнес-задач",
+        "Технологический выбор",
+        "Проектирование систем",
         "C#/.NET",
-        "Веб-производство",
-        "Базы данных/инфраструктура",
-        "GitHub-процессы",
+        "Проектирование БД/инфраструктуры",
+        "GitHub-процессы разработки",
         "Генеративный ИИ",
         "Проектирование ИИ-процессов",
-        "Обеспечение качества",
-        "Интеграция устройств",
-        "IT-образование"
+        "Проектирование качества",
+        "Интеграция на местах"
       ]
     }
   }

--- a/src/content/authors/gui.json
+++ b/src/content/authors/gui.json
@@ -3,7 +3,7 @@
   "name": "Gui",
   "avatar": "",
   "avatarImage": "",
-  "bio": "Acecore 代表。業務システム、Web、DB/インフラ、品質保証、AI活用を、事業課題の整理から設計・導入後の改善までつなげて推進している。\nC#/.NET を軸にした実装力を土台に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども踏まえ、要件整理、技術選定、品質基準、GitHubベースの開発運用まで一体で設計する。\n生成AIは、開発・検証・情報整理・多言語対応などの業務プロセスに取り入れ、小規模チームでも速く確かな成果を出すための実務基盤として活用している。",
+  "bio": "Acecore 代表。業務システム、Web、DB/インフラ、品質保証、AI活用を、事業課題の整理から設計・導入後の改善までつなげて推進している。\nC#/.NET を軸にした実装力を土台に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども踏まえ、要件整理、技術選定、品質基準、GitHubベースの開発運用まで一体で設計する。\n生成AIは、開発・検証・情報整理などの業務プロセスに取り入れ、小規模チームでも速く確かな成果を出すための実務基盤として活用している。",
   "url": "https://acecore.net/about/",
   "github": "https://github.com/acecore-systems",
   "twitter": "https://x.com/acecorenet",
@@ -22,7 +22,7 @@
   "i18n": {
     "en": {
       "name": "Gui",
-      "bio": "CEO of Acecore. Leads business systems, web, databases and infrastructure, quality assurance, and AI adoption from business problem framing through design, rollout, and post-launch improvement.\nBuilds on hands-on C#/.NET capability while also covering PHP/JavaScript, SQL Server/PostgreSQL/MySQL, and Linux/Windows Server, designing requirements, technology choices, quality standards, and GitHub-based development operations as one coherent workflow.\nUses generative AI across development, verification, information organization, and multilingual operations, treating it as practical infrastructure that helps small teams deliver faster and more reliably.",
+      "bio": "CEO of Acecore. Leads business systems, web, databases and infrastructure, quality assurance, and AI adoption from business problem framing through design, rollout, and post-launch improvement.\nBuilds on hands-on C#/.NET capability while also covering PHP/JavaScript, SQL Server/PostgreSQL/MySQL, and Linux/Windows Server, designing requirements, technology choices, quality standards, and GitHub-based development operations as one coherent workflow.\nUses generative AI across development, verification, and information organization, treating it as practical infrastructure that helps small teams deliver faster and more reliably.",
       "skills": [
         "Business problem framing",
         "Technology selection",
@@ -38,7 +38,7 @@
     },
     "zh-cn": {
       "name": "Gui",
-      "bio": "Acecore 代表。从业务课题梳理到设计、导入和上线后的改进，统筹推进业务系统、Web、数据库/基础设施、质量保证以及 AI 应用。\n以 C#/.NET 的实际开发能力为基础，同时理解 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，将需求整理、技术选型、质量标准和基于 GitHub 的开发运营作为整体流程来设计。\n将生成式 AI 用于开发、验证、信息整理和多语言对应等业务流程，作为帮助小团队更快、更可靠交付成果的实务基础。",
+      "bio": "Acecore 代表。从业务课题梳理到设计、导入和上线后的改进，统筹推进业务系统、Web、数据库/基础设施、质量保证以及 AI 应用。\n以 C#/.NET 的实际开发能力为基础，同时理解 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，将需求整理、技术选型、质量标准和基于 GitHub 的开发运营作为整体流程来设计。\n将生成式 AI 用于开发、验证和信息整理等业务流程，作为帮助小团队更快、更可靠交付成果的实务基础。",
       "skills": [
         "业务课题梳理",
         "技术选型",
@@ -54,7 +54,7 @@
     },
     "es": {
       "name": "Gui",
-      "bio": "CEO de Acecore. Lidera sistemas de negocio, web, bases de datos e infraestructura, calidad y adopción de IA desde la definición de problemas de negocio hasta el diseño, la puesta en marcha y la mejora posterior.\nSe apoya en capacidad práctica con C#/.NET y también cubre PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, diseñando requisitos, selección tecnológica, estándares de calidad y operaciones de desarrollo basadas en GitHub como un flujo coherente.\nIncorpora la IA generativa en procesos de desarrollo, verificación, organización de información y operación multilingüe, como una base práctica para que equipos pequeños entreguen más rápido y con mayor fiabilidad.",
+      "bio": "CEO de Acecore. Lidera sistemas de negocio, web, bases de datos e infraestructura, calidad y adopción de IA desde la definición de problemas de negocio hasta el diseño, la puesta en marcha y la mejora posterior.\nSe apoya en capacidad práctica con C#/.NET y también cubre PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, diseñando requisitos, selección tecnológica, estándares de calidad y operaciones de desarrollo basadas en GitHub como un flujo coherente.\nIncorpora la IA generativa en procesos de desarrollo, verificación y organización de información, como una base práctica para que equipos pequeños entreguen más rápido y con mayor fiabilidad.",
       "skills": [
         "Definición de problemas de negocio",
         "Selección tecnológica",
@@ -70,7 +70,7 @@
     },
     "pt": {
       "name": "Gui",
-      "bio": "CEO da Acecore. Lidera sistemas de negócio, web, bancos de dados e infraestrutura, qualidade e adoção de IA da definição de problemas de negócio ao design, implantação e melhoria após o lançamento.\nParte de capacidade prática em C#/.NET e também cobre PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, desenhando requisitos, escolhas tecnológicas, padrões de qualidade e operações de desenvolvimento baseadas em GitHub como um fluxo único.\nIncorpora IA generativa a processos de desenvolvimento, verificação, organização de informações e operação multilíngue, como uma base prática para que equipes pequenas entreguem mais rápido e com maior confiabilidade.",
+      "bio": "CEO da Acecore. Lidera sistemas de negócio, web, bancos de dados e infraestrutura, qualidade e adoção de IA da definição de problemas de negócio ao design, implantação e melhoria após o lançamento.\nParte de capacidade prática em C#/.NET e também cobre PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, desenhando requisitos, escolhas tecnológicas, padrões de qualidade e operações de desenvolvimento baseadas em GitHub como um fluxo único.\nIncorpora IA generativa a processos de desenvolvimento, verificação e organização de informações, como uma base prática para que equipes pequenas entreguem mais rápido e com maior confiabilidade.",
       "skills": [
         "Definição de problemas de negócio",
         "Seleção tecnológica",
@@ -86,7 +86,7 @@
     },
     "fr": {
       "name": "Gui",
-      "bio": "PDG d'Acecore. Pilote les systèmes métier, le web, les bases de données et l'infrastructure, la qualité et l'adoption de l'IA, du cadrage des enjeux métier à la conception, au déploiement et à l'amélioration continue.\nS'appuie sur une capacité pratique en C#/.NET tout en couvrant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, afin de concevoir les besoins, les choix technologiques, les standards de qualité et les opérations de développement basées sur GitHub comme un flux cohérent.\nIntègre l'IA générative aux processus de développement, de vérification, d'organisation de l'information et d'exploitation multilingue, comme une base pratique pour aider les petites équipes à livrer plus vite et plus sûrement.",
+      "bio": "PDG d'Acecore. Pilote les systèmes métier, le web, les bases de données et l'infrastructure, la qualité et l'adoption de l'IA, du cadrage des enjeux métier à la conception, au déploiement et à l'amélioration continue.\nS'appuie sur une capacité pratique en C#/.NET tout en couvrant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, afin de concevoir les besoins, les choix technologiques, les standards de qualité et les opérations de développement basées sur GitHub comme un flux cohérent.\nIntègre l'IA générative aux processus de développement, de vérification et d'organisation de l'information, comme une base pratique pour aider les petites équipes à livrer plus vite et plus sûrement.",
       "skills": [
         "Cadrage des enjeux métier",
         "Choix technologiques",
@@ -102,7 +102,7 @@
     },
     "ko": {
       "name": "Gui",
-      "bio": "Acecore 대표. 업무 시스템, 웹, DB/인프라, 품질, AI 활용을 사업 과제 정리부터 설계, 도입 후 개선까지 이어지는 흐름으로 추진합니다.\nC#/.NET 기반의 실무 구현력을 바탕으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 고려하며, 요구사항 정리, 기술 선택, 품질 기준, GitHub 기반 개발 운영을 하나의 흐름으로 설계합니다.\n생성형 AI는 개발, 검증, 정보 정리, 다국어 대응 등 업무 프로세스에 도입해 소규모 팀도 빠르고 확실하게 성과를 낼 수 있는 실무 기반으로 활용하고 있습니다.",
+      "bio": "Acecore 대표. 업무 시스템, 웹, DB/인프라, 품질, AI 활용을 사업 과제 정리부터 설계, 도입 후 개선까지 이어지는 흐름으로 추진합니다.\nC#/.NET 기반의 실무 구현력을 바탕으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 고려하며, 요구사항 정리, 기술 선택, 품질 기준, GitHub 기반 개발 운영을 하나의 흐름으로 설계합니다.\n생성형 AI는 개발, 검증, 정보 정리 등 업무 프로세스에 도입해 소규모 팀도 빠르고 확실하게 성과를 낼 수 있는 실무 기반으로 활용하고 있습니다.",
       "skills": [
         "사업 과제 정리",
         "기술 선택",
@@ -118,7 +118,7 @@
     },
     "de": {
       "name": "Gui",
-      "bio": "CEO von Acecore. Steuert Geschäftssysteme, Web, Datenbanken und Infrastruktur, Qualität und KI-Einsatz von der Analyse geschäftlicher Probleme über Design und Einführung bis zur Verbesserung nach dem Launch.\nBaut auf praktischer C#/.NET-Kompetenz auf und berücksichtigt zugleich PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, um Anforderungen, Technologieauswahl, Qualitätsstandards und GitHub-basierte Entwicklungsabläufe als kohärenten Prozess zu gestalten.\nIntegriert generative KI in Entwicklungs-, Prüfungs-, Informationsorganisations- und mehrsprachige Betriebsprozesse, als praktische Grundlage, damit kleine Teams schneller und verlässlicher liefern können.",
+      "bio": "CEO von Acecore. Steuert Geschäftssysteme, Web, Datenbanken und Infrastruktur, Qualität und KI-Einsatz von der Analyse geschäftlicher Probleme über Design und Einführung bis zur Verbesserung nach dem Launch.\nBaut auf praktischer C#/.NET-Kompetenz auf und berücksichtigt zugleich PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, um Anforderungen, Technologieauswahl, Qualitätsstandards und GitHub-basierte Entwicklungsabläufe als kohärenten Prozess zu gestalten.\nIntegriert generative KI in Entwicklungs-, Prüfungs- und Informationsorganisationsprozesse, als praktische Grundlage, damit kleine Teams schneller und verlässlicher liefern können.",
       "skills": [
         "Geschäftsproblem-Analyse",
         "Technologieauswahl",
@@ -134,7 +134,7 @@
     },
     "ru": {
       "name": "Gui",
-      "bio": "Генеральный директор Acecore. Руководит бизнес-системами, вебом, базами данных и инфраструктурой, качеством и внедрением ИИ от формулирования бизнес-задач до проектирования, запуска и дальнейшего улучшения.\nОпирается на практическую экспертизу C#/.NET и также учитывает PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, проектируя требования, технологический выбор, стандарты качества и GitHub-ориентированные процессы разработки как единую систему.\nВстраивает генеративный ИИ в процессы разработки, проверки, организации информации и многоязычной работы как практическую основу, помогающую небольшим командам быстрее и надежнее достигать результата.",
+      "bio": "Генеральный директор Acecore. Руководит бизнес-системами, вебом, базами данных и инфраструктурой, качеством и внедрением ИИ от формулирования бизнес-задач до проектирования, запуска и дальнейшего улучшения.\nОпирается на практическую экспертизу C#/.NET и также учитывает PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, проектируя требования, технологический выбор, стандарты качества и GitHub-ориентированные процессы разработки как единую систему.\nВстраивает генеративный ИИ в процессы разработки, проверки и организации информации как практическую основу, помогающую небольшим командам быстрее и надежнее достигать результата.",
       "skills": [
         "Формулирование бизнес-задач",
         "Технологический выбор",

--- a/src/content/authors/gui.json
+++ b/src/content/authors/gui.json
@@ -3,7 +3,7 @@
   "name": "Gui",
   "avatar": "",
   "avatarImage": "",
-  "bio": "Acecore 代表。業務システム、Web、DB/インフラ、品質保証、AI活用を、単発の作業ではなく事業課題の整理から設計・導入後の改善までつなげて推進している。\nC#/.NET を軸にした実装力を土台に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども踏まえ、要件整理、技術選定、品質基準、GitHubベースの開発運用まで一体で設計する。\n生成AIは単なる作業効率化ではなく、多言語翻訳、問い合わせAIチャット、Playwrightによるテスト自動化、調査・事務整理に組み込み、小規模チームでも速く確かな成果を出すための実務基盤として活用している。",
+  "bio": "Acecore 代表。業務システム、Web、DB/インフラ、品質保証、AI活用を、事業課題の整理から設計・導入後の改善までつなげて推進している。\nC#/.NET を軸にした実装力を土台に、PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server なども踏まえ、要件整理、技術選定、品質基準、GitHubベースの開発運用まで一体で設計する。\n生成AIは、開発・検証・情報整理・多言語対応などの業務プロセスに取り入れ、小規模チームでも速く確かな成果を出すための実務基盤として活用している。",
   "url": "https://acecore.net/about/",
   "github": "https://github.com/acecore-systems",
   "twitter": "https://x.com/acecorenet",
@@ -22,7 +22,7 @@
   "i18n": {
     "en": {
       "name": "Gui",
-      "bio": "CEO of Acecore. Leads business systems, web, databases and infrastructure, quality assurance, and AI adoption as connected business initiatives, from clarifying problems to design, rollout, and post-launch improvement.\nBuilds on hands-on C#/.NET capability while also covering PHP/JavaScript, SQL Server/PostgreSQL/MySQL, and Linux/Windows Server, designing requirements, technology choices, quality standards, and GitHub-based development operations as one coherent workflow.\nUses generative AI not just for task efficiency, but as an operational foundation for multilingual translation, inquiry chatbots, Playwright-based test automation, research, and back-office organization so small teams can deliver faster with confidence.",
+      "bio": "CEO of Acecore. Leads business systems, web, databases and infrastructure, quality assurance, and AI adoption from business problem framing through design, rollout, and post-launch improvement.\nBuilds on hands-on C#/.NET capability while also covering PHP/JavaScript, SQL Server/PostgreSQL/MySQL, and Linux/Windows Server, designing requirements, technology choices, quality standards, and GitHub-based development operations as one coherent workflow.\nUses generative AI across development, verification, information organization, and multilingual operations, treating it as practical infrastructure that helps small teams deliver faster and more reliably.",
       "skills": [
         "Business problem framing",
         "Technology selection",
@@ -38,7 +38,7 @@
     },
     "zh-cn": {
       "name": "Gui",
-      "bio": "Acecore 代表。从业务课题梳理到设计、导入和上线后的改进，统筹推进业务系统、Web、数据库/基础设施、质量保证以及 AI 应用，而不是只处理单项作业。\n以 C#/.NET 的实际开发能力为基础，同时理解 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，将需求整理、技术选型、质量标准和基于 GitHub 的开发运营作为整体流程来设计。\n生成式 AI 不只是用于提高作业效率，也被纳入多语言翻译、咨询 AI 聊天、基于 Playwright 的测试自动化、调查和后台事务整理，作为小团队快速而可靠交付的业务基础。",
+      "bio": "Acecore 代表。从业务课题梳理到设计、导入和上线后的改进，统筹推进业务系统、Web、数据库/基础设施、质量保证以及 AI 应用。\n以 C#/.NET 的实际开发能力为基础，同时理解 PHP/JavaScript、SQL Server/PostgreSQL/MySQL、Linux/Windows Server，将需求整理、技术选型、质量标准和基于 GitHub 的开发运营作为整体流程来设计。\n将生成式 AI 用于开发、验证、信息整理和多语言对应等业务流程，作为帮助小团队更快、更可靠交付成果的实务基础。",
       "skills": [
         "业务课题梳理",
         "技术选型",
@@ -54,7 +54,7 @@
     },
     "es": {
       "name": "Gui",
-      "bio": "CEO de Acecore. Lidera sistemas de negocio, web, bases de datos e infraestructura, calidad y adopción de IA como iniciativas conectadas al negocio, desde la definición del problema hasta el diseño, la puesta en marcha y la mejora posterior.\nSe apoya en capacidad práctica con C#/.NET y también cubre PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, diseñando requisitos, selección tecnológica, estándares de calidad y operaciones de desarrollo basadas en GitHub como un flujo coherente.\nUsa la IA generativa no solo para mejorar la eficiencia, sino como una base operativa para traducción multilingüe, chatbots de consulta, automatización de pruebas con Playwright, investigación y organización administrativa, ayudando a equipos pequeños a entregar más rápido y con confianza.",
+      "bio": "CEO de Acecore. Lidera sistemas de negocio, web, bases de datos e infraestructura, calidad y adopción de IA desde la definición de problemas de negocio hasta el diseño, la puesta en marcha y la mejora posterior.\nSe apoya en capacidad práctica con C#/.NET y también cubre PHP/JavaScript, SQL Server/PostgreSQL/MySQL y Linux/Windows Server, diseñando requisitos, selección tecnológica, estándares de calidad y operaciones de desarrollo basadas en GitHub como un flujo coherente.\nIncorpora la IA generativa en procesos de desarrollo, verificación, organización de información y operación multilingüe, como una base práctica para que equipos pequeños entreguen más rápido y con mayor fiabilidad.",
       "skills": [
         "Definición de problemas de negocio",
         "Selección tecnológica",
@@ -70,7 +70,7 @@
     },
     "pt": {
       "name": "Gui",
-      "bio": "CEO da Acecore. Lidera sistemas de negócio, web, bancos de dados e infraestrutura, qualidade e adoção de IA como iniciativas conectadas ao negócio, da definição do problema ao design, implantação e melhoria após o lançamento.\nParte de capacidade prática em C#/.NET e também cobre PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, desenhando requisitos, escolhas tecnológicas, padrões de qualidade e operações de desenvolvimento baseadas em GitHub como um fluxo único.\nUsa IA generativa não apenas para eficiência de tarefas, mas como base operacional para tradução multilíngue, chatbots de atendimento, automação de testes com Playwright, pesquisa e organização administrativa, ajudando equipes pequenas a entregar mais rápido e com confiança.",
+      "bio": "CEO da Acecore. Lidera sistemas de negócio, web, bancos de dados e infraestrutura, qualidade e adoção de IA da definição de problemas de negócio ao design, implantação e melhoria após o lançamento.\nParte de capacidade prática em C#/.NET e também cobre PHP/JavaScript, SQL Server/PostgreSQL/MySQL e Linux/Windows Server, desenhando requisitos, escolhas tecnológicas, padrões de qualidade e operações de desenvolvimento baseadas em GitHub como um fluxo único.\nIncorpora IA generativa a processos de desenvolvimento, verificação, organização de informações e operação multilíngue, como uma base prática para que equipes pequenas entreguem mais rápido e com maior confiabilidade.",
       "skills": [
         "Definição de problemas de negócio",
         "Seleção tecnológica",
@@ -86,7 +86,7 @@
     },
     "fr": {
       "name": "Gui",
-      "bio": "PDG d'Acecore. Pilote les systèmes métier, le web, les bases de données et l'infrastructure, la qualité et l'adoption de l'IA comme des initiatives reliées aux enjeux de l'entreprise, de la clarification des problèmes à la conception, au déploiement et à l'amélioration continue.\nS'appuie sur une capacité pratique en C#/.NET tout en couvrant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, afin de concevoir les besoins, les choix technologiques, les standards de qualité et les opérations de développement basées sur GitHub comme un flux cohérent.\nUtilise l'IA générative non seulement pour gagner en efficacité, mais comme socle opérationnel pour la traduction multilingue, les chatbots de demande, l'automatisation des tests avec Playwright, la recherche et l'organisation administrative, afin d'aider les petites équipes à livrer plus vite avec confiance.",
+      "bio": "PDG d'Acecore. Pilote les systèmes métier, le web, les bases de données et l'infrastructure, la qualité et l'adoption de l'IA, du cadrage des enjeux métier à la conception, au déploiement et à l'amélioration continue.\nS'appuie sur une capacité pratique en C#/.NET tout en couvrant aussi PHP/JavaScript, SQL Server/PostgreSQL/MySQL et Linux/Windows Server, afin de concevoir les besoins, les choix technologiques, les standards de qualité et les opérations de développement basées sur GitHub comme un flux cohérent.\nIntègre l'IA générative aux processus de développement, de vérification, d'organisation de l'information et d'exploitation multilingue, comme une base pratique pour aider les petites équipes à livrer plus vite et plus sûrement.",
       "skills": [
         "Cadrage des enjeux métier",
         "Choix technologiques",
@@ -102,7 +102,7 @@
     },
     "ko": {
       "name": "Gui",
-      "bio": "Acecore 대표. 업무 시스템, 웹, DB/인프라, 품질, AI 활용을 단순 작업이 아니라 사업 과제 정리부터 설계, 도입 후 개선까지 이어지는 흐름으로 추진합니다.\nC#/.NET 기반의 실무 구현력을 바탕으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 고려하며, 요구사항 정리, 기술 선택, 품질 기준, GitHub 기반 개발 운영을 하나의 흐름으로 설계합니다.\n생성형 AI는 단순한 작업 효율화가 아니라 다국어 번역, 문의 AI 챗봇, Playwright 기반 테스트 자동화, 조사와 사무 정리에 통합해 소규모 팀도 빠르고 확실하게 성과를 낼 수 있는 업무 기반으로 활용하고 있습니다.",
+      "bio": "Acecore 대표. 업무 시스템, 웹, DB/인프라, 품질, AI 활용을 사업 과제 정리부터 설계, 도입 후 개선까지 이어지는 흐름으로 추진합니다.\nC#/.NET 기반의 실무 구현력을 바탕으로 PHP/JavaScript, SQL Server/PostgreSQL/MySQL, Linux/Windows Server도 고려하며, 요구사항 정리, 기술 선택, 품질 기준, GitHub 기반 개발 운영을 하나의 흐름으로 설계합니다.\n생성형 AI는 개발, 검증, 정보 정리, 다국어 대응 등 업무 프로세스에 도입해 소규모 팀도 빠르고 확실하게 성과를 낼 수 있는 실무 기반으로 활용하고 있습니다.",
       "skills": [
         "사업 과제 정리",
         "기술 선택",
@@ -118,7 +118,7 @@
     },
     "de": {
       "name": "Gui",
-      "bio": "CEO von Acecore. Steuert Geschäftssysteme, Web, Datenbanken und Infrastruktur, Qualität und KI-Einsatz als zusammenhängende Geschäftsinitiativen, von der Klärung der Probleme über Design und Einführung bis zur Verbesserung nach dem Launch.\nBaut auf praktischer C#/.NET-Kompetenz auf und berücksichtigt zugleich PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, um Anforderungen, Technologieauswahl, Qualitätsstandards und GitHub-basierte Entwicklungsabläufe als kohärenten Prozess zu gestalten.\nNutzt generative KI nicht nur zur Effizienzsteigerung einzelner Aufgaben, sondern als operative Grundlage für mehrsprachige Übersetzung, Anfrage-Chatbots, Testautomatisierung mit Playwright, Recherche und administrative Organisation, damit kleine Teams schneller und verlässlicher liefern können.",
+      "bio": "CEO von Acecore. Steuert Geschäftssysteme, Web, Datenbanken und Infrastruktur, Qualität und KI-Einsatz von der Analyse geschäftlicher Probleme über Design und Einführung bis zur Verbesserung nach dem Launch.\nBaut auf praktischer C#/.NET-Kompetenz auf und berücksichtigt zugleich PHP/JavaScript, SQL Server/PostgreSQL/MySQL und Linux/Windows Server, um Anforderungen, Technologieauswahl, Qualitätsstandards und GitHub-basierte Entwicklungsabläufe als kohärenten Prozess zu gestalten.\nIntegriert generative KI in Entwicklungs-, Prüfungs-, Informationsorganisations- und mehrsprachige Betriebsprozesse, als praktische Grundlage, damit kleine Teams schneller und verlässlicher liefern können.",
       "skills": [
         "Geschäftsproblem-Analyse",
         "Technologieauswahl",
@@ -134,7 +134,7 @@
     },
     "ru": {
       "name": "Gui",
-      "bio": "Генеральный директор Acecore. Руководит бизнес-системами, вебом, базами данных и инфраструктурой, качеством и внедрением ИИ как связанными бизнес-инициативами: от прояснения задач до проектирования, запуска и дальнейшего улучшения.\nОпирается на практическую экспертизу C#/.NET и также учитывает PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, проектируя требования, технологический выбор, стандарты качества и GitHub-ориентированные процессы разработки как единую систему.\nИспользует генеративный ИИ не только для повышения эффективности отдельных задач, а как операционную основу для многоязычного перевода, чатботов для обращений, автоматизации тестирования с Playwright, исследований и организации административной работы, чтобы небольшие команды могли быстрее и надежнее достигать результата.",
+      "bio": "Генеральный директор Acecore. Руководит бизнес-системами, вебом, базами данных и инфраструктурой, качеством и внедрением ИИ от формулирования бизнес-задач до проектирования, запуска и дальнейшего улучшения.\nОпирается на практическую экспертизу C#/.NET и также учитывает PHP/JavaScript, SQL Server/PostgreSQL/MySQL и Linux/Windows Server, проектируя требования, технологический выбор, стандарты качества и GitHub-ориентированные процессы разработки как единую систему.\nВстраивает генеративный ИИ в процессы разработки, проверки, организации информации и многоязычной работы как практическую основу, помогающую небольшим командам быстрее и надежнее достигать результата.",
       "skills": [
         "Формулирование бизнес-задач",
         "Технологический выбор",


### PR DESCRIPTION
## 関連 Issue

Closes #26

## 概要

Gui の著者情報を、Acecore 代表としての事業・技術の推進力が伝わる内容に更新しました。
個人情報や個別案件名には踏み込まず、公開プロフィールとして使える範囲で実務領域・AI活用を整理しています。

## 主な変更点

- `src/content/authors/gui.json` の日本語 bio/skills を、事業課題整理、技術選定、品質基準、GitHub 開発運用、導入後改善を設計・推進する代表視点に調整
- C#/.NET を軸にした実装力は土台として残しつつ、Web、DB/インフラ、品質設計、現場連携の扱い方を上位概念に整理
- 生成AIの説明は個別のツール・施策名を避け、開発、検証、情報整理などの業務プロセスに取り入れる表現へ調整
- `en`, `zh-cn`, `es`, `pt`, `fr`, `ko`, `de`, `ru` の翻訳 bio/skills も同じ方向性で更新

## 確認したこと

- `npx prettier --check src/content/authors/gui.json`
- `git diff --check`
- `npm run build`

## 未確認事項・補足

- ブラウザでの表示確認は未実施です。
- Build 時に既存と同種の Vite 未使用 import 警告と Pagefind の日本語 stemming 非対応メモが出ましたが、build と Pagefind index 作成は完了しています。
- 生年月日、居住地、学歴、資格取得日、個別の勤務先・案件名などの個人情報寄りの内容は含めていません。