### PR TITLE
[codex] トップページヒーローとヘッダーナビを調整

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,6 +11,7 @@ interface Props {
 const locale = Astro.props.locale ?? getLocaleFromUrl(Astro.url)
 const languageSwitcherPath = Astro.props.languageSwitcherPath
 const navLinks = [
+  { href: getLocalizedUrl('/', locale), label: t(locale, 'nav.home') },
   {
     href: getLocalizedUrl('/services/', locale),
     label: t(locale, 'nav.services'),
@@ -42,7 +43,7 @@ const currentPath = Astro.url.pathname
       Acecore
     </a>
     <nav
-      class="hidden items-center gap-1 md:flex"
+      class="hidden items-center gap-1 lg:flex"
       aria-label={t(locale, 'common.mainNav')}
     >
       {
@@ -78,7 +79,7 @@ const currentPath = Astro.url.pathname
         {contactLink.label}
       </a>
     </nav>
-    <div class="flex items-center gap-1 md:hidden">
+    <div class="flex items-center gap-1 lg:hidden">
       <button
         data-search-trigger
         class="ac-touch rounded-md text-slate-500 hover:bg-slate-50 hover:text-brand-600"
@@ -106,7 +107,7 @@ const currentPath = Astro.url.pathname
   </div>
   <nav
     id="mobile-menu"
-    class="hidden border-t border-brand-900/10 bg-white md:hidden"
+    class="hidden border-t border-brand-900/10 bg-white lg:hidden"
     aria-label={t(locale, 'common.mobileNav')}
   >
     <div class="ac-container ac-blueprint-soft flex flex-col gap-2 py-4">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -47,7 +47,7 @@ const firstSliderImage = sliderImages[0]
     >
       <div class="mb-8 h-px w-28 bg-brand-600" aria-hidden="true"></div>
       <h1
-        class="max-w-[20rem] text-[1.38rem] font-800 leading-[1.30] text-slate-950 [overflow-wrap:anywhere] sm:max-w-3xl sm:text-4xl lg:text-[2.65rem] xl:text-[2.85rem]"
+        class="max-w-[20rem] text-[1.38rem] font-800 leading-[1.30] text-slate-950 [overflow-wrap:anywhere] sm:max-w-3xl sm:text-4xl lg:text-[2.65rem] lg:leading-[1.40] xl:text-[2.85rem]"
       >
         {
           titleLines?.length


### PR DESCRIPTION
## 関連 Issue

なし

## 概要

トップページのヒーロー見出しで、デスクトップ表示時の行間が詰まって見える問題を調整しました。あわせて、ヘッダーナビゲーションに「ホーム」を表示するようにしました。

## 主な変更点

- `src/components/Hero.astro` の見出しクラスに `lg:leading-[1.40]` を追加
- ベースの `leading-[1.30]` は変更せず、デスクトップ幅以上だけ行間を広げるように調整
- `src/components/Header.astro` のナビゲーションリンク先頭に `nav.home` を追加
- ナビ項目が増えたため、デスクトップナビの表示開始を `md` から `lg` に変更し、タブレット幅ではモバイルメニューに切り替えるように調整

## 確認したこと

- `C:\Users\gnish\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe ..\..\node_modules\prettier\bin\prettier.cjs --check src\components\Hero.astro`
- `C:\Users\gnish\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe ..\..\node_modules\prettier\bin\prettier.cjs --check src\components\Header.astro`
- `C:\Users\gnish\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe scripts\write-cms-runtime-config.mjs`
- `$env:ASTRO_TELEMETRY_DISABLED='1'; C:\Users\gnish\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe ..\..\node_modules\astro\bin\astro.mjs build`
- `C:\Users\gnish\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe ..\..\node_modules\pagefind\lib\runner\bin.cjs --site dist`
- `git diff --check`
- `npx playwright screenshot --viewport-size=1440,900 http://127.0.0.1:4502/ C:\Users\gnish\AppData\Local\Temp\acecore-nav-desktop.png`
- `npx playwright screenshot --viewport-size=390,844 http://127.0.0.1:4502/ C:\Users\gnish\AppData\Local\Temp\acecore-nav-mobile.png`
- `rg -n "ホーム" dist\index.html` で desktop nav / mobile menu の両方に「ホーム」が含まれることを確認

## 未確認事項・補足

- Browser プラグインは `windows sandbox failed: spawn setup refresh` で使用できなかったため、表示確認は Playwright CLI で代替しました。
- PR 用 worktree では、親 checkout の `node_modules` を参照する Astro build が sandbox 内で `Cannot read directory "../../../..": Access is denied.` により失敗するため、同じ build を権限付きで再実行して成功を確認しました。
- モバイルメニューを開く操作の自動化は、一時 Playwright module import が `Cannot find module 'playwright'` で使えなかったため未実施です。生成 HTML でメニュー内に「ホーム」が含まれることと、mobile 幅でハンバーガー表示になることを確認しています。
