### PR TITLE
Schools予約と会員ポータルを追加

### DIFF
--- a/functions/api/schools/_shared.ts
+++ b/functions/api/schools/_shared.ts
@@ -1,0 +1,524 @@
+export type D1PreparedStatement = {
+  bind(...values: unknown[]): D1PreparedStatement
+  first<T = Record<string, unknown>>(): Promise<T | null>
+  all<T = Record<string, unknown>>(): Promise<{ results?: T[] }>
+  run(): Promise<unknown>
+}
+
+export type D1Database = {
+  prepare(query: string): D1PreparedStatement
+}
+
+export type Env = {
+  COMMENTS_DB?: D1Database
+  RESEND_API_KEY?: string
+  SCHOOLS_EMAIL_FROM?: string
+  SCHOOLS_SITE_URL?: string
+  SCHOOLS_ALLOWED_HOSTNAMES?: string
+  SCHOOLS_OTP_SECRET?: string
+  SCHOOLS_ADMIN_TOKEN?: string
+  STRIPE_SECRET_KEY?: string
+  STRIPE_WEBHOOK_SECRET?: string
+  STRIPE_PRICE_SCHOOLS_INITIAL_FEE?: string
+  STRIPE_CUSTOMER_PORTAL_RETURN_URL?: string
+  [key: string]: unknown
+}
+
+export type PagesContext = {
+  request: Request
+  env: Env
+  params?: Record<string, string>
+}
+
+export type CourseRow = {
+  id: string
+  title: string
+  summary: string
+  target: string
+  recommended_age: string
+  frequency: string
+  price_label: string
+  monthly_price_env_key: string
+  active: number
+  sort_order: number
+}
+
+export type InstructorRow = {
+  id: string
+  name: string
+  email: string | null
+  calendar_token: string
+  active: number
+  sort_order: number
+}
+
+export type AvailabilityRuleRow = {
+  id: string
+  instructor_id: string
+  course_id: string
+  weekday: number
+  start_time: string
+  end_time: string
+  slot_minutes: number
+  capacity: number
+}
+
+export type BookingRow = {
+  id: string
+  booking_type: string
+  status: string
+  guardian_id: string
+  student_id: string
+  course_id: string
+  instructor_id: string
+  start_at: string
+  end_at: string
+  timezone: string
+  guardian_name: string
+  guardian_email: string
+  guardian_phone: string | null
+  student_name: string
+  student_grade: string | null
+  message: string | null
+  stripe_customer_id: string | null
+  stripe_subscription_id: string | null
+  course_title?: string
+  instructor_name?: string
+}
+
+export const ACTIVE_BOOKING_STATUSES = [
+  'trial_confirmed',
+  'payment_pending',
+  'active',
+  'rescheduled',
+]
+
+const DEFAULT_ALLOWED_HOSTNAMES = [
+  'acecore.net',
+  'www.acecore.net',
+  'acecore-net.pages.dev',
+  'localhost',
+  '127.0.0.1',
+]
+
+const encoder = new TextEncoder()
+
+export function jsonResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      ...headers,
+    },
+  })
+}
+
+export function textResponse(
+  body: string,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      ...headers,
+    },
+  })
+}
+
+export function optionsResponse(request: Request, env: Env): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': getCorsOrigin(request, env),
+      'Access-Control-Allow-Methods': 'GET, POST, PATCH, OPTIONS',
+      'Access-Control-Allow-Headers': 'Accept, Authorization, Content-Type',
+      'Access-Control-Max-Age': '86400',
+    },
+  })
+}
+
+export function getDb(env: Env): D1Database | null {
+  return env.COMMENTS_DB ?? null
+}
+
+export function getSiteUrl(request: Request, env: Env): string {
+  const configured = String(env.SCHOOLS_SITE_URL || '').trim()
+  if (configured) return configured.replace(/\/$/, '')
+  return new URL(request.url).origin
+}
+
+export function isAllowedRequestOrigin(request: Request, env: Env): boolean {
+  const origin = request.headers.get('Origin')
+  if (!origin) return true
+
+  try {
+    const originUrl = new URL(origin)
+    const requestUrl = new URL(request.url)
+    if (originUrl.hostname === requestUrl.hostname) return true
+    return getAllowedHostnames(env).some((hostname) =>
+      matchesAllowedHostname(originUrl.hostname.toLowerCase(), hostname),
+    )
+  } catch {
+    return false
+  }
+}
+
+export function getCorsOrigin(request: Request, env: Env): string {
+  const origin = request.headers.get('Origin')
+  if (!origin) return 'https://acecore.net'
+  return isAllowedRequestOrigin(request, env) ? origin : 'https://acecore.net'
+}
+
+export function normalizeEmail(value: unknown): string {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .slice(0, 254)
+}
+
+export function normalizeText(value: unknown, maxLength = 160): string {
+  return String(value || '')
+    .replace(/[\u0000-\u001f\u007f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxLength)
+}
+
+export function normalizeMessage(value: unknown, maxLength = 1000): string {
+  return String(value || '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+    .trim()
+    .slice(0, maxLength)
+}
+
+export function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
+export function isValidId(value: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{0,80}$/.test(value)
+}
+
+export function toPublicCourse(row: CourseRow) {
+  return {
+    id: row.id,
+    title: row.title,
+    summary: row.summary,
+    target: row.target,
+    recommendedAge: row.recommended_age,
+    frequency: row.frequency,
+    priceLabel: row.price_label,
+  }
+}
+
+export function toPublicInstructor(row: InstructorRow) {
+  return {
+    id: row.id,
+    name: row.name,
+  }
+}
+
+export function toPublicBooking(row: BookingRow) {
+  return {
+    id: row.id,
+    bookingType: row.booking_type,
+    status: row.status,
+    courseId: row.course_id,
+    courseTitle: row.course_title,
+    instructorId: row.instructor_id,
+    instructorName: row.instructor_name,
+    startAt: row.start_at,
+    endAt: row.end_at,
+    timezone: row.timezone,
+    studentName: row.student_name,
+    studentGrade: row.student_grade,
+    message: row.message,
+    hasStripeSubscription: Boolean(row.stripe_subscription_id),
+  }
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', encoder.encode(value))
+  return bytesToHex(new Uint8Array(digest))
+}
+
+export async function hmacSha256Hex(
+  secret: string,
+  value: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(value))
+  return bytesToHex(new Uint8Array(signature))
+}
+
+export function getBearerToken(request: Request): string {
+  const value = request.headers.get('Authorization') || ''
+  return value.startsWith('Bearer ') ? value.slice('Bearer '.length).trim() : ''
+}
+
+export async function getPortalSession(
+  db: D1Database,
+  request: Request,
+): Promise<{ guardianId: string; email: string } | null> {
+  const token = getBearerToken(request)
+  if (!token) return null
+  const tokenHash = await sha256Hex(token)
+  const now = new Date().toISOString()
+  const session = await db
+    .prepare(
+      `SELECT guardian_id, email
+       FROM school_portal_sessions
+       WHERE token_hash = ? AND expires_at > ?
+       LIMIT 1`,
+    )
+    .bind(tokenHash, now)
+    .first<{ guardian_id: string; email: string }>()
+
+  if (!session) return null
+
+  await db
+    .prepare(
+      `UPDATE school_portal_sessions
+       SET last_seen_at = ?
+       WHERE token_hash = ?`,
+    )
+    .bind(now, tokenHash)
+    .run()
+
+  return { guardianId: session.guardian_id, email: session.email }
+}
+
+export function isAdminRequest(request: Request, env: Env): boolean {
+  const token = getBearerToken(request)
+  const expected = String(env.SCHOOLS_ADMIN_TOKEN || '').trim()
+  return Boolean(token && expected && token === expected)
+}
+
+export function makeJstDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date)
+}
+
+export function getJstWeekday(date: Date): number {
+  const value = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Tokyo',
+    weekday: 'short',
+  }).format(date)
+  return ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].indexOf(value)
+}
+
+export function getJstTime(date: Date): string {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'Asia/Tokyo',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+      .formatToParts(date)
+      .map((part) => [part.type, part.value]),
+  )
+  return `${parts.hour}:${parts.minute}`
+}
+
+export function toJstSlot(dateKey: string, time: string): Date {
+  return new Date(`${dateKey}T${time}:00+09:00`)
+}
+
+export function addMinutes(date: Date, minutes: number): Date {
+  return new Date(date.getTime() + minutes * 60 * 1000)
+}
+
+export function minutesFromTime(time: string): number {
+  const [hour, minute] = time.split(':').map((part) => Number(part))
+  return hour * 60 + minute
+}
+
+export function timeFromMinutes(value: number): string {
+  const hour = Math.floor(value / 60)
+  const minute = value % 60
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+}
+
+export async function createOrUpdateGuardian(
+  db: D1Database,
+  payload: {
+    email: string
+    name: string
+    phone?: string
+    stripeCustomerId?: string
+  },
+): Promise<string> {
+  const now = new Date().toISOString()
+  const existing = await db
+    .prepare('SELECT id FROM school_guardian_accounts WHERE email = ? LIMIT 1')
+    .bind(payload.email)
+    .first<{ id: string }>()
+
+  if (existing) {
+    await db
+      .prepare(
+        `UPDATE school_guardian_accounts
+         SET name = ?, phone = COALESCE(NULLIF(?, ''), phone),
+             stripe_customer_id = COALESCE(NULLIF(?, ''), stripe_customer_id),
+             updated_at = ?
+         WHERE id = ?`,
+      )
+      .bind(
+        payload.name,
+        payload.phone || '',
+        payload.stripeCustomerId || '',
+        now,
+        existing.id,
+      )
+      .run()
+    return existing.id
+  }
+
+  const id = crypto.randomUUID()
+  await db
+    .prepare(
+      `INSERT INTO school_guardian_accounts (
+         id, email, name, phone, stripe_customer_id, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      id,
+      payload.email,
+      payload.name,
+      payload.phone || null,
+      payload.stripeCustomerId || null,
+      now,
+      now,
+    )
+    .run()
+
+  return id
+}
+
+export async function createStudent(
+  db: D1Database,
+  payload: {
+    guardianId: string
+    name: string
+    grade?: string
+  },
+): Promise<string> {
+  const now = new Date().toISOString()
+  const existing = await db
+    .prepare(
+      `SELECT id
+       FROM school_students
+       WHERE guardian_id = ? AND name = ? AND COALESCE(grade, '') = ?
+       LIMIT 1`,
+    )
+    .bind(payload.guardianId, payload.name, payload.grade || '')
+    .first<{ id: string }>()
+
+  if (existing) {
+    await db
+      .prepare('UPDATE school_students SET updated_at = ? WHERE id = ?')
+      .bind(now, existing.id)
+      .run()
+    return existing.id
+  }
+
+  const id = crypto.randomUUID()
+  await db
+    .prepare(
+      `INSERT INTO school_students (
+         id, guardian_id, name, grade, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(id, payload.guardianId, payload.name, payload.grade || null, now, now)
+    .run()
+
+  return id
+}
+
+export async function writeAuditLog(
+  db: D1Database,
+  bookingId: string,
+  actorType: string,
+  action: string,
+  detail?: unknown,
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO school_booking_audit_logs (
+         id, booking_id, actor_type, action, detail, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      crypto.randomUUID(),
+      bookingId,
+      actorType,
+      action,
+      detail ? JSON.stringify(detail) : null,
+      new Date().toISOString(),
+    )
+    .run()
+}
+
+export async function sendEmail(
+  env: Env,
+  payload: { to: string; subject: string; html: string },
+): Promise<boolean> {
+  const apiKey = String(env.RESEND_API_KEY || '').trim()
+  const from = String(env.SCHOOLS_EMAIL_FROM || 'Acecore <noreply@acecore.net>')
+  if (!apiKey) return false
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from,
+      to: payload.to,
+      subject: payload.subject,
+      html: payload.html,
+    }),
+  })
+
+  return response.ok
+}
+
+function getAllowedHostnames(env: Env): string[] {
+  const configured = String(env.SCHOOLS_ALLOWED_HOSTNAMES || '')
+    .split(',')
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean)
+  return configured.length > 0 ? configured : DEFAULT_ALLOWED_HOSTNAMES
+}
+
+function matchesAllowedHostname(hostname: string, allowed: string): boolean {
+  if (hostname === allowed) return true
+  if (allowed === 'localhost' || allowed === '127.0.0.1') return false
+  return hostname.endsWith(`.${allowed}`)
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}

--- a/functions/api/schools/availability.ts
+++ b/functions/api/schools/availability.ts
@@ -1,0 +1,183 @@
+import {
+  ACTIVE_BOOKING_STATUSES,
+  addMinutes,
+  getDb,
+  getJstWeekday,
+  isAllowedRequestOrigin,
+  isValidId,
+  jsonResponse,
+  makeJstDate,
+  minutesFromTime,
+  optionsResponse,
+  timeFromMinutes,
+  toJstSlot,
+  toPublicCourse,
+  toPublicInstructor,
+  type AvailabilityRuleRow,
+  type BookingRow,
+  type CourseRow,
+  type InstructorRow,
+  type PagesContext,
+} from './_shared'
+
+const DEFAULT_DAYS = 21
+const MAX_DAYS = 45
+const BOOKING_BUFFER_MS = 2 * 60 * 60 * 1000
+
+export const onRequestGet = async ({
+  request,
+  env,
+}: PagesContext): Promise<Response> => {
+  if (!isAllowedRequestOrigin(request, env)) {
+    return jsonResponse({ ok: false, message: 'Invalid request origin.' }, 403)
+  }
+
+  const db = getDb(env)
+  if (!db) {
+    return jsonResponse(
+      { ok: false, message: '予約機能を一時的に利用できません。' },
+      503,
+    )
+  }
+
+  const url = new URL(request.url)
+  const requestedCourseId = normalizeOptionalId(url.searchParams.get('course'))
+  const requestedInstructorId = normalizeOptionalId(
+    url.searchParams.get('instructor'),
+  )
+  const days = normalizeDays(url.searchParams.get('days'))
+  const windowEnd = addMinutes(new Date(), days * 24 * 60).toISOString()
+
+  try {
+    const [coursesResult, instructorsResult, rulesResult, bookingsResult] =
+      await Promise.all([
+        db
+          .prepare(
+            `SELECT *
+             FROM school_courses
+             WHERE active = 1
+             ORDER BY sort_order ASC, title ASC`,
+          )
+          .all<CourseRow>(),
+        db
+          .prepare(
+            `SELECT *
+             FROM school_instructors
+             WHERE active = 1
+             ORDER BY sort_order ASC, name ASC`,
+          )
+          .all<InstructorRow>(),
+        db
+          .prepare(
+            `SELECT *
+             FROM school_availability_rules
+             WHERE active = 1
+             ORDER BY weekday ASC, start_time ASC`,
+          )
+          .all<AvailabilityRuleRow>(),
+        db
+          .prepare(
+            `SELECT id, instructor_id, start_at, status
+             FROM school_bookings
+             WHERE start_at >= ? AND start_at < ?
+               AND status IN (${ACTIVE_BOOKING_STATUSES.map(() => '?').join(',')})`,
+          )
+          .bind(new Date().toISOString(), windowEnd, ...ACTIVE_BOOKING_STATUSES)
+          .all<BookingRow>(),
+      ])
+
+    const courses = (coursesResult.results ?? []).filter(
+      (course) => !requestedCourseId || course.id === requestedCourseId,
+    )
+    const instructors = (instructorsResult.results ?? []).filter(
+      (instructor) =>
+        !requestedInstructorId || instructor.id === requestedInstructorId,
+    )
+    const courseIds = new Set(courses.map((course) => course.id))
+    const instructorIds = new Set(
+      instructors.map((instructor) => instructor.id),
+    )
+    const rules = (rulesResult.results ?? []).filter(
+      (rule) =>
+        courseIds.has(rule.course_id) && instructorIds.has(rule.instructor_id),
+    )
+
+    return jsonResponse({
+      ok: true,
+      courses: courses.map(toPublicCourse),
+      instructors: instructors.map(toPublicInstructor),
+      slots: buildSlots(rules, bookingsResult.results ?? [], days),
+    })
+  } catch (error) {
+    console.error('Failed to load school availability:', error)
+    return jsonResponse(
+      { ok: false, message: '予約枠を読み込めませんでした。' },
+      503,
+    )
+  }
+}
+
+export const onRequestOptions = ({ request, env }: PagesContext): Response =>
+  optionsResponse(request, env)
+
+function buildSlots(
+  rules: AvailabilityRuleRow[],
+  bookings: BookingRow[],
+  days: number,
+) {
+  const now = Date.now()
+  const bookedCounts = new Map<string, number>()
+  for (const booking of bookings) {
+    const key = `${booking.instructor_id}:${booking.start_at}`
+    bookedCounts.set(key, (bookedCounts.get(key) ?? 0) + 1)
+  }
+
+  const slots = []
+  for (let offset = 0; offset < days; offset += 1) {
+    const date = addMinutes(new Date(), offset * 24 * 60)
+    const dateKey = makeJstDate(date)
+    const weekday = getJstWeekday(toJstSlot(dateKey, '00:00'))
+
+    for (const rule of rules) {
+      if (rule.weekday !== weekday) continue
+
+      const startMinute = minutesFromTime(rule.start_time)
+      const endMinute = minutesFromTime(rule.end_time)
+      for (
+        let minute = startMinute;
+        minute + rule.slot_minutes <= endMinute;
+        minute += rule.slot_minutes
+      ) {
+        const slotStart = toJstSlot(dateKey, timeFromMinutes(minute))
+        const slotEnd = addMinutes(slotStart, rule.slot_minutes)
+        if (slotStart.getTime() <= now + BOOKING_BUFFER_MS) continue
+
+        const startAt = slotStart.toISOString()
+        const booked = bookedCounts.get(`${rule.instructor_id}:${startAt}`) ?? 0
+        const remaining = Math.max(0, rule.capacity - booked)
+        if (remaining <= 0) continue
+
+        slots.push({
+          courseId: rule.course_id,
+          instructorId: rule.instructor_id,
+          startAt,
+          endAt: slotEnd.toISOString(),
+          remaining,
+        })
+      }
+    }
+  }
+
+  return slots.sort((a, b) => a.startAt.localeCompare(b.startAt))
+}
+
+function normalizeOptionalId(value: string | null): string {
+  const normalized = String(value || '').trim()
+  return isValidId(normalized) ? normalized : ''
+}
+
+function normalizeDays(value: string | null): number {
+  const days = Number(value || DEFAULT_DAYS)
+  if (!Number.isFinite(days)) return DEFAULT_DAYS
+  return Math.min(Math.max(Math.floor(days), 1), MAX_DAYS)
+}

--- a/functions/api/schools/bookings/[id].ts
+++ b/functions/api/schools/bookings/[id].ts
@@ -1,0 +1,227 @@
+import {
+  ACTIVE_BOOKING_STATUSES,
+  getDb,
+  getJstTime,
+  getJstWeekday,
+  getPortalSession,
+  isAdminRequest,
+  isAllowedRequestOrigin,
+  jsonResponse,
+  minutesFromTime,
+  normalizeMessage,
+  normalizeText,
+  optionsResponse,
+  writeAuditLog,
+  type AvailabilityRuleRow,
+  type BookingRow,
+  type PagesContext,
+} from '../_shared'
+
+type PatchPayload = {
+  action?: unknown
+  startAt?: unknown
+  endAt?: unknown
+  reason?: unknown
+}
+
+export const onRequestPatch = async ({
+  request,
+  env,
+  params,
+}: PagesContext): Promise<Response> => {
+  if (!isAllowedRequestOrigin(request, env)) {
+    return jsonResponse({ ok: false, message: 'Invalid request origin.' }, 403)
+  }
+
+  const db = getDb(env)
+  if (!db) {
+    return jsonResponse(
+      { ok: false, message: '予約機能を利用できません。' },
+      503,
+    )
+  }
+
+  const bookingId = normalizeText(params?.id, 80)
+  const session = await getPortalSession(db, request)
+  const isAdmin = isAdminRequest(request, env)
+  if (!session && !isAdmin) {
+    return jsonResponse({ ok: false, message: 'ログインしてください。' }, 401)
+  }
+
+  const booking = await db
+    .prepare(
+      `SELECT *
+       FROM school_bookings
+       WHERE id = ?
+       LIMIT 1`,
+    )
+    .bind(bookingId)
+    .first<BookingRow>()
+  if (!booking) {
+    return jsonResponse({ ok: false, message: '予約が見つかりません。' }, 404)
+  }
+  if (!isAdmin && booking.guardian_id !== session?.guardianId) {
+    return jsonResponse({ ok: false, message: '予約が見つかりません。' }, 404)
+  }
+
+  const payload = (await request
+    .json()
+    .catch(() => null)) as PatchPayload | null
+  const action = normalizeText(payload?.action, 40)
+  const now = new Date().toISOString()
+
+  if (action === 'cancel') {
+    if (!ACTIVE_BOOKING_STATUSES.includes(booking.status)) {
+      return jsonResponse(
+        { ok: false, message: 'この予約はキャンセルできません。' },
+        409,
+      )
+    }
+
+    const reason = normalizeMessage(payload?.reason, 400)
+    await db
+      .prepare(
+        `UPDATE school_bookings
+         SET status = 'cancelled', cancel_reason = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .bind(reason || null, now, booking.id)
+      .run()
+    await writeAuditLog(
+      db,
+      booking.id,
+      isAdmin ? 'admin' : 'guardian',
+      'cancelled',
+      {
+        reason,
+      },
+    )
+    return jsonResponse({ ok: true, status: 'cancelled' })
+  }
+
+  if (action === 'reschedule') {
+    const startAt = new Date(normalizeText(payload?.startAt, 40))
+    const endAt = new Date(normalizeText(payload?.endAt, 40))
+    if (!ACTIVE_BOOKING_STATUSES.includes(booking.status)) {
+      return jsonResponse(
+        { ok: false, message: 'この予約は変更できません。' },
+        409,
+      )
+    }
+    if (
+      !Number.isFinite(startAt.getTime()) ||
+      !Number.isFinite(endAt.getTime())
+    ) {
+      return jsonResponse(
+        { ok: false, message: '変更先の枠を選んでください。' },
+        400,
+      )
+    }
+
+    const availability = await assertRescheduleSlotAvailable(
+      db,
+      booking,
+      startAt,
+      endAt,
+    )
+    if (!availability.ok) {
+      return jsonResponse({ ok: false, message: availability.message }, 409)
+    }
+
+    await db
+      .prepare(
+        `UPDATE school_bookings
+         SET start_at = ?, end_at = ?, status = 'rescheduled', updated_at = ?
+         WHERE id = ?`,
+      )
+      .bind(startAt.toISOString(), endAt.toISOString(), now, booking.id)
+      .run()
+    await writeAuditLog(
+      db,
+      booking.id,
+      isAdmin ? 'admin' : 'guardian',
+      'rescheduled',
+      {
+        from: booking.start_at,
+        to: startAt.toISOString(),
+      },
+    )
+    return jsonResponse({ ok: true, status: 'rescheduled' })
+  }
+
+  return jsonResponse({ ok: false, message: '操作を選択してください。' }, 400)
+}
+
+export const onRequestOptions = ({ request, env }: PagesContext): Response =>
+  optionsResponse(request, env)
+
+async function assertRescheduleSlotAvailable(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  booking: BookingRow,
+  startAt: Date,
+  endAt: Date,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const durationMinutes = Math.round(
+    (endAt.getTime() - startAt.getTime()) / 60000,
+  )
+  if (durationMinutes <= 0) {
+    return { ok: false, message: '変更先の枠を選んでください。' }
+  }
+  if (startAt.getTime() <= Date.now() + 2 * 60 * 60 * 1000) {
+    return { ok: false, message: '直前の枠には変更できません。' }
+  }
+
+  const startTime = getJstTime(startAt)
+  const endTime = getJstTime(endAt)
+  const rule = await db
+    .prepare(
+      `SELECT *
+       FROM school_availability_rules
+       WHERE active = 1
+         AND course_id = ?
+         AND instructor_id = ?
+         AND weekday = ?
+         AND start_time <= ?
+         AND end_time >= ?
+       ORDER BY capacity DESC
+       LIMIT 1`,
+    )
+    .bind(
+      booking.course_id,
+      booking.instructor_id,
+      getJstWeekday(startAt),
+      startTime,
+      endTime,
+    )
+    .first<AvailabilityRuleRow>()
+
+  if (!rule) {
+    return { ok: false, message: '変更先の枠は受付対象外です。' }
+  }
+
+  const slotOffset =
+    minutesFromTime(startTime) - minutesFromTime(rule.start_time)
+  if (durationMinutes !== rule.slot_minutes || slotOffset % rule.slot_minutes) {
+    return { ok: false, message: '変更先の枠は受付対象外です。' }
+  }
+
+  const count = await db
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM school_bookings
+       WHERE instructor_id = ? AND start_at = ? AND id <> ?
+         AND status IN (${ACTIVE_BOOKING_STATUSES.map(() => '?').join(',')})`,
+    )
+    .bind(
+      booking.instructor_id,
+      startAt.toISOString(),
+      booking.id,
+      ...ACTIVE_BOOKING_STATUSES,
+    )
+    .first<{ count: number }>()
+  if (Number(count?.count || 0) >= rule.capacity) {
+    return { ok: false, message: 'この枠は満席です。' }
+  }
+
+  return { ok: true }
+}

--- a/functions/api/schools/bookings/index.ts
+++ b/functions/api/schools/bookings/index.ts
@@ -1,0 +1,404 @@
+import {
+  ACTIVE_BOOKING_STATUSES,
+  createOrUpdateGuardian,
+  createStudent,
+  getDb,
+  getJstTime,
+  getJstWeekday,
+  getSiteUrl,
+  isAllowedRequestOrigin,
+  isValidEmail,
+  isValidId,
+  jsonResponse,
+  minutesFromTime,
+  normalizeEmail,
+  normalizeMessage,
+  normalizeText,
+  optionsResponse,
+  sendEmail,
+  writeAuditLog,
+  type AvailabilityRuleRow,
+  type CourseRow,
+  type Env,
+  type PagesContext,
+} from '../_shared'
+
+type BookingPayload = {
+  bookingType?: unknown
+  courseId?: unknown
+  instructorId?: unknown
+  startAt?: unknown
+  endAt?: unknown
+  guardianName?: unknown
+  guardianEmail?: unknown
+  guardianPhone?: unknown
+  studentName?: unknown
+  studentGrade?: unknown
+  message?: unknown
+  locale?: unknown
+}
+
+type StripeCheckoutResponse = {
+  id?: string
+  url?: string
+  customer?: string
+  error?: { message?: string }
+}
+
+export const onRequestPost = async ({
+  request,
+  env,
+}: PagesContext): Promise<Response> => {
+  if (!isAllowedRequestOrigin(request, env)) {
+    return jsonResponse({ ok: false, message: 'Invalid request origin.' }, 403)
+  }
+
+  const db = getDb(env)
+  if (!db) {
+    return jsonResponse(
+      { ok: false, message: '予約機能を一時的に利用できません。' },
+      503,
+    )
+  }
+
+  const payload = (await request
+    .json()
+    .catch(() => null)) as BookingPayload | null
+  const validation = validatePayload(payload)
+  if (!validation.ok) {
+    return jsonResponse({ ok: false, message: validation.message }, 400)
+  }
+
+  try {
+    const course = await db
+      .prepare('SELECT * FROM school_courses WHERE id = ? AND active = 1')
+      .bind(validation.courseId)
+      .first<CourseRow>()
+    if (!course) {
+      return jsonResponse(
+        { ok: false, message: 'コースが見つかりません。' },
+        404,
+      )
+    }
+
+    const availability = await assertSlotAvailable(db, validation)
+    if (!availability.ok) {
+      return jsonResponse({ ok: false, message: availability.message }, 409)
+    }
+
+    const guardianId = await createOrUpdateGuardian(db, {
+      email: validation.guardianEmail,
+      name: validation.guardianName,
+      phone: validation.guardianPhone,
+    })
+    const studentId = await createStudent(db, {
+      guardianId,
+      name: validation.studentName,
+      grade: validation.studentGrade,
+    })
+    const bookingId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    const initialStatus =
+      validation.bookingType === 'enrollment'
+        ? 'payment_pending'
+        : 'trial_confirmed'
+
+    await db
+      .prepare(
+        `INSERT INTO school_bookings (
+           id, booking_type, status, guardian_id, student_id, course_id,
+           instructor_id, start_at, end_at, timezone, guardian_name,
+           guardian_email, guardian_phone, student_name, student_grade,
+           message, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'Asia/Tokyo', ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        bookingId,
+        validation.bookingType,
+        initialStatus,
+        guardianId,
+        studentId,
+        validation.courseId,
+        validation.instructorId,
+        validation.startAt,
+        validation.endAt,
+        validation.guardianName,
+        validation.guardianEmail,
+        validation.guardianPhone || null,
+        validation.studentName,
+        validation.studentGrade || null,
+        validation.message || null,
+        now,
+        now,
+      )
+      .run()
+    await writeAuditLog(db, bookingId, 'guardian', 'created', {
+      bookingType: validation.bookingType,
+      courseId: validation.courseId,
+    })
+
+    if (validation.bookingType === 'enrollment') {
+      const checkout = await createCheckoutSession(
+        request,
+        env,
+        course,
+        bookingId,
+        validation,
+      )
+      await db
+        .prepare(
+          `UPDATE school_bookings
+           SET stripe_checkout_session_id = ?, stripe_customer_id = ?, updated_at = ?
+           WHERE id = ?`,
+        )
+        .bind(checkout.id || null, checkout.customer || null, now, bookingId)
+        .run()
+
+      return jsonResponse({
+        ok: true,
+        bookingId,
+        status: initialStatus,
+        checkoutUrl: checkout.url,
+      })
+    }
+
+    await sendEmail(env, {
+      to: validation.guardianEmail,
+      subject: 'Acecore Schools 無料体験予約を受け付けました',
+      html: buildBookingMailHtml(course.title, validation),
+    }).catch((error) =>
+      console.error('Failed to send trial booking mail:', error),
+    )
+
+    return jsonResponse({ ok: true, bookingId, status: initialStatus }, 201)
+  } catch (error) {
+    console.error('Failed to create school booking:', error)
+    return jsonResponse(
+      { ok: false, message: '予約を作成できませんでした。' },
+      500,
+    )
+  }
+}
+
+export const onRequestOptions = ({ request, env }: PagesContext): Response =>
+  optionsResponse(request, env)
+
+function validatePayload(payload: BookingPayload | null):
+  | {
+      ok: true
+      bookingType: 'trial' | 'enrollment'
+      courseId: string
+      instructorId: string
+      startAt: string
+      endAt: string
+      guardianName: string
+      guardianEmail: string
+      guardianPhone: string
+      studentName: string
+      studentGrade: string
+      message: string
+      locale: string
+    }
+  | { ok: false; message: string } {
+  if (!payload || typeof payload !== 'object') {
+    return { ok: false, message: '入力内容を確認してください。' }
+  }
+
+  const bookingType =
+    payload.bookingType === 'enrollment' ? 'enrollment' : 'trial'
+  const courseId = normalizeText(payload.courseId, 80)
+  const instructorId = normalizeText(payload.instructorId, 80)
+  const startAt = normalizeText(payload.startAt, 40)
+  const endAt = normalizeText(payload.endAt, 40)
+  const guardianName = normalizeText(payload.guardianName)
+  const guardianEmail = normalizeEmail(payload.guardianEmail)
+  const guardianPhone = normalizeText(payload.guardianPhone, 40)
+  const studentName = normalizeText(payload.studentName)
+  const studentGrade = normalizeText(payload.studentGrade, 80)
+  const message = normalizeMessage(payload.message)
+  const locale = normalizeText(payload.locale, 16) || 'ja'
+
+  if (!isValidId(courseId) || !isValidId(instructorId)) {
+    return { ok: false, message: 'コースまたは講師を選択してください。' }
+  }
+  if (!guardianName || !studentName || !isValidEmail(guardianEmail)) {
+    return { ok: false, message: '保護者情報と受講者情報を入力してください。' }
+  }
+  if (!Number.isFinite(new Date(startAt).getTime())) {
+    return { ok: false, message: '予約枠を選択してください。' }
+  }
+  if (!Number.isFinite(new Date(endAt).getTime())) {
+    return { ok: false, message: '予約枠を選択してください。' }
+  }
+
+  return {
+    ok: true,
+    bookingType,
+    courseId,
+    instructorId,
+    startAt: new Date(startAt).toISOString(),
+    endAt: new Date(endAt).toISOString(),
+    guardianName,
+    guardianEmail,
+    guardianPhone,
+    studentName,
+    studentGrade,
+    message,
+    locale,
+  }
+}
+
+async function assertSlotAvailable(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  booking: {
+    courseId: string
+    instructorId: string
+    startAt: string
+    endAt: string
+  },
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const start = new Date(booking.startAt)
+  const end = new Date(booking.endAt)
+  const durationMinutes = Math.round((end.getTime() - start.getTime()) / 60000)
+  if (durationMinutes <= 0) {
+    return { ok: false, message: '予約枠を選択してください。' }
+  }
+  if (start.getTime() <= Date.now() + 2 * 60 * 60 * 1000) {
+    return { ok: false, message: '直前の枠は予約できません。' }
+  }
+
+  const weekday = getJstWeekday(start)
+  const startTime = getJstTime(start)
+  const endTime = getJstTime(end)
+  const rule = await db
+    .prepare(
+      `SELECT *
+       FROM school_availability_rules
+       WHERE active = 1
+         AND course_id = ?
+         AND instructor_id = ?
+         AND weekday = ?
+         AND start_time <= ?
+         AND end_time >= ?
+       ORDER BY capacity DESC
+       LIMIT 1`,
+    )
+    .bind(booking.courseId, booking.instructorId, weekday, startTime, endTime)
+    .first<AvailabilityRuleRow>()
+
+  if (!rule) {
+    return { ok: false, message: '選択した枠は受付対象外です。' }
+  }
+
+  const slotOffset =
+    minutesFromTime(startTime) - minutesFromTime(rule.start_time)
+  if (durationMinutes !== rule.slot_minutes || slotOffset % rule.slot_minutes) {
+    return { ok: false, message: '選択した枠は受付対象外です。' }
+  }
+
+  const count = await db
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM school_bookings
+       WHERE instructor_id = ? AND start_at = ?
+         AND status IN (${ACTIVE_BOOKING_STATUSES.map(() => '?').join(',')})`,
+    )
+    .bind(booking.instructorId, booking.startAt, ...ACTIVE_BOOKING_STATUSES)
+    .first<{ count: number }>()
+
+  if (Number(count?.count || 0) >= rule.capacity) {
+    return { ok: false, message: 'この枠は満席です。別の枠を選んでください。' }
+  }
+
+  return { ok: true }
+}
+
+async function createCheckoutSession(
+  request: Request,
+  env: Env,
+  course: CourseRow,
+  bookingId: string,
+  booking: {
+    guardianEmail: string
+    guardianName: string
+    startAt: string
+    locale: string
+  },
+): Promise<StripeCheckoutResponse> {
+  const secretKey = String(env.STRIPE_SECRET_KEY || '').trim()
+  if (!secretKey) {
+    throw new Error('STRIPE_SECRET_KEY is not configured.')
+  }
+
+  const monthlyPriceId = String(env[course.monthly_price_env_key] || '').trim()
+  if (!monthlyPriceId) {
+    throw new Error(`${course.monthly_price_env_key} is not configured.`)
+  }
+
+  const siteUrl = getSiteUrl(request, env)
+  const successUrl = `${siteUrl}/schools/portal/?booking=${bookingId}&checkout=success`
+  const cancelUrl = `${siteUrl}/schools/book/?booking=${bookingId}&checkout=cancel`
+  const body = new URLSearchParams()
+  body.set('mode', 'subscription')
+  body.set('customer_email', booking.guardianEmail)
+  body.set('success_url', successUrl)
+  body.set('cancel_url', cancelUrl)
+  body.set('client_reference_id', bookingId)
+  body.set('metadata[booking_id]', bookingId)
+  body.set('metadata[course_id]', course.id)
+  body.set('metadata[start_at]', booking.startAt)
+  body.set('subscription_data[metadata][booking_id]', bookingId)
+  body.set('line_items[0][price]', monthlyPriceId)
+  body.set('line_items[0][quantity]', '1')
+
+  const initialPriceId = String(
+    env.STRIPE_PRICE_SCHOOLS_INITIAL_FEE || '',
+  ).trim()
+  if (initialPriceId) {
+    body.set('line_items[1][price]', initialPriceId)
+    body.set('line_items[1][quantity]', '1')
+  }
+
+  const response = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${secretKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Stripe-Version': '2026-02-25.clover',
+    },
+    body,
+  })
+  const result = (await response.json()) as StripeCheckoutResponse
+  if (!response.ok || !result.url) {
+    throw new Error(result.error?.message || 'Failed to create Checkout.')
+  }
+  return result
+}
+
+function buildBookingMailHtml(
+  courseTitle: string,
+  booking: { guardianName: string; studentName: string; startAt: string },
+): string {
+  const start = new Date(booking.startAt).toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+  return `<p>${escapeHtml(booking.guardianName)} 様</p>
+<p>Acecore Schools の無料体験予約を受け付けました。</p>
+<ul>
+  <li>コース: ${escapeHtml(courseTitle)}</li>
+  <li>受講者: ${escapeHtml(booking.studentName)}</li>
+  <li>日時: ${escapeHtml(start)}</li>
+</ul>
+<p>変更やキャンセルは会員ポータルから行えます。</p>`
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}

--- a/functions/api/schools/calendar/[token].ts
+++ b/functions/api/schools/calendar/[token].ts
@@ -1,0 +1,94 @@
+import {
+  getDb,
+  textResponse,
+  type BookingRow,
+  type InstructorRow,
+  type PagesContext,
+} from '../_shared'
+
+export const onRequestGet = async ({
+  env,
+  params,
+}: PagesContext): Promise<Response> => {
+  const db = getDb(env)
+  const token = String(params?.token || '').trim()
+  if (!db || !/^[a-zA-Z0-9_-]{8,120}$/.test(token)) {
+    return textResponse('Calendar not found.', 404)
+  }
+
+  const instructor = await db
+    .prepare(
+      `SELECT *
+       FROM school_instructors
+       WHERE calendar_token = ? AND active = 1
+       LIMIT 1`,
+    )
+    .bind(token)
+    .first<InstructorRow>()
+
+  if (!instructor) return textResponse('Calendar not found.', 404)
+
+  const now = new Date()
+  const rows = await db
+    .prepare(
+      `SELECT b.*, c.title AS course_title, i.name AS instructor_name
+       FROM school_bookings b
+       JOIN school_courses c ON c.id = b.course_id
+       JOIN school_instructors i ON i.id = b.instructor_id
+       WHERE b.instructor_id = ?
+         AND b.status NOT IN ('cancelled', 'rejected')
+         AND b.start_at >= ?
+       ORDER BY b.start_at ASC
+       LIMIT 200`,
+    )
+    .bind(instructor.id, now.toISOString())
+    .all<BookingRow>()
+
+  return textResponse(buildIcs(instructor, rows.results ?? []), 200, {
+    'Content-Type': 'text/calendar; charset=utf-8',
+  })
+}
+
+function buildIcs(instructor: InstructorRow, bookings: BookingRow[]): string {
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Acecore//Schools Booking//JA',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    `X-WR-CALNAME:${escapeIcs(`Acecore Schools ${instructor.name}`)}`,
+    'X-WR-TIMEZONE:Asia/Tokyo',
+  ]
+
+  for (const booking of bookings) {
+    lines.push(
+      'BEGIN:VEVENT',
+      `UID:${booking.id}@acecore.net`,
+      `DTSTAMP:${formatIcsDate(new Date())}`,
+      `DTSTART:${formatIcsDate(new Date(booking.start_at))}`,
+      `DTEND:${formatIcsDate(new Date(booking.end_at))}`,
+      `SUMMARY:${escapeIcs(`${booking.course_title || booking.course_id} / ${booking.student_name}`)}`,
+      `DESCRIPTION:${escapeIcs(`種別: ${booking.booking_type}\n状態: ${booking.status}\n変更はAcecore Schoolsポータルで行ってください。`)}`,
+      'END:VEVENT',
+    )
+  }
+
+  lines.push('END:VCALENDAR')
+  return `${lines.join('\r\n')}\r\n`
+}
+
+function formatIcsDate(date: Date): string {
+  return date
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z')
+}
+
+function escapeIcs(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '')
+}

--- a/functions/api/schools/portal/otp.ts
+++ b/functions/api/schools/portal/otp.ts
@@ -1,0 +1,96 @@
+import {
+  createOrUpdateGuardian,
+  getDb,
+  hmacSha256Hex,
+  isAllowedRequestOrigin,
+  isValidEmail,
+  jsonResponse,
+  normalizeEmail,
+  normalizeText,
+  optionsResponse,
+  sendEmail,
+  type PagesContext,
+} from '../_shared'
+
+type OtpPayload = {
+  email?: unknown
+  name?: unknown
+}
+
+const OTP_TTL_MS = 10 * 60 * 1000
+
+export const onRequestPost = async ({
+  request,
+  env,
+}: PagesContext): Promise<Response> => {
+  if (!isAllowedRequestOrigin(request, env)) {
+    return jsonResponse({ ok: false, message: 'Invalid request origin.' }, 403)
+  }
+
+  const db = getDb(env)
+  if (!db) {
+    return jsonResponse(
+      { ok: false, message: 'ポータルを利用できません。' },
+      503,
+    )
+  }
+
+  const payload = (await request.json().catch(() => null)) as OtpPayload | null
+  const email = normalizeEmail(payload?.email)
+  const name = normalizeText(payload?.name) || '保護者'
+  if (!isValidEmail(email)) {
+    return jsonResponse(
+      { ok: false, message: 'メールアドレスを入力してください。' },
+      400,
+    )
+  }
+
+  const code = String(Math.floor(100000 + Math.random() * 900000))
+  const secret = String(
+    env.SCHOOLS_OTP_SECRET || env.STRIPE_WEBHOOK_SECRET || '',
+  )
+  const codeHash = await hmacSha256Hex(
+    secret || 'acecore-schools-otp',
+    `${email}:${code}`,
+  )
+  const now = new Date()
+  const guardianId = await createOrUpdateGuardian(db, { email, name })
+
+  await db
+    .prepare(
+      `INSERT INTO school_portal_otps (
+         id, email, code_hash, expires_at, created_at
+       ) VALUES (?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      crypto.randomUUID(),
+      email,
+      codeHash,
+      new Date(now.getTime() + OTP_TTL_MS).toISOString(),
+      now.toISOString(),
+    )
+    .run()
+
+  const delivered = await sendEmail(env, {
+    to: email,
+    subject: 'Acecore Schools ポータル認証コード',
+    html: `<p>Acecore Schools ポータルの認証コードです。</p>
+<p style="font-size: 24px; font-weight: 700;">${code}</p>
+<p>10分以内に入力してください。</p>`,
+  }).catch((error) => {
+    console.error('Failed to send portal OTP:', error)
+    return false
+  })
+
+  return jsonResponse({
+    ok: true,
+    guardianId,
+    delivered,
+    message: delivered
+      ? '認証コードを送信しました。'
+      : '認証コードを発行しました。メール送信設定を確認してください。',
+  })
+}
+
+export const onRequestOptions = ({ request, env }: PagesContext): Response =>
+  optionsResponse(request, env)

--- a/functions/api/schools/portal/session.ts
+++ b/functions/api/schools/portal/session.ts
@@ -1,0 +1,183 @@
+import {
+  getDb,
+  getPortalSession,
+  hmacSha256Hex,
+  isAllowedRequestOrigin,
+  isValidEmail,
+  jsonResponse,
+  normalizeEmail,
+  normalizeText,
+  optionsResponse,
+  sha256Hex,
+  toPublicBooking,
+  type BookingRow,
+  type PagesContext,
+} from '../_shared'
+
+type SessionPayload = {
+  email?: unknown
+  code?: unknown
+}
+
+const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+export const onRequestPost = async ({
+  request,
+  env,
+}: PagesContext): Promise<Response> => {
+  if (!isAllowedRequestOrigin(request, env)) {
+    return jsonResponse({ ok: false, message: 'Invalid request origin.' }, 403)
+  }
+
+  const db = getDb(env)
+  if (!db) {
+    return jsonResponse(
+      { ok: false, message: 'ポータルを利用できません。' },
+      503,
+    )
+  }
+
+  const payload = (await request
+    .json()
+    .catch(() => null)) as SessionPayload | null
+  const email = normalizeEmail(payload?.email)
+  const code = normalizeText(payload?.code, 12)
+  if (!isValidEmail(email) || !/^\d{6}$/.test(code)) {
+    return jsonResponse(
+      { ok: false, message: '認証コードを確認してください。' },
+      400,
+    )
+  }
+
+  const secret = String(
+    env.SCHOOLS_OTP_SECRET || env.STRIPE_WEBHOOK_SECRET || '',
+  )
+  const codeHash = await hmacSha256Hex(
+    secret || 'acecore-schools-otp',
+    `${email}:${code}`,
+  )
+  const now = new Date()
+  const otp = await db
+    .prepare(
+      `SELECT id
+       FROM school_portal_otps
+       WHERE email = ? AND code_hash = ? AND expires_at > ? AND consumed_at IS NULL
+       ORDER BY created_at DESC
+       LIMIT 1`,
+    )
+    .bind(email, codeHash, now.toISOString())
+    .first<{ id: string }>()
+
+  if (!otp) {
+    return jsonResponse(
+      { ok: false, message: '認証コードが正しくありません。' },
+      401,
+    )
+  }
+
+  const guardian = await db
+    .prepare('SELECT id, name FROM school_guardian_accounts WHERE email = ?')
+    .bind(email)
+    .first<{ id: string; name: string }>()
+  if (!guardian) {
+    return jsonResponse(
+      { ok: false, message: 'アカウントが見つかりません。' },
+      404,
+    )
+  }
+
+  await db
+    .prepare('UPDATE school_portal_otps SET consumed_at = ? WHERE id = ?')
+    .bind(now.toISOString(), otp.id)
+    .run()
+
+  const token = crypto.randomUUID() + crypto.randomUUID()
+  const tokenHash = await sha256Hex(token)
+  await db
+    .prepare(
+      `INSERT INTO school_portal_sessions (
+         id, guardian_id, email, token_hash, expires_at, created_at, last_seen_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      crypto.randomUUID(),
+      guardian.id,
+      email,
+      tokenHash,
+      new Date(now.getTime() + SESSION_TTL_MS).toISOString(),
+      now.toISOString(),
+      now.toISOString(),
+    )
+    .run()
+
+  return jsonResponse({
+    ok: true,
+    token,
+    account: { email, name: guardian.name },
+  })
+}
+
+export const onRequestGet = async ({
+  request,
+  env,
+}: PagesContext): Promise<Response> => {
+  if (!isAllowedRequestOrigin(request, env)) {
+    return jsonResponse({ ok: false, message: 'Invalid request origin.' }, 403)
+  }
+
+  const db = getDb(env)
+  if (!db) {
+    return jsonResponse(
+      { ok: false, message: 'ポータルを利用できません。' },
+      503,
+    )
+  }
+
+  const session = await getPortalSession(db, request)
+  if (!session) {
+    return jsonResponse({ ok: false, message: 'ログインしてください。' }, 401)
+  }
+
+  const account = await db
+    .prepare(
+      `SELECT id, email, name, phone, stripe_customer_id
+       FROM school_guardian_accounts
+       WHERE id = ?`,
+    )
+    .bind(session.guardianId)
+    .first<{
+      id: string
+      email: string
+      name: string
+      phone: string | null
+      stripe_customer_id: string | null
+    }>()
+  const bookings = await db
+    .prepare(
+      `SELECT b.*, c.title AS course_title, i.name AS instructor_name
+       FROM school_bookings b
+       JOIN school_courses c ON c.id = b.course_id
+       JOIN school_instructors i ON i.id = b.instructor_id
+       WHERE b.guardian_id = ?
+       ORDER BY b.start_at DESC
+       LIMIT 50`,
+    )
+    .bind(session.guardianId)
+    .all<BookingRow>()
+
+  return jsonResponse({
+    ok: true,
+    account: account
+      ? {
+          email: account.email,
+          name: account.name,
+          phone: account.phone,
+          hasStripeCustomer: Boolean(account.stripe_customer_id),
+        }
+      : { email: session.email },
+    bookings: (bookings.results ?? []).map(toPublicBooking),
+  })
+}
+
+export const onRequestOptions = ({ request, env }: PagesContext): Response =>
+  optionsResponse(request, env)

--- a/functions/api/schools/portal/stripe.ts
+++ b/functions/api/schools/portal/stripe.ts
@@ -1,0 +1,89 @@
+import {
+  getDb,
+  getPortalSession,
+  getSiteUrl,
+  isAllowedRequestOrigin,
+  jsonResponse,
+  optionsResponse,
+  type PagesContext,
+} from '../_shared'
+
+type PortalResponse = {
+  url?: string
+  error?: { message?: string }
+}
+
+export const onRequestPost = async ({
+  request,
+  env,
+}: PagesContext): Promise<Response> => {
+  if (!isAllowedRequestOrigin(request, env)) {
+    return jsonResponse({ ok: false, message: 'Invalid request origin.' }, 403)
+  }
+
+  const db = getDb(env)
+  const secretKey = String(env.STRIPE_SECRET_KEY || '').trim()
+  if (!db || !secretKey) {
+    return jsonResponse(
+      { ok: false, message: '請求ポータルを利用できません。' },
+      503,
+    )
+  }
+
+  const session = await getPortalSession(db, request)
+  if (!session) {
+    return jsonResponse({ ok: false, message: 'ログインしてください。' }, 401)
+  }
+
+  const account = await db
+    .prepare(
+      `SELECT stripe_customer_id
+       FROM school_guardian_accounts
+       WHERE id = ?`,
+    )
+    .bind(session.guardianId)
+    .first<{ stripe_customer_id: string | null }>()
+
+  if (!account?.stripe_customer_id) {
+    return jsonResponse(
+      { ok: false, message: 'Stripe顧客情報がありません。' },
+      404,
+    )
+  }
+
+  const body = new URLSearchParams()
+  body.set('customer', account.stripe_customer_id)
+  body.set(
+    'return_url',
+    String(env.STRIPE_CUSTOMER_PORTAL_RETURN_URL || '') ||
+      `${getSiteUrl(request, env)}/schools/portal/`,
+  )
+
+  const response = await fetch(
+    'https://api.stripe.com/v1/billing_portal/sessions',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Stripe-Version': '2026-02-25.clover',
+      },
+      body,
+    },
+  )
+  const result = (await response.json()) as PortalResponse
+  if (!response.ok || !result.url) {
+    return jsonResponse(
+      {
+        ok: false,
+        message: result.error?.message || 'Stripeポータルを開けません。',
+      },
+      502,
+    )
+  }
+
+  return jsonResponse({ ok: true, url: result.url })
+}
+
+export const onRequestOptions = ({ request, env }: PagesContext): Response =>
+  optionsResponse(request, env)

--- a/functions/api/stripe/webhook.ts
+++ b/functions/api/stripe/webhook.ts
@@ -1,0 +1,144 @@
+import {
+  getDb,
+  hmacSha256Hex,
+  jsonResponse,
+  type PagesContext,
+} from '../schools/_shared'
+
+type StripeEvent = {
+  id?: string
+  type?: string
+  created?: number
+  data?: {
+    object?: {
+      id?: string
+      customer?: string
+      subscription?: string
+      metadata?: Record<string, string>
+    }
+  }
+}
+
+const SIGNATURE_TOLERANCE_SECONDS = 300
+
+export const onRequestPost = async ({
+  request,
+  env,
+}: PagesContext): Promise<Response> => {
+  const db = getDb(env)
+  const webhookSecret = String(env.STRIPE_WEBHOOK_SECRET || '').trim()
+  if (!db || !webhookSecret) {
+    return jsonResponse(
+      { ok: false, message: 'Webhook is not configured.' },
+      503,
+    )
+  }
+
+  const rawBody = await request.text()
+  const signature = request.headers.get('Stripe-Signature') || ''
+  const verified = await verifyStripeSignature(
+    rawBody,
+    signature,
+    webhookSecret,
+  )
+  if (!verified) {
+    return jsonResponse({ ok: false, message: 'Invalid signature.' }, 400)
+  }
+
+  const event = JSON.parse(rawBody) as StripeEvent
+  if (!event.id || !event.type) {
+    return jsonResponse({ ok: false, message: 'Invalid event.' }, 400)
+  }
+
+  const now = new Date().toISOString()
+  const duplicate = await db
+    .prepare('SELECT id FROM school_stripe_events WHERE id = ? LIMIT 1')
+    .bind(event.id)
+    .first<{ id: string }>()
+  if (duplicate) return jsonResponse({ ok: true, duplicate: true })
+
+  await db
+    .prepare(
+      `INSERT INTO school_stripe_events (id, type, created_at, processed_at)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .bind(
+      event.id,
+      event.type,
+      event.created ? new Date(event.created * 1000).toISOString() : now,
+      now,
+    )
+    .run()
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data?.object
+    const bookingId = session?.metadata?.booking_id
+    if (bookingId) {
+      await db
+        .prepare(
+          `UPDATE school_bookings
+           SET status = 'active',
+               stripe_checkout_session_id = COALESCE(?, stripe_checkout_session_id),
+               stripe_customer_id = COALESCE(?, stripe_customer_id),
+               stripe_subscription_id = COALESCE(?, stripe_subscription_id),
+               updated_at = ?
+           WHERE id = ?`,
+        )
+        .bind(
+          session?.id || null,
+          session?.customer || null,
+          session?.subscription || null,
+          now,
+          bookingId,
+        )
+        .run()
+    }
+  }
+
+  if (event.type === 'customer.subscription.deleted') {
+    const subscription = event.data?.object
+    if (subscription?.id) {
+      await db
+        .prepare(
+          `UPDATE school_bookings
+           SET status = 'cancelled', updated_at = ?
+           WHERE stripe_subscription_id = ?`,
+        )
+        .bind(now, subscription.id)
+        .run()
+    }
+  }
+
+  return jsonResponse({ ok: true })
+}
+
+async function verifyStripeSignature(
+  rawBody: string,
+  signature: string,
+  secret: string,
+): Promise<boolean> {
+  const parts = Object.fromEntries(
+    signature
+      .split(',')
+      .map((part) => part.split('='))
+      .filter((part) => part.length === 2),
+  )
+  const timestamp = Number(parts.t)
+  const expected = parts.v1
+  if (!timestamp || !expected) return false
+
+  const drift = Math.abs(Date.now() / 1000 - timestamp)
+  if (drift > SIGNATURE_TOLERANCE_SECONDS) return false
+
+  const actual = await hmacSha256Hex(secret, `${timestamp}.${rawBody}`)
+  return timingSafeEqual(actual, expected)
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let result = 0
+  for (let i = 0; i < a.length; i += 1) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return result === 0
+}

--- a/migrations/0002_create_school_booking.sql
+++ b/migrations/0002_create_school_booking.sql
@@ -1,0 +1,215 @@
+CREATE TABLE IF NOT EXISTS school_guardian_accounts (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  phone TEXT,
+  stripe_customer_id TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS school_students (
+  id TEXT PRIMARY KEY,
+  guardian_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  grade TEXT,
+  notes TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (guardian_id) REFERENCES school_guardian_accounts (id)
+);
+
+CREATE TABLE IF NOT EXISTS school_instructors (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT,
+  calendar_token TEXT NOT NULL UNIQUE,
+  active INTEGER NOT NULL DEFAULT 1,
+  sort_order INTEGER NOT NULL DEFAULT 100,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS school_courses (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  target TEXT NOT NULL,
+  recommended_age TEXT NOT NULL,
+  frequency TEXT NOT NULL,
+  price_label TEXT NOT NULL,
+  monthly_price_env_key TEXT NOT NULL,
+  active INTEGER NOT NULL DEFAULT 1,
+  sort_order INTEGER NOT NULL DEFAULT 100,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS school_course_instructors (
+  course_id TEXT NOT NULL,
+  instructor_id TEXT NOT NULL,
+  PRIMARY KEY (course_id, instructor_id),
+  FOREIGN KEY (course_id) REFERENCES school_courses (id),
+  FOREIGN KEY (instructor_id) REFERENCES school_instructors (id)
+);
+
+CREATE TABLE IF NOT EXISTS school_availability_rules (
+  id TEXT PRIMARY KEY,
+  instructor_id TEXT NOT NULL,
+  course_id TEXT NOT NULL,
+  weekday INTEGER NOT NULL,
+  start_time TEXT NOT NULL,
+  end_time TEXT NOT NULL,
+  slot_minutes INTEGER NOT NULL DEFAULT 60,
+  capacity INTEGER NOT NULL DEFAULT 1,
+  active INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (instructor_id) REFERENCES school_instructors (id),
+  FOREIGN KEY (course_id) REFERENCES school_courses (id)
+);
+
+CREATE TABLE IF NOT EXISTS school_bookings (
+  id TEXT PRIMARY KEY,
+  booking_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  guardian_id TEXT NOT NULL,
+  student_id TEXT NOT NULL,
+  course_id TEXT NOT NULL,
+  instructor_id TEXT NOT NULL,
+  start_at TEXT NOT NULL,
+  end_at TEXT NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'Asia/Tokyo',
+  guardian_name TEXT NOT NULL,
+  guardian_email TEXT NOT NULL,
+  guardian_phone TEXT,
+  student_name TEXT NOT NULL,
+  student_grade TEXT,
+  message TEXT,
+  stripe_checkout_session_id TEXT,
+  stripe_customer_id TEXT,
+  stripe_subscription_id TEXT,
+  cancel_reason TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (guardian_id) REFERENCES school_guardian_accounts (id),
+  FOREIGN KEY (student_id) REFERENCES school_students (id),
+  FOREIGN KEY (course_id) REFERENCES school_courses (id),
+  FOREIGN KEY (instructor_id) REFERENCES school_instructors (id)
+);
+
+CREATE TABLE IF NOT EXISTS school_booking_audit_logs (
+  id TEXT PRIMARY KEY,
+  booking_id TEXT NOT NULL,
+  actor_type TEXT NOT NULL,
+  action TEXT NOT NULL,
+  detail TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (booking_id) REFERENCES school_bookings (id)
+);
+
+CREATE TABLE IF NOT EXISTS school_portal_otps (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL,
+  code_hash TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  consumed_at TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS school_portal_sessions (
+  id TEXT PRIMARY KEY,
+  guardian_id TEXT NOT NULL,
+  email TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  FOREIGN KEY (guardian_id) REFERENCES school_guardian_accounts (id)
+);
+
+CREATE TABLE IF NOT EXISTS school_stripe_events (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  processed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_school_students_guardian
+  ON school_students (guardian_id);
+
+CREATE INDEX IF NOT EXISTS idx_school_bookings_guardian_start
+  ON school_bookings (guardian_id, start_at);
+
+CREATE INDEX IF NOT EXISTS idx_school_bookings_instructor_start
+  ON school_bookings (instructor_id, start_at);
+
+CREATE INDEX IF NOT EXISTS idx_school_bookings_course_start
+  ON school_bookings (course_id, start_at);
+
+CREATE INDEX IF NOT EXISTS idx_school_bookings_status_start
+  ON school_bookings (status, start_at);
+
+CREATE INDEX IF NOT EXISTS idx_school_portal_otps_email_created
+  ON school_portal_otps (email, created_at);
+
+INSERT OR IGNORE INTO school_instructors (
+  id,
+  name,
+  email,
+  calendar_token,
+  active,
+  sort_order,
+  created_at,
+  updated_at
+) VALUES
+  ('hatt', 'Hatt', 'info@acecore.net', 'cal_' || lower(hex(randomblob(24))), 1, 10, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('acecore-staff', 'Acecore Staff', 'info@acecore.net', 'cal_' || lower(hex(randomblob(24))), 1, 20, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z');
+
+INSERT OR IGNORE INTO school_courses (
+  id,
+  title,
+  summary,
+  target,
+  recommended_age,
+  frequency,
+  price_label,
+  monthly_price_env_key,
+  active,
+  sort_order,
+  created_at,
+  updated_at
+) VALUES
+  ('juku', '学習塾', '学校の学習、定期テスト、受験対策を個別に組み立てます。', '小学生・中学生・高校生', '小学4年生以上', '週1回から相談', '月謝 8千〜3.3万円', 'STRIPE_PRICE_SCHOOLS_JUKU_MONTHLY', 1, 10, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('robot-programming', 'ロボット / プログラミング', '工作、センサー、マインクラフトなどから論理的思考を育てます。', '小学生・中学生', '小学3年生以上', '月2回または週1回', '月謝 8千〜2.2万円', 'STRIPE_PRICE_SCHOOLS_ROBOT_MONTHLY', 1, 20, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('practical-programming', '実践プログラミング', 'Web制作、Python、API、Gitなど実務につながる内容を学びます。', '中学生以上・社会人', '中学生以上', '週1回から相談', '月謝 1.1万〜3.3万円', 'STRIPE_PRICE_SCHOOLS_PROGRAMMING_MONTHLY', 1, 30, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('pc-smartphone', 'パソコン / スマホ', '基本操作、Office、メール、オンライン会議、セキュリティを扱います。', '初心者・シニア・社会人', '年齢不問', '単発または月2回から', '月謝 8千円〜 / 単発相談可', 'STRIPE_PRICE_SCHOOLS_PC_MONTHLY', 1, 40, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('ged', '高卒認定', '科目ごとの計画作成、過去問演習、学習習慣づくりを支援します。', '高卒認定を目指す方', '高校生相当以上', '週1回から相談', '月謝 1.1万〜3.3万円', 'STRIPE_PRICE_SCHOOLS_GED_MONTHLY', 1, 50, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z');
+
+INSERT OR IGNORE INTO school_course_instructors (course_id, instructor_id) VALUES
+  ('juku', 'acecore-staff'),
+  ('robot-programming', 'hatt'),
+  ('robot-programming', 'acecore-staff'),
+  ('practical-programming', 'hatt'),
+  ('pc-smartphone', 'acecore-staff'),
+  ('ged', 'acecore-staff');
+
+INSERT OR IGNORE INTO school_availability_rules (
+  id,
+  instructor_id,
+  course_id,
+  weekday,
+  start_time,
+  end_time,
+  slot_minutes,
+  capacity,
+  active,
+  created_at,
+  updated_at
+) VALUES
+  ('rule-juku-wed', 'acecore-staff', 'juku', 3, '17:00', '20:00', 60, 1, 1, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('rule-juku-sat', 'acecore-staff', 'juku', 6, '10:00', '14:00', 60, 1, 1, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('rule-robot-sat', 'hatt', 'robot-programming', 6, '14:00', '18:00', 60, 1, 1, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('rule-programming-thu', 'hatt', 'practical-programming', 4, '18:00', '21:00', 60, 1, 1, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('rule-pc-tue', 'acecore-staff', 'pc-smartphone', 2, '13:00', '17:00', 60, 1, 1, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z'),
+  ('rule-ged-fri', 'acecore-staff', 'ged', 5, '17:00', '20:00', 60, 1, 1, '2026-06-07T00:00:00.000Z', '2026-06-07T00:00:00.000Z');

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -2276,6 +2276,87 @@ collections:
             label: '導入'
             hint: 'intro'
             widget: string
+          - name: 'trialEyebrow'
+            label: '無料体験・補助見出し'
+            hint: 'trialEyebrow'
+            widget: string
+          - name: 'trialTitle'
+            label: '無料体験・見出し'
+            hint: 'trialTitle'
+            widget: string
+          - name: 'trialBody'
+            label: '無料体験・本文'
+            hint: 'trialBody'
+            widget: text
+          - name: 'trialCta'
+            label: '無料体験・CTA'
+            hint: 'trialCta'
+            widget: string
+          - name: 'portalCta'
+            label: 'ポータル・CTA'
+            hint: 'portalCta'
+            widget: string
+          - name: 'trialPoint1Title'
+            label: '無料体験ポイント1・見出し'
+            hint: 'trialPoint1Title'
+            widget: string
+          - name: 'trialPoint1Body'
+            label: '無料体験ポイント1・本文'
+            hint: 'trialPoint1Body'
+            widget: string
+          - name: 'trialPoint2Title'
+            label: '無料体験ポイント2・見出し'
+            hint: 'trialPoint2Title'
+            widget: string
+          - name: 'trialPoint2Body'
+            label: '無料体験ポイント2・本文'
+            hint: 'trialPoint2Body'
+            widget: string
+          - name: 'trialPoint3Title'
+            label: '無料体験ポイント3・見出し'
+            hint: 'trialPoint3Title'
+            widget: string
+          - name: 'trialPoint3Body'
+            label: '無料体験ポイント3・本文'
+            hint: 'trialPoint3Body'
+            widget: string
+          - name: 'courseDetailEyebrow'
+            label: 'コース詳細・補助見出し'
+            hint: 'courseDetailEyebrow'
+            widget: string
+          - name: 'courseDetailTitle'
+            label: 'コース詳細・見出し'
+            hint: 'courseDetailTitle'
+            widget: string
+          - name: 'courseTargetLabel'
+            label: 'コース詳細・対象者ラベル'
+            hint: 'courseTargetLabel'
+            widget: string
+          - name: 'courseAgeLabel'
+            label: 'コース詳細・推奨年齢ラベル'
+            hint: 'courseAgeLabel'
+            widget: string
+          - name: 'courseFrequencyLabel'
+            label: 'コース詳細・頻度ラベル'
+            hint: 'courseFrequencyLabel'
+            widget: string
+          - name: 'courseScheduleLabel'
+            label: 'コース詳細・時間帯ラベル'
+            hint: 'courseScheduleLabel'
+            widget: string
+          - name: 'courseDetails'
+            label: 'コース詳細'
+            hint: 'courseDetails'
+            widget: list
+            summary: '{{fields.title}}'
+            fields:
+              - { name: 'id', label: 'ID', widget: string }
+              - { name: 'icon', label: 'アイコン', widget: string }
+              - { name: 'title', label: 'タイトル', widget: string }
+              - { name: 'target', label: '対象者', widget: string }
+              - { name: 'recommendedAge', label: '推奨年齢', widget: string }
+              - { name: 'frequency', label: '頻度', widget: string }
+              - { name: 'schedule', label: '曜日・時間帯', widget: string }
           - name: 'juku'
             label: '塾'
             hint: 'juku'
@@ -2529,10 +2610,183 @@ collections:
             label: 'CTA: フォーム'
             hint: 'ctaForm'
             widget: string
+          - name: 'ctaBook'
+            label: 'CTA: 予約'
+            hint: 'ctaBook'
+            widget: string
+          - name: 'ctaPortal'
+            label: 'CTA: ポータル'
+            hint: 'ctaPortal'
+            widget: string
           - name: 'ctaLine'
             label: 'CTA: LINE'
             hint: 'ctaLine'
             widget: string
+          - name: 'guardianFaqTitle'
+            label: '保護者FAQ・見出し'
+            hint: 'guardianFaqTitle'
+            widget: string
+          - name: 'guardianFaqs'
+            label: '保護者FAQ'
+            hint: 'guardianFaqs'
+            widget: list
+            summary: '{{fields.question}}'
+            fields:
+              - { name: 'question', label: '質問', widget: string }
+              - { name: 'answer', label: '回答', widget: text }
+          - name: 'bookingPage'
+            label: '予約ページ'
+            hint: 'bookingPage'
+            widget: object
+            collapsed: true
+            fields:
+              - { name: 'title', label: 'タイトル', widget: string }
+              - { name: 'description', label: '説明', widget: string }
+              - {
+                  name: 'heroTitle',
+                  label: 'ヒーロー・タイトル',
+                  widget: string,
+                }
+              - {
+                  name: 'heroSubtitle',
+                  label: 'ヒーロー・サブタイトル',
+                  widget: string,
+                }
+              - {
+                  name: 'heroImgAlt',
+                  label: '画像代替テキスト',
+                  widget: string,
+                }
+              - {
+                  name: 'flowTrialTitle',
+                  label: '流れ・無料体験見出し',
+                  widget: string,
+                }
+              - {
+                  name: 'flowTrialBody',
+                  label: '流れ・無料体験本文',
+                  widget: string,
+                }
+              - {
+                  name: 'flowPaymentTitle',
+                  label: '流れ・決済見出し',
+                  widget: string,
+                }
+              - {
+                  name: 'flowPaymentBody',
+                  label: '流れ・決済本文',
+                  widget: string,
+                }
+              - {
+                  name: 'flowPortalTitle',
+                  label: '流れ・ポータル見出し',
+                  widget: string,
+                }
+              - {
+                  name: 'flowPortalBody',
+                  label: '流れ・ポータル本文',
+                  widget: string,
+                }
+              - { name: 'typeLabel', label: '種別ラベル', widget: string }
+              - { name: 'typeTrial', label: '無料体験ラベル', widget: string }
+              - { name: 'typeTrialBody', label: '無料体験説明', widget: string }
+              - {
+                  name: 'typeEnrollment',
+                  label: '本申込みラベル',
+                  widget: string,
+                }
+              - {
+                  name: 'typeEnrollmentBody',
+                  label: '本申込み説明',
+                  widget: string,
+                }
+              - { name: 'courseLabel', label: 'コースラベル', widget: string }
+              - { name: 'instructorLabel', label: '講師ラベル', widget: string }
+              - { name: 'slotLabel', label: '予約枠ラベル', widget: string }
+              - { name: 'slotNote', label: '予約枠補足', widget: string }
+              - { name: 'guardianName', label: '保護者名', widget: string }
+              - { name: 'guardianEmail', label: 'メール', widget: string }
+              - { name: 'guardianPhone', label: '電話', widget: string }
+              - { name: 'studentName', label: '受講者名', widget: string }
+              - { name: 'studentGrade', label: '学年', widget: string }
+              - { name: 'message', label: '相談内容', widget: string }
+              - { name: 'submit', label: '送信ボタン', widget: string }
+              - { name: 'portalLink', label: 'ポータルリンク', widget: string }
+              - { name: 'sideTitle', label: 'サイド見出し', widget: string }
+              - { name: 'sideItem1', label: 'サイド項目1', widget: string }
+              - { name: 'sideItem2', label: 'サイド項目2', widget: string }
+              - { name: 'sideItem3', label: 'サイド項目3', widget: string }
+              - {
+                  name: 'calendarPolicyTitle',
+                  label: 'カレンダー方針見出し',
+                  widget: string,
+                }
+              - {
+                  name: 'calendarPolicyBody',
+                  label: 'カレンダー方針本文',
+                  widget: text,
+                }
+          - name: 'portalPage'
+            label: '会員ポータル'
+            hint: 'portalPage'
+            widget: object
+            collapsed: true
+            fields:
+              - { name: 'title', label: 'タイトル', widget: string }
+              - { name: 'description', label: '説明', widget: string }
+              - {
+                  name: 'heroTitle',
+                  label: 'ヒーロー・タイトル',
+                  widget: string,
+                }
+              - {
+                  name: 'heroSubtitle',
+                  label: 'ヒーロー・サブタイトル',
+                  widget: string,
+                }
+              - {
+                  name: 'heroImgAlt',
+                  label: '画像代替テキスト',
+                  widget: string,
+                }
+              - { name: 'loginTitle', label: 'ログイン見出し', widget: string }
+              - { name: 'loginBody', label: 'ログイン本文', widget: text }
+              - {
+                  name: 'namePlaceholder',
+                  label: '名前 placeholder',
+                  widget: string,
+                }
+              - {
+                  name: 'emailPlaceholder',
+                  label: 'メール placeholder',
+                  widget: string,
+                }
+              - {
+                  name: 'codePlaceholder',
+                  label: 'コード placeholder',
+                  widget: string,
+                }
+              - { name: 'sendCode', label: 'コード送信ボタン', widget: string }
+              - { name: 'login', label: 'ログインボタン', widget: string }
+              - {
+                  name: 'calendarTitle',
+                  label: 'カレンダー見出し',
+                  widget: string,
+                }
+              - { name: 'calendarBody', label: 'カレンダー本文', widget: text }
+              - {
+                  name: 'dashboardEyebrow',
+                  label: 'ダッシュボード補助見出し',
+                  widget: string,
+                }
+              - {
+                  name: 'dashboardTitle',
+                  label: 'ダッシュボード見出し',
+                  widget: string,
+                }
+              - { name: 'refresh', label: '更新ボタン', widget: string }
+              - { name: 'billing', label: '請求ボタン', widget: string }
+              - { name: 'empty', label: '空状態', widget: string }
       - name: 'acestudio'
         label: 'AceStudioページ'
         file: src/i18n/source/ja/pages/acestudio.json

--- a/src/i18n/source/ja/pages/schools.json
+++ b/src/i18n/source/ja/pages/schools.json
@@ -8,6 +8,70 @@
   "learningFlowTitle": "Acecore Schoolsの学びを流れで見る",
   "learningFlowDesc": "興味の入口から実践、継続までを一本の学習導線として見せています。",
   "intro": "お子さまから大人の方まで、一人ひとりの目標やペースに合わせた個別指導を行っています。サービス一覧での位置づけもご覧いただけます。",
+  "trialEyebrow": "Free Trial",
+  "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+  "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+  "trialCta": "無料体験を予約する",
+  "portalCta": "会員ポータルを開く",
+  "trialPoint1Title": "オンライン予約",
+  "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+  "trialPoint2Title": "本申込みも対応",
+  "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+  "trialPoint3Title": "変更はポータル",
+  "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+  "courseDetailEyebrow": "Course Guide",
+  "courseDetailTitle": "対象者・頻度・授業スケジュール",
+  "courseTargetLabel": "対象者",
+  "courseAgeLabel": "推奨年齢",
+  "courseFrequencyLabel": "授業頻度",
+  "courseScheduleLabel": "主な曜日・時間帯",
+  "courseDetails": [
+    {
+      "id": "juku",
+      "icon": "book-open",
+      "title": "学習塾",
+      "target": "小学生・中学生・高校生",
+      "recommendedAge": "小学4年生以上",
+      "frequency": "週1回から相談",
+      "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+    },
+    {
+      "id": "robot-programming",
+      "icon": "bot",
+      "title": "ロボット / プログラミング",
+      "target": "小学生・中学生",
+      "recommendedAge": "小学3年生以上",
+      "frequency": "月2回または週1回",
+      "schedule": "土曜 14:00〜18:00"
+    },
+    {
+      "id": "practical-programming",
+      "icon": "code-xml",
+      "title": "実践プログラミング",
+      "target": "中学生以上・社会人",
+      "recommendedAge": "中学生以上",
+      "frequency": "週1回から相談",
+      "schedule": "木曜 18:00〜21:00"
+    },
+    {
+      "id": "pc-smartphone",
+      "icon": "monitor-smartphone",
+      "title": "パソコン / スマホ",
+      "target": "初心者・シニア・社会人",
+      "recommendedAge": "年齢不問",
+      "frequency": "単発または月2回から",
+      "schedule": "火曜 13:00〜17:00"
+    },
+    {
+      "id": "ged",
+      "icon": "file-badge",
+      "title": "高卒認定",
+      "target": "高卒認定を目指す方",
+      "recommendedAge": "高校生相当以上",
+      "frequency": "週1回から相談",
+      "schedule": "金曜 17:00〜20:00"
+    }
+  ],
   "juku": {
     "title": "学習塾",
     "desc": "私たちの学習塾では、一人ひとりの生徒に合わせた指導を行い、基礎から応用までの学力を身につけることができます。経験豊富な講師陣が、生徒の成長をサポートします。",
@@ -108,7 +172,85 @@
   "ctaHeading": "お問い合わせ・お申し込み",
   "ctaBody": "各コースの詳細やお申し込みは、お問い合わせフォームまたはLINEからご相談ください。「どのコースが合うか分からない」という内容でも大丈夫です。",
   "ctaForm": "お問い合わせフォーム",
+  "ctaBook": "予約へ進む",
+  "ctaPortal": "ポータルで確認する",
   "ctaLine": "LINEで問い合わせる",
+  "guardianFaqTitle": "保護者向けFAQ",
+  "guardianFaqs": [
+    {
+      "question": "無料体験では何を確認できますか？",
+      "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+    },
+    {
+      "question": "予約後に日程変更できますか？",
+      "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+    },
+    {
+      "question": "本申込みの支払いはどうなりますか？",
+      "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+    },
+    {
+      "question": "外部カレンダーで予定を見られますか？",
+      "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+    }
+  ],
+  "bookingPage": {
+    "title": "Schools 予約",
+    "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+    "heroTitle": "Schools 予約",
+    "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+    "heroImgAlt": "ロボット工作と学習の準備風景",
+    "flowTrialTitle": "無料体験を予約",
+    "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+    "flowPaymentTitle": "本申込みはStripe決済",
+    "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+    "flowPortalTitle": "変更はポータルで管理",
+    "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+    "typeLabel": "予約種別",
+    "typeTrial": "無料体験",
+    "typeTrialBody": "初回相談・体験授業として予約します。",
+    "typeEnrollment": "本申込み",
+    "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+    "courseLabel": "コース",
+    "instructorLabel": "講師",
+    "slotLabel": "予約枠",
+    "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+    "guardianName": "保護者名",
+    "guardianEmail": "メールアドレス",
+    "guardianPhone": "電話番号",
+    "studentName": "受講者名",
+    "studentGrade": "学年・年齢",
+    "message": "相談したい内容",
+    "submit": "予約する",
+    "portalLink": "予約済みの方はこちら",
+    "sideTitle": "予約前に確認すること",
+    "sideItem1": "無料体験は費用なしで予約できます。",
+    "sideItem2": "本申込みはStripeの画面で決済します。",
+    "sideItem3": "変更・キャンセルはポータルから行います。",
+    "calendarPolicyTitle": "外部カレンダーについて",
+    "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+  },
+  "portalPage": {
+    "title": "Schools 会員ポータル",
+    "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+    "heroTitle": "会員ポータル",
+    "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+    "heroImgAlt": "予約管理画面を確認する作業風景",
+    "loginTitle": "メールでログイン",
+    "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+    "namePlaceholder": "お名前",
+    "emailPlaceholder": "メールアドレス",
+    "codePlaceholder": "6桁の認証コード",
+    "sendCode": "認証コードを送る",
+    "login": "ログイン",
+    "calendarTitle": "外部カレンダーは表示専用",
+    "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+    "dashboardEyebrow": "Dashboard",
+    "dashboardTitle": "予約一覧",
+    "refresh": "更新",
+    "billing": "請求を確認",
+    "empty": "ログインすると予約が表示されます。"
+  },
   "learningSteps": [
     {
       "title": "興味を見つける",

--- a/src/i18n/translations/de.json
+++ b/src/i18n/translations/de.json
@@ -853,7 +853,149 @@
         "Fragen Sie die Lehrkräfte jederzeit",
         "Natürliche Kontinuität durch praktische Erfahrung",
         "Direkt verbunden mit Prüfungen, Zertifizierungen und echter Arbeit"
-      ]
+      ],
+      "trialEyebrow": "Free Trial",
+      "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+      "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+      "trialCta": "無料体験を予約する",
+      "portalCta": "会員ポータルを開く",
+      "trialPoint1Title": "オンライン予約",
+      "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+      "trialPoint2Title": "本申込みも対応",
+      "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+      "trialPoint3Title": "変更はポータル",
+      "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+      "courseDetailEyebrow": "Course Guide",
+      "courseDetailTitle": "対象者・頻度・授業スケジュール",
+      "courseTargetLabel": "対象者",
+      "courseAgeLabel": "推奨年齢",
+      "courseFrequencyLabel": "授業頻度",
+      "courseScheduleLabel": "主な曜日・時間帯",
+      "courseDetails": [
+        {
+          "id": "juku",
+          "icon": "book-open",
+          "title": "学習塾",
+          "target": "小学生・中学生・高校生",
+          "recommendedAge": "小学4年生以上",
+          "frequency": "週1回から相談",
+          "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+        },
+        {
+          "id": "robot-programming",
+          "icon": "bot",
+          "title": "ロボット / プログラミング",
+          "target": "小学生・中学生",
+          "recommendedAge": "小学3年生以上",
+          "frequency": "月2回または週1回",
+          "schedule": "土曜 14:00〜18:00"
+        },
+        {
+          "id": "practical-programming",
+          "icon": "code-xml",
+          "title": "実践プログラミング",
+          "target": "中学生以上・社会人",
+          "recommendedAge": "中学生以上",
+          "frequency": "週1回から相談",
+          "schedule": "木曜 18:00〜21:00"
+        },
+        {
+          "id": "pc-smartphone",
+          "icon": "monitor-smartphone",
+          "title": "パソコン / スマホ",
+          "target": "初心者・シニア・社会人",
+          "recommendedAge": "年齢不問",
+          "frequency": "単発または月2回から",
+          "schedule": "火曜 13:00〜17:00"
+        },
+        {
+          "id": "ged",
+          "icon": "file-badge",
+          "title": "高卒認定",
+          "target": "高卒認定を目指す方",
+          "recommendedAge": "高校生相当以上",
+          "frequency": "週1回から相談",
+          "schedule": "金曜 17:00〜20:00"
+        }
+      ],
+      "ctaBook": "予約へ進む",
+      "ctaPortal": "ポータルで確認する",
+      "guardianFaqTitle": "保護者向けFAQ",
+      "guardianFaqs": [
+        {
+          "question": "無料体験では何を確認できますか？",
+          "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+        },
+        {
+          "question": "予約後に日程変更できますか？",
+          "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+        },
+        {
+          "question": "本申込みの支払いはどうなりますか？",
+          "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+        },
+        {
+          "question": "外部カレンダーで予定を見られますか？",
+          "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+        }
+      ],
+      "bookingPage": {
+        "title": "Schools 予約",
+        "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+        "heroTitle": "Schools 予約",
+        "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+        "heroImgAlt": "ロボット工作と学習の準備風景",
+        "flowTrialTitle": "無料体験を予約",
+        "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+        "flowPaymentTitle": "本申込みはStripe決済",
+        "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+        "flowPortalTitle": "変更はポータルで管理",
+        "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+        "typeLabel": "予約種別",
+        "typeTrial": "無料体験",
+        "typeTrialBody": "初回相談・体験授業として予約します。",
+        "typeEnrollment": "本申込み",
+        "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+        "courseLabel": "コース",
+        "instructorLabel": "講師",
+        "slotLabel": "予約枠",
+        "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+        "guardianName": "保護者名",
+        "guardianEmail": "メールアドレス",
+        "guardianPhone": "電話番号",
+        "studentName": "受講者名",
+        "studentGrade": "学年・年齢",
+        "message": "相談したい内容",
+        "submit": "予約する",
+        "portalLink": "予約済みの方はこちら",
+        "sideTitle": "予約前に確認すること",
+        "sideItem1": "無料体験は費用なしで予約できます。",
+        "sideItem2": "本申込みはStripeの画面で決済します。",
+        "sideItem3": "変更・キャンセルはポータルから行います。",
+        "calendarPolicyTitle": "外部カレンダーについて",
+        "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+      },
+      "portalPage": {
+        "title": "Schools 会員ポータル",
+        "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+        "heroTitle": "会員ポータル",
+        "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+        "heroImgAlt": "予約管理画面を確認する作業風景",
+        "loginTitle": "メールでログイン",
+        "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+        "namePlaceholder": "お名前",
+        "emailPlaceholder": "メールアドレス",
+        "codePlaceholder": "6桁の認証コード",
+        "sendCode": "認証コードを送る",
+        "login": "ログイン",
+        "calendarTitle": "外部カレンダーは表示専用",
+        "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+        "dashboardEyebrow": "Dashboard",
+        "dashboardTitle": "予約一覧",
+        "refresh": "更新",
+        "billing": "請求を確認",
+        "empty": "ログインすると予約が表示されます。"
+      }
     },
     "privacy": {
       "title": "Datenschutzerklärung",

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -799,7 +799,149 @@
         "Ask instructors anytime",
         "Natural continuity through hands-on experience",
         "Directly connected to exams, certifications, and real work"
-      ]
+      ],
+      "trialEyebrow": "Free Trial",
+      "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+      "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+      "trialCta": "無料体験を予約する",
+      "portalCta": "会員ポータルを開く",
+      "trialPoint1Title": "オンライン予約",
+      "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+      "trialPoint2Title": "本申込みも対応",
+      "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+      "trialPoint3Title": "変更はポータル",
+      "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+      "courseDetailEyebrow": "Course Guide",
+      "courseDetailTitle": "対象者・頻度・授業スケジュール",
+      "courseTargetLabel": "対象者",
+      "courseAgeLabel": "推奨年齢",
+      "courseFrequencyLabel": "授業頻度",
+      "courseScheduleLabel": "主な曜日・時間帯",
+      "courseDetails": [
+        {
+          "id": "juku",
+          "icon": "book-open",
+          "title": "学習塾",
+          "target": "小学生・中学生・高校生",
+          "recommendedAge": "小学4年生以上",
+          "frequency": "週1回から相談",
+          "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+        },
+        {
+          "id": "robot-programming",
+          "icon": "bot",
+          "title": "ロボット / プログラミング",
+          "target": "小学生・中学生",
+          "recommendedAge": "小学3年生以上",
+          "frequency": "月2回または週1回",
+          "schedule": "土曜 14:00〜18:00"
+        },
+        {
+          "id": "practical-programming",
+          "icon": "code-xml",
+          "title": "実践プログラミング",
+          "target": "中学生以上・社会人",
+          "recommendedAge": "中学生以上",
+          "frequency": "週1回から相談",
+          "schedule": "木曜 18:00〜21:00"
+        },
+        {
+          "id": "pc-smartphone",
+          "icon": "monitor-smartphone",
+          "title": "パソコン / スマホ",
+          "target": "初心者・シニア・社会人",
+          "recommendedAge": "年齢不問",
+          "frequency": "単発または月2回から",
+          "schedule": "火曜 13:00〜17:00"
+        },
+        {
+          "id": "ged",
+          "icon": "file-badge",
+          "title": "高卒認定",
+          "target": "高卒認定を目指す方",
+          "recommendedAge": "高校生相当以上",
+          "frequency": "週1回から相談",
+          "schedule": "金曜 17:00〜20:00"
+        }
+      ],
+      "ctaBook": "予約へ進む",
+      "ctaPortal": "ポータルで確認する",
+      "guardianFaqTitle": "保護者向けFAQ",
+      "guardianFaqs": [
+        {
+          "question": "無料体験では何を確認できますか？",
+          "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+        },
+        {
+          "question": "予約後に日程変更できますか？",
+          "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+        },
+        {
+          "question": "本申込みの支払いはどうなりますか？",
+          "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+        },
+        {
+          "question": "外部カレンダーで予定を見られますか？",
+          "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+        }
+      ],
+      "bookingPage": {
+        "title": "Schools 予約",
+        "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+        "heroTitle": "Schools 予約",
+        "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+        "heroImgAlt": "ロボット工作と学習の準備風景",
+        "flowTrialTitle": "無料体験を予約",
+        "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+        "flowPaymentTitle": "本申込みはStripe決済",
+        "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+        "flowPortalTitle": "変更はポータルで管理",
+        "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+        "typeLabel": "予約種別",
+        "typeTrial": "無料体験",
+        "typeTrialBody": "初回相談・体験授業として予約します。",
+        "typeEnrollment": "本申込み",
+        "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+        "courseLabel": "コース",
+        "instructorLabel": "講師",
+        "slotLabel": "予約枠",
+        "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+        "guardianName": "保護者名",
+        "guardianEmail": "メールアドレス",
+        "guardianPhone": "電話番号",
+        "studentName": "受講者名",
+        "studentGrade": "学年・年齢",
+        "message": "相談したい内容",
+        "submit": "予約する",
+        "portalLink": "予約済みの方はこちら",
+        "sideTitle": "予約前に確認すること",
+        "sideItem1": "無料体験は費用なしで予約できます。",
+        "sideItem2": "本申込みはStripeの画面で決済します。",
+        "sideItem3": "変更・キャンセルはポータルから行います。",
+        "calendarPolicyTitle": "外部カレンダーについて",
+        "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+      },
+      "portalPage": {
+        "title": "Schools 会員ポータル",
+        "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+        "heroTitle": "会員ポータル",
+        "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+        "heroImgAlt": "予約管理画面を確認する作業風景",
+        "loginTitle": "メールでログイン",
+        "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+        "namePlaceholder": "お名前",
+        "emailPlaceholder": "メールアドレス",
+        "codePlaceholder": "6桁の認証コード",
+        "sendCode": "認証コードを送る",
+        "login": "ログイン",
+        "calendarTitle": "外部カレンダーは表示専用",
+        "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+        "dashboardEyebrow": "Dashboard",
+        "dashboardTitle": "予約一覧",
+        "refresh": "更新",
+        "billing": "請求を確認",
+        "empty": "ログインすると予約が表示されます。"
+      }
     },
     "privacy": {
       "title": "Privacy Policy",

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -508,7 +508,149 @@
         "Consulta con instructores en cualquier momento",
         "Continuidad natural a través de la experiencia",
         "Conexión directa con exámenes, certificaciones y trabajo real"
-      ]
+      ],
+      "trialEyebrow": "Free Trial",
+      "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+      "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+      "trialCta": "無料体験を予約する",
+      "portalCta": "会員ポータルを開く",
+      "trialPoint1Title": "オンライン予約",
+      "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+      "trialPoint2Title": "本申込みも対応",
+      "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+      "trialPoint3Title": "変更はポータル",
+      "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+      "courseDetailEyebrow": "Course Guide",
+      "courseDetailTitle": "対象者・頻度・授業スケジュール",
+      "courseTargetLabel": "対象者",
+      "courseAgeLabel": "推奨年齢",
+      "courseFrequencyLabel": "授業頻度",
+      "courseScheduleLabel": "主な曜日・時間帯",
+      "courseDetails": [
+        {
+          "id": "juku",
+          "icon": "book-open",
+          "title": "学習塾",
+          "target": "小学生・中学生・高校生",
+          "recommendedAge": "小学4年生以上",
+          "frequency": "週1回から相談",
+          "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+        },
+        {
+          "id": "robot-programming",
+          "icon": "bot",
+          "title": "ロボット / プログラミング",
+          "target": "小学生・中学生",
+          "recommendedAge": "小学3年生以上",
+          "frequency": "月2回または週1回",
+          "schedule": "土曜 14:00〜18:00"
+        },
+        {
+          "id": "practical-programming",
+          "icon": "code-xml",
+          "title": "実践プログラミング",
+          "target": "中学生以上・社会人",
+          "recommendedAge": "中学生以上",
+          "frequency": "週1回から相談",
+          "schedule": "木曜 18:00〜21:00"
+        },
+        {
+          "id": "pc-smartphone",
+          "icon": "monitor-smartphone",
+          "title": "パソコン / スマホ",
+          "target": "初心者・シニア・社会人",
+          "recommendedAge": "年齢不問",
+          "frequency": "単発または月2回から",
+          "schedule": "火曜 13:00〜17:00"
+        },
+        {
+          "id": "ged",
+          "icon": "file-badge",
+          "title": "高卒認定",
+          "target": "高卒認定を目指す方",
+          "recommendedAge": "高校生相当以上",
+          "frequency": "週1回から相談",
+          "schedule": "金曜 17:00〜20:00"
+        }
+      ],
+      "ctaBook": "予約へ進む",
+      "ctaPortal": "ポータルで確認する",
+      "guardianFaqTitle": "保護者向けFAQ",
+      "guardianFaqs": [
+        {
+          "question": "無料体験では何を確認できますか？",
+          "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+        },
+        {
+          "question": "予約後に日程変更できますか？",
+          "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+        },
+        {
+          "question": "本申込みの支払いはどうなりますか？",
+          "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+        },
+        {
+          "question": "外部カレンダーで予定を見られますか？",
+          "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+        }
+      ],
+      "bookingPage": {
+        "title": "Schools 予約",
+        "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+        "heroTitle": "Schools 予約",
+        "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+        "heroImgAlt": "ロボット工作と学習の準備風景",
+        "flowTrialTitle": "無料体験を予約",
+        "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+        "flowPaymentTitle": "本申込みはStripe決済",
+        "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+        "flowPortalTitle": "変更はポータルで管理",
+        "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+        "typeLabel": "予約種別",
+        "typeTrial": "無料体験",
+        "typeTrialBody": "初回相談・体験授業として予約します。",
+        "typeEnrollment": "本申込み",
+        "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+        "courseLabel": "コース",
+        "instructorLabel": "講師",
+        "slotLabel": "予約枠",
+        "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+        "guardianName": "保護者名",
+        "guardianEmail": "メールアドレス",
+        "guardianPhone": "電話番号",
+        "studentName": "受講者名",
+        "studentGrade": "学年・年齢",
+        "message": "相談したい内容",
+        "submit": "予約する",
+        "portalLink": "予約済みの方はこちら",
+        "sideTitle": "予約前に確認すること",
+        "sideItem1": "無料体験は費用なしで予約できます。",
+        "sideItem2": "本申込みはStripeの画面で決済します。",
+        "sideItem3": "変更・キャンセルはポータルから行います。",
+        "calendarPolicyTitle": "外部カレンダーについて",
+        "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+      },
+      "portalPage": {
+        "title": "Schools 会員ポータル",
+        "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+        "heroTitle": "会員ポータル",
+        "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+        "heroImgAlt": "予約管理画面を確認する作業風景",
+        "loginTitle": "メールでログイン",
+        "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+        "namePlaceholder": "お名前",
+        "emailPlaceholder": "メールアドレス",
+        "codePlaceholder": "6桁の認証コード",
+        "sendCode": "認証コードを送る",
+        "login": "ログイン",
+        "calendarTitle": "外部カレンダーは表示専用",
+        "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+        "dashboardEyebrow": "Dashboard",
+        "dashboardTitle": "予約一覧",
+        "refresh": "更新",
+        "billing": "請求を確認",
+        "empty": "ログインすると予約が表示されます。"
+      }
     },
     "about": {
       "title": "Acerca de nosotros",

--- a/src/i18n/translations/fr.json
+++ b/src/i18n/translations/fr.json
@@ -508,7 +508,149 @@
         "Demandez aux instructeurs à tout moment",
         "Continuité naturelle à travers l'expérience pratique",
         "Directement connecté aux examens, certifications et travail réel"
-      ]
+      ],
+      "trialEyebrow": "Free Trial",
+      "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+      "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+      "trialCta": "無料体験を予約する",
+      "portalCta": "会員ポータルを開く",
+      "trialPoint1Title": "オンライン予約",
+      "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+      "trialPoint2Title": "本申込みも対応",
+      "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+      "trialPoint3Title": "変更はポータル",
+      "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+      "courseDetailEyebrow": "Course Guide",
+      "courseDetailTitle": "対象者・頻度・授業スケジュール",
+      "courseTargetLabel": "対象者",
+      "courseAgeLabel": "推奨年齢",
+      "courseFrequencyLabel": "授業頻度",
+      "courseScheduleLabel": "主な曜日・時間帯",
+      "courseDetails": [
+        {
+          "id": "juku",
+          "icon": "book-open",
+          "title": "学習塾",
+          "target": "小学生・中学生・高校生",
+          "recommendedAge": "小学4年生以上",
+          "frequency": "週1回から相談",
+          "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+        },
+        {
+          "id": "robot-programming",
+          "icon": "bot",
+          "title": "ロボット / プログラミング",
+          "target": "小学生・中学生",
+          "recommendedAge": "小学3年生以上",
+          "frequency": "月2回または週1回",
+          "schedule": "土曜 14:00〜18:00"
+        },
+        {
+          "id": "practical-programming",
+          "icon": "code-xml",
+          "title": "実践プログラミング",
+          "target": "中学生以上・社会人",
+          "recommendedAge": "中学生以上",
+          "frequency": "週1回から相談",
+          "schedule": "木曜 18:00〜21:00"
+        },
+        {
+          "id": "pc-smartphone",
+          "icon": "monitor-smartphone",
+          "title": "パソコン / スマホ",
+          "target": "初心者・シニア・社会人",
+          "recommendedAge": "年齢不問",
+          "frequency": "単発または月2回から",
+          "schedule": "火曜 13:00〜17:00"
+        },
+        {
+          "id": "ged",
+          "icon": "file-badge",
+          "title": "高卒認定",
+          "target": "高卒認定を目指す方",
+          "recommendedAge": "高校生相当以上",
+          "frequency": "週1回から相談",
+          "schedule": "金曜 17:00〜20:00"
+        }
+      ],
+      "ctaBook": "予約へ進む",
+      "ctaPortal": "ポータルで確認する",
+      "guardianFaqTitle": "保護者向けFAQ",
+      "guardianFaqs": [
+        {
+          "question": "無料体験では何を確認できますか？",
+          "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+        },
+        {
+          "question": "予約後に日程変更できますか？",
+          "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+        },
+        {
+          "question": "本申込みの支払いはどうなりますか？",
+          "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+        },
+        {
+          "question": "外部カレンダーで予定を見られますか？",
+          "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+        }
+      ],
+      "bookingPage": {
+        "title": "Schools 予約",
+        "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+        "heroTitle": "Schools 予約",
+        "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+        "heroImgAlt": "ロボット工作と学習の準備風景",
+        "flowTrialTitle": "無料体験を予約",
+        "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+        "flowPaymentTitle": "本申込みはStripe決済",
+        "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+        "flowPortalTitle": "変更はポータルで管理",
+        "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+        "typeLabel": "予約種別",
+        "typeTrial": "無料体験",
+        "typeTrialBody": "初回相談・体験授業として予約します。",
+        "typeEnrollment": "本申込み",
+        "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+        "courseLabel": "コース",
+        "instructorLabel": "講師",
+        "slotLabel": "予約枠",
+        "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+        "guardianName": "保護者名",
+        "guardianEmail": "メールアドレス",
+        "guardianPhone": "電話番号",
+        "studentName": "受講者名",
+        "studentGrade": "学年・年齢",
+        "message": "相談したい内容",
+        "submit": "予約する",
+        "portalLink": "予約済みの方はこちら",
+        "sideTitle": "予約前に確認すること",
+        "sideItem1": "無料体験は費用なしで予約できます。",
+        "sideItem2": "本申込みはStripeの画面で決済します。",
+        "sideItem3": "変更・キャンセルはポータルから行います。",
+        "calendarPolicyTitle": "外部カレンダーについて",
+        "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+      },
+      "portalPage": {
+        "title": "Schools 会員ポータル",
+        "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+        "heroTitle": "会員ポータル",
+        "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+        "heroImgAlt": "予約管理画面を確認する作業風景",
+        "loginTitle": "メールでログイン",
+        "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+        "namePlaceholder": "お名前",
+        "emailPlaceholder": "メールアドレス",
+        "codePlaceholder": "6桁の認証コード",
+        "sendCode": "認証コードを送る",
+        "login": "ログイン",
+        "calendarTitle": "外部カレンダーは表示専用",
+        "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+        "dashboardEyebrow": "Dashboard",
+        "dashboardTitle": "予約一覧",
+        "refresh": "更新",
+        "billing": "請求を確認",
+        "empty": "ログインすると予約が表示されます。"
+      }
     },
     "about": {
       "title": "À propos",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -508,7 +508,149 @@
         "언제든 강사에게 질문 가능",
         "체험을 통해 자연스럽게 지속",
         "시험, 자격증, 실무에 직결"
-      ]
+      ],
+      "trialEyebrow": "Free Trial",
+      "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+      "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+      "trialCta": "無料体験を予約する",
+      "portalCta": "会員ポータルを開く",
+      "trialPoint1Title": "オンライン予約",
+      "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+      "trialPoint2Title": "本申込みも対応",
+      "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+      "trialPoint3Title": "変更はポータル",
+      "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+      "courseDetailEyebrow": "Course Guide",
+      "courseDetailTitle": "対象者・頻度・授業スケジュール",
+      "courseTargetLabel": "対象者",
+      "courseAgeLabel": "推奨年齢",
+      "courseFrequencyLabel": "授業頻度",
+      "courseScheduleLabel": "主な曜日・時間帯",
+      "courseDetails": [
+        {
+          "id": "juku",
+          "icon": "book-open",
+          "title": "学習塾",
+          "target": "小学生・中学生・高校生",
+          "recommendedAge": "小学4年生以上",
+          "frequency": "週1回から相談",
+          "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+        },
+        {
+          "id": "robot-programming",
+          "icon": "bot",
+          "title": "ロボット / プログラミング",
+          "target": "小学生・中学生",
+          "recommendedAge": "小学3年生以上",
+          "frequency": "月2回または週1回",
+          "schedule": "土曜 14:00〜18:00"
+        },
+        {
+          "id": "practical-programming",
+          "icon": "code-xml",
+          "title": "実践プログラミング",
+          "target": "中学生以上・社会人",
+          "recommendedAge": "中学生以上",
+          "frequency": "週1回から相談",
+          "schedule": "木曜 18:00〜21:00"
+        },
+        {
+          "id": "pc-smartphone",
+          "icon": "monitor-smartphone",
+          "title": "パソコン / スマホ",
+          "target": "初心者・シニア・社会人",
+          "recommendedAge": "年齢不問",
+          "frequency": "単発または月2回から",
+          "schedule": "火曜 13:00〜17:00"
+        },
+        {
+          "id": "ged",
+          "icon": "file-badge",
+          "title": "高卒認定",
+          "target": "高卒認定を目指す方",
+          "recommendedAge": "高校生相当以上",
+          "frequency": "週1回から相談",
+          "schedule": "金曜 17:00〜20:00"
+        }
+      ],
+      "ctaBook": "予約へ進む",
+      "ctaPortal": "ポータルで確認する",
+      "guardianFaqTitle": "保護者向けFAQ",
+      "guardianFaqs": [
+        {
+          "question": "無料体験では何を確認できますか？",
+          "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+        },
+        {
+          "question": "予約後に日程変更できますか？",
+          "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+        },
+        {
+          "question": "本申込みの支払いはどうなりますか？",
+          "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+        },
+        {
+          "question": "外部カレンダーで予定を見られますか？",
+          "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+        }
+      ],
+      "bookingPage": {
+        "title": "Schools 予約",
+        "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+        "heroTitle": "Schools 予約",
+        "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+        "heroImgAlt": "ロボット工作と学習の準備風景",
+        "flowTrialTitle": "無料体験を予約",
+        "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+        "flowPaymentTitle": "本申込みはStripe決済",
+        "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+        "flowPortalTitle": "変更はポータルで管理",
+        "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+        "typeLabel": "予約種別",
+        "typeTrial": "無料体験",
+        "typeTrialBody": "初回相談・体験授業として予約します。",
+        "typeEnrollment": "本申込み",
+        "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+        "courseLabel": "コース",
+        "instructorLabel": "講師",
+        "slotLabel": "予約枠",
+        "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+        "guardianName": "保護者名",
+        "guardianEmail": "メールアドレス",
+        "guardianPhone": "電話番号",
+        "studentName": "受講者名",
+        "studentGrade": "学年・年齢",
+        "message": "相談したい内容",
+        "submit": "予約する",
+        "portalLink": "予約済みの方はこちら",
+        "sideTitle": "予約前に確認すること",
+        "sideItem1": "無料体験は費用なしで予約できます。",
+        "sideItem2": "本申込みはStripeの画面で決済します。",
+        "sideItem3": "変更・キャンセルはポータルから行います。",
+        "calendarPolicyTitle": "外部カレンダーについて",
+        "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+      },
+      "portalPage": {
+        "title": "Schools 会員ポータル",
+        "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+        "heroTitle": "会員ポータル",
+        "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+        "heroImgAlt": "予約管理画面を確認する作業風景",
+        "loginTitle": "メールでログイン",
+        "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+        "namePlaceholder": "お名前",
+        "emailPlaceholder": "メールアドレス",
+        "codePlaceholder": "6桁の認証コード",
+        "sendCode": "認証コードを送る",
+        "login": "ログイン",
+        "calendarTitle": "外部カレンダーは表示専用",
+        "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+        "dashboardEyebrow": "Dashboard",
+        "dashboardTitle": "予約一覧",
+        "refresh": "更新",
+        "billing": "請求を確認",
+        "empty": "ログインすると予約が表示されます。"
+      }
     },
     "about": {
       "title": "회사 소개",

--- a/src/i18n/translations/pt.json
+++ b/src/i18n/translations/pt.json
@@ -508,7 +508,149 @@
         "Pergunte aos instrutores a qualquer momento",
         "Continuidade natural através de experiência prática",
         "Diretamente conectado a exames, certificações e trabalho real"
-      ]
+      ],
+      "trialEyebrow": "Free Trial",
+      "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+      "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+      "trialCta": "無料体験を予約する",
+      "portalCta": "会員ポータルを開く",
+      "trialPoint1Title": "オンライン予約",
+      "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+      "trialPoint2Title": "本申込みも対応",
+      "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+      "trialPoint3Title": "変更はポータル",
+      "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+      "courseDetailEyebrow": "Course Guide",
+      "courseDetailTitle": "対象者・頻度・授業スケジュール",
+      "courseTargetLabel": "対象者",
+      "courseAgeLabel": "推奨年齢",
+      "courseFrequencyLabel": "授業頻度",
+      "courseScheduleLabel": "主な曜日・時間帯",
+      "courseDetails": [
+        {
+          "id": "juku",
+          "icon": "book-open",
+          "title": "学習塾",
+          "target": "小学生・中学生・高校生",
+          "recommendedAge": "小学4年生以上",
+          "frequency": "週1回から相談",
+          "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+        },
+        {
+          "id": "robot-programming",
+          "icon": "bot",
+          "title": "ロボット / プログラミング",
+          "target": "小学生・中学生",
+          "recommendedAge": "小学3年生以上",
+          "frequency": "月2回または週1回",
+          "schedule": "土曜 14:00〜18:00"
+        },
+        {
+          "id": "practical-programming",
+          "icon": "code-xml",
+          "title": "実践プログラミング",
+          "target": "中学生以上・社会人",
+          "recommendedAge": "中学生以上",
+          "frequency": "週1回から相談",
+          "schedule": "木曜 18:00〜21:00"
+        },
+        {
+          "id": "pc-smartphone",
+          "icon": "monitor-smartphone",
+          "title": "パソコン / スマホ",
+          "target": "初心者・シニア・社会人",
+          "recommendedAge": "年齢不問",
+          "frequency": "単発または月2回から",
+          "schedule": "火曜 13:00〜17:00"
+        },
+        {
+          "id": "ged",
+          "icon": "file-badge",
+          "title": "高卒認定",
+          "target": "高卒認定を目指す方",
+          "recommendedAge": "高校生相当以上",
+          "frequency": "週1回から相談",
+          "schedule": "金曜 17:00〜20:00"
+        }
+      ],
+      "ctaBook": "予約へ進む",
+      "ctaPortal": "ポータルで確認する",
+      "guardianFaqTitle": "保護者向けFAQ",
+      "guardianFaqs": [
+        {
+          "question": "無料体験では何を確認できますか？",
+          "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+        },
+        {
+          "question": "予約後に日程変更できますか？",
+          "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+        },
+        {
+          "question": "本申込みの支払いはどうなりますか？",
+          "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+        },
+        {
+          "question": "外部カレンダーで予定を見られますか？",
+          "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+        }
+      ],
+      "bookingPage": {
+        "title": "Schools 予約",
+        "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+        "heroTitle": "Schools 予約",
+        "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+        "heroImgAlt": "ロボット工作と学習の準備風景",
+        "flowTrialTitle": "無料体験を予約",
+        "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+        "flowPaymentTitle": "本申込みはStripe決済",
+        "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+        "flowPortalTitle": "変更はポータルで管理",
+        "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+        "typeLabel": "予約種別",
+        "typeTrial": "無料体験",
+        "typeTrialBody": "初回相談・体験授業として予約します。",
+        "typeEnrollment": "本申込み",
+        "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+        "courseLabel": "コース",
+        "instructorLabel": "講師",
+        "slotLabel": "予約枠",
+        "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+        "guardianName": "保護者名",
+        "guardianEmail": "メールアドレス",
+        "guardianPhone": "電話番号",
+        "studentName": "受講者名",
+        "studentGrade": "学年・年齢",
+        "message": "相談したい内容",
+        "submit": "予約する",
+        "portalLink": "予約済みの方はこちら",
+        "sideTitle": "予約前に確認すること",
+        "sideItem1": "無料体験は費用なしで予約できます。",
+        "sideItem2": "本申込みはStripeの画面で決済します。",
+        "sideItem3": "変更・キャンセルはポータルから行います。",
+        "calendarPolicyTitle": "外部カレンダーについて",
+        "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+      },
+      "portalPage": {
+        "title": "Schools 会員ポータル",
+        "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+        "heroTitle": "会員ポータル",
+        "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+        "heroImgAlt": "予約管理画面を確認する作業風景",
+        "loginTitle": "メールでログイン",
+        "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+        "namePlaceholder": "お名前",
+        "emailPlaceholder": "メールアドレス",
+        "codePlaceholder": "6桁の認証コード",
+        "sendCode": "認証コードを送る",
+        "login": "ログイン",
+        "calendarTitle": "外部カレンダーは表示専用",
+        "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+        "dashboardEyebrow": "Dashboard",
+        "dashboardTitle": "予約一覧",
+        "refresh": "更新",
+        "billing": "請求を確認",
+        "empty": "ログインすると予約が表示されます。"
+      }
     },
     "about": {
       "title": "Sobre Nós",

--- a/src/i18n/translations/ru.json
+++ b/src/i18n/translations/ru.json
@@ -508,7 +508,149 @@
         "Спрашивайте преподавателей в любое время",
         "Естественная преемственность через практический опыт",
         "Напрямую связано с экзаменами, сертификатами и реальной работой"
-      ]
+      ],
+      "trialEyebrow": "Free Trial",
+      "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+      "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+      "trialCta": "無料体験を予約する",
+      "portalCta": "会員ポータルを開く",
+      "trialPoint1Title": "オンライン予約",
+      "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+      "trialPoint2Title": "本申込みも対応",
+      "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+      "trialPoint3Title": "変更はポータル",
+      "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+      "courseDetailEyebrow": "Course Guide",
+      "courseDetailTitle": "対象者・頻度・授業スケジュール",
+      "courseTargetLabel": "対象者",
+      "courseAgeLabel": "推奨年齢",
+      "courseFrequencyLabel": "授業頻度",
+      "courseScheduleLabel": "主な曜日・時間帯",
+      "courseDetails": [
+        {
+          "id": "juku",
+          "icon": "book-open",
+          "title": "学習塾",
+          "target": "小学生・中学生・高校生",
+          "recommendedAge": "小学4年生以上",
+          "frequency": "週1回から相談",
+          "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+        },
+        {
+          "id": "robot-programming",
+          "icon": "bot",
+          "title": "ロボット / プログラミング",
+          "target": "小学生・中学生",
+          "recommendedAge": "小学3年生以上",
+          "frequency": "月2回または週1回",
+          "schedule": "土曜 14:00〜18:00"
+        },
+        {
+          "id": "practical-programming",
+          "icon": "code-xml",
+          "title": "実践プログラミング",
+          "target": "中学生以上・社会人",
+          "recommendedAge": "中学生以上",
+          "frequency": "週1回から相談",
+          "schedule": "木曜 18:00〜21:00"
+        },
+        {
+          "id": "pc-smartphone",
+          "icon": "monitor-smartphone",
+          "title": "パソコン / スマホ",
+          "target": "初心者・シニア・社会人",
+          "recommendedAge": "年齢不問",
+          "frequency": "単発または月2回から",
+          "schedule": "火曜 13:00〜17:00"
+        },
+        {
+          "id": "ged",
+          "icon": "file-badge",
+          "title": "高卒認定",
+          "target": "高卒認定を目指す方",
+          "recommendedAge": "高校生相当以上",
+          "frequency": "週1回から相談",
+          "schedule": "金曜 17:00〜20:00"
+        }
+      ],
+      "ctaBook": "予約へ進む",
+      "ctaPortal": "ポータルで確認する",
+      "guardianFaqTitle": "保護者向けFAQ",
+      "guardianFaqs": [
+        {
+          "question": "無料体験では何を確認できますか？",
+          "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+        },
+        {
+          "question": "予約後に日程変更できますか？",
+          "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+        },
+        {
+          "question": "本申込みの支払いはどうなりますか？",
+          "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+        },
+        {
+          "question": "外部カレンダーで予定を見られますか？",
+          "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+        }
+      ],
+      "bookingPage": {
+        "title": "Schools 予約",
+        "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+        "heroTitle": "Schools 予約",
+        "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+        "heroImgAlt": "ロボット工作と学習の準備風景",
+        "flowTrialTitle": "無料体験を予約",
+        "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+        "flowPaymentTitle": "本申込みはStripe決済",
+        "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+        "flowPortalTitle": "変更はポータルで管理",
+        "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+        "typeLabel": "予約種別",
+        "typeTrial": "無料体験",
+        "typeTrialBody": "初回相談・体験授業として予約します。",
+        "typeEnrollment": "本申込み",
+        "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+        "courseLabel": "コース",
+        "instructorLabel": "講師",
+        "slotLabel": "予約枠",
+        "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+        "guardianName": "保護者名",
+        "guardianEmail": "メールアドレス",
+        "guardianPhone": "電話番号",
+        "studentName": "受講者名",
+        "studentGrade": "学年・年齢",
+        "message": "相談したい内容",
+        "submit": "予約する",
+        "portalLink": "予約済みの方はこちら",
+        "sideTitle": "予約前に確認すること",
+        "sideItem1": "無料体験は費用なしで予約できます。",
+        "sideItem2": "本申込みはStripeの画面で決済します。",
+        "sideItem3": "変更・キャンセルはポータルから行います。",
+        "calendarPolicyTitle": "外部カレンダーについて",
+        "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+      },
+      "portalPage": {
+        "title": "Schools 会員ポータル",
+        "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+        "heroTitle": "会員ポータル",
+        "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+        "heroImgAlt": "予約管理画面を確認する作業風景",
+        "loginTitle": "メールでログイン",
+        "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+        "namePlaceholder": "お名前",
+        "emailPlaceholder": "メールアドレス",
+        "codePlaceholder": "6桁の認証コード",
+        "sendCode": "認証コードを送る",
+        "login": "ログイン",
+        "calendarTitle": "外部カレンダーは表示専用",
+        "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+        "dashboardEyebrow": "Dashboard",
+        "dashboardTitle": "予約一覧",
+        "refresh": "更新",
+        "billing": "請求を確認",
+        "empty": "ログインすると予約が表示されます。"
+      }
     },
     "about": {
       "title": "О нас",

--- a/src/i18n/translations/zh-cn.json
+++ b/src/i18n/translations/zh-cn.json
@@ -508,7 +508,149 @@
         "随时可以向讲师提问",
         "通过体验自然地持续学习",
         "直接对接升学、资格考试和实务"
-      ]
+      ],
+      "trialEyebrow": "Free Trial",
+      "trialTitle": "まずは無料体験から、合う学び方を確認できます",
+      "trialBody": "コース、講師、空き枠を選んでそのまま予約できます。本申込みは月謝と初期費用をStripeで決済し、予約変更やキャンセルは会員ポータルから行えます。",
+      "trialCta": "無料体験を予約する",
+      "portalCta": "会員ポータルを開く",
+      "trialPoint1Title": "オンライン予約",
+      "trialPoint1Body": "講師ごとの空き枠から選択できます。",
+      "trialPoint2Title": "本申込みも対応",
+      "trialPoint2Body": "月謝と初期費用をStripeで受け付けます。",
+      "trialPoint3Title": "変更はポータル",
+      "trialPoint3Body": "外部カレンダー編集ではなく安全に管理します。",
+      "courseDetailEyebrow": "Course Guide",
+      "courseDetailTitle": "対象者・頻度・授業スケジュール",
+      "courseTargetLabel": "対象者",
+      "courseAgeLabel": "推奨年齢",
+      "courseFrequencyLabel": "授業頻度",
+      "courseScheduleLabel": "主な曜日・時間帯",
+      "courseDetails": [
+        {
+          "id": "juku",
+          "icon": "book-open",
+          "title": "学習塾",
+          "target": "小学生・中学生・高校生",
+          "recommendedAge": "小学4年生以上",
+          "frequency": "週1回から相談",
+          "schedule": "水曜 17:00〜20:00 / 土曜 10:00〜14:00"
+        },
+        {
+          "id": "robot-programming",
+          "icon": "bot",
+          "title": "ロボット / プログラミング",
+          "target": "小学生・中学生",
+          "recommendedAge": "小学3年生以上",
+          "frequency": "月2回または週1回",
+          "schedule": "土曜 14:00〜18:00"
+        },
+        {
+          "id": "practical-programming",
+          "icon": "code-xml",
+          "title": "実践プログラミング",
+          "target": "中学生以上・社会人",
+          "recommendedAge": "中学生以上",
+          "frequency": "週1回から相談",
+          "schedule": "木曜 18:00〜21:00"
+        },
+        {
+          "id": "pc-smartphone",
+          "icon": "monitor-smartphone",
+          "title": "パソコン / スマホ",
+          "target": "初心者・シニア・社会人",
+          "recommendedAge": "年齢不問",
+          "frequency": "単発または月2回から",
+          "schedule": "火曜 13:00〜17:00"
+        },
+        {
+          "id": "ged",
+          "icon": "file-badge",
+          "title": "高卒認定",
+          "target": "高卒認定を目指す方",
+          "recommendedAge": "高校生相当以上",
+          "frequency": "週1回から相談",
+          "schedule": "金曜 17:00〜20:00"
+        }
+      ],
+      "ctaBook": "予約へ進む",
+      "ctaPortal": "ポータルで確認する",
+      "guardianFaqTitle": "保護者向けFAQ",
+      "guardianFaqs": [
+        {
+          "question": "無料体験では何を確認できますか？",
+          "answer": "お子さまの興味、現在の理解度、通える頻度を確認し、合うコースや進め方を相談できます。"
+        },
+        {
+          "question": "予約後に日程変更できますか？",
+          "answer": "できます。会員ポータルにメール認証でログインし、空き枠から変更できます。外部カレンダーからの編集は受け付けません。"
+        },
+        {
+          "question": "本申込みの支払いはどうなりますか？",
+          "answer": "Stripeで月謝サブスクリプションと初期費用を受け付けます。請求状況はポータルから確認できます。"
+        },
+        {
+          "question": "外部カレンダーで予定を見られますか？",
+          "answer": "講師用の表示専用カレンダーを用意できます。予約の追加・変更・キャンセルはポータルから行います。"
+        }
+      ],
+      "bookingPage": {
+        "title": "Schools 予約",
+        "description": "Acecore Schoolsの無料体験予約と本申込みをオンラインで受け付けます。",
+        "heroTitle": "Schools 予約",
+        "heroSubtitle": "無料体験から本申込みまで、空き枠を選んで進められます",
+        "heroImgAlt": "ロボット工作と学習の準備風景",
+        "flowTrialTitle": "無料体験を予約",
+        "flowTrialBody": "まずは講師とコースの相性を確認できます。",
+        "flowPaymentTitle": "本申込みはStripe決済",
+        "flowPaymentBody": "月謝と初期費用を安全に受け付けます。",
+        "flowPortalTitle": "変更はポータルで管理",
+        "flowPortalBody": "日程変更やキャンセルは会員ポータルから行います。",
+        "typeLabel": "予約種別",
+        "typeTrial": "無料体験",
+        "typeTrialBody": "初回相談・体験授業として予約します。",
+        "typeEnrollment": "本申込み",
+        "typeEnrollmentBody": "予約後にStripe Checkoutへ進みます。",
+        "courseLabel": "コース",
+        "instructorLabel": "講師",
+        "slotLabel": "予約枠",
+        "slotNote": "空き枠は講師とコースの組み合わせで表示されます。",
+        "guardianName": "保護者名",
+        "guardianEmail": "メールアドレス",
+        "guardianPhone": "電話番号",
+        "studentName": "受講者名",
+        "studentGrade": "学年・年齢",
+        "message": "相談したい内容",
+        "submit": "予約する",
+        "portalLink": "予約済みの方はこちら",
+        "sideTitle": "予約前に確認すること",
+        "sideItem1": "無料体験は費用なしで予約できます。",
+        "sideItem2": "本申込みはStripeの画面で決済します。",
+        "sideItem3": "変更・キャンセルはポータルから行います。",
+        "calendarPolicyTitle": "外部カレンダーについて",
+        "calendarPolicyBody": "外部カレンダーは表示専用です。追加・編集・削除はポータルに限定します。"
+      },
+      "portalPage": {
+        "title": "Schools 会員ポータル",
+        "description": "Acecore Schoolsの予約、日程変更、キャンセル、支払い状況を確認できます。",
+        "heroTitle": "会員ポータル",
+        "heroSubtitle": "予約の確認・変更・キャンセルを安全に管理します",
+        "heroImgAlt": "予約管理画面を確認する作業風景",
+        "loginTitle": "メールでログイン",
+        "loginBody": "登録したメールアドレスに届く6桁の認証コードでログインします。",
+        "namePlaceholder": "お名前",
+        "emailPlaceholder": "メールアドレス",
+        "codePlaceholder": "6桁の認証コード",
+        "sendCode": "認証コードを送る",
+        "login": "ログイン",
+        "calendarTitle": "外部カレンダーは表示専用",
+        "calendarBody": "iPhone、Outlook、Google Calendarなどで確認する場合も、変更はポータルから行ってください。",
+        "dashboardEyebrow": "Dashboard",
+        "dashboardTitle": "予約一覧",
+        "refresh": "更新",
+        "billing": "請求を確認",
+        "empty": "ログインすると予約が表示されます。"
+      }
     },
     "about": {
       "title": "关于我们",

--- a/src/pages/[locale]/schools/book.astro
+++ b/src/pages/[locale]/schools/book.astro
@@ -1,0 +1,14 @@
+---
+import SchoolsBookingPage from '../../../views/SchoolsBookingPage.astro'
+import { locales, defaultLocale, type Locale } from '../../../i18n'
+
+export function getStaticPaths() {
+  return locales
+    .filter((l) => l !== defaultLocale)
+    .map((locale) => ({ params: { locale } }))
+}
+
+const locale = Astro.params.locale as Locale
+---
+
+<SchoolsBookingPage locale={locale} />

--- a/src/pages/[locale]/schools/portal.astro
+++ b/src/pages/[locale]/schools/portal.astro
@@ -1,0 +1,14 @@
+---
+import SchoolsPortalPage from '../../../views/SchoolsPortalPage.astro'
+import { locales, defaultLocale, type Locale } from '../../../i18n'
+
+export function getStaticPaths() {
+  return locales
+    .filter((l) => l !== defaultLocale)
+    .map((locale) => ({ params: { locale } }))
+}
+
+const locale = Astro.params.locale as Locale
+---
+
+<SchoolsPortalPage locale={locale} />

--- a/src/pages/schools/book.astro
+++ b/src/pages/schools/book.astro
@@ -1,0 +1,5 @@
+---
+import SchoolsBookingPage from '../../views/SchoolsBookingPage.astro'
+---
+
+<SchoolsBookingPage locale="ja" />

--- a/src/pages/schools/portal.astro
+++ b/src/pages/schools/portal.astro
@@ -1,0 +1,5 @@
+---
+import SchoolsPortalPage from '../../views/SchoolsPortalPage.astro'
+---
+
+<SchoolsPortalPage locale="ja" />

--- a/src/views/SchoolsBookingPage.astro
+++ b/src/views/SchoolsBookingPage.astro
@@ -1,0 +1,422 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro'
+import Hero from '../components/Hero.astro'
+import Breadcrumb from '../components/Breadcrumb.astro'
+import Icon from '../components/Icon.astro'
+import { optimizeImage } from '../utils/image'
+import { t, getLocalizedUrl, type Locale } from '../i18n'
+
+interface Props {
+  locale: Locale
+}
+
+const { locale } = Astro.props
+const u = (path: string) => getLocalizedUrl(path, locale)
+const bookingLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: `${t(locale, 'pages.schools.bookingPage.title')} | Acecore`,
+  description: t(locale, 'pages.schools.bookingPage.description'),
+  url: `https://acecore.net${u('/schools/book/')}`,
+}
+---
+
+<BaseLayout
+  title={t(locale, 'pages.schools.bookingPage.title')}
+  description={t(locale, 'pages.schools.bookingPage.description')}
+  jsonLd={bookingLd}
+  locale={locale}
+>
+  <Hero
+    title={t(locale, 'pages.schools.bookingPage.heroTitle')}
+    subtitle={t(locale, 'pages.schools.bookingPage.heroSubtitle')}
+    images={[
+      {
+        src: optimizeImage(
+          'https://images.unsplash.com/photo-1581092921461-eab62e97a780?w=1400&h=600&fit=crop&q=80&fm=webp',
+        ),
+        alt: t(locale, 'pages.schools.bookingPage.heroImgAlt'),
+      },
+    ]}
+  />
+
+  <section class="ac-section">
+    <div class="ac-container max-w-5xl">
+      <Breadcrumb
+        items={[
+          { label: t(locale, 'pages.schools.title'), href: u('/schools/') },
+          { label: t(locale, 'pages.schools.bookingPage.title') },
+        ]}
+        locale={locale}
+      />
+
+      <div class="mb-8 grid gap-4 md:grid-cols-3">
+        <div class="rounded-lg border border-brand-100 bg-brand-50 p-5">
+          <Icon name="calendar-check" class="mb-3 text-2xl text-brand-600" />
+          <h2 class="mb-2 text-base ac-heading">
+            {t(locale, 'pages.schools.bookingPage.flowTrialTitle')}
+          </h2>
+          <p class="m-0 text-sm leading-relaxed text-slate-600">
+            {t(locale, 'pages.schools.bookingPage.flowTrialBody')}
+          </p>
+        </div>
+        <div class="rounded-lg border border-emerald-100 bg-emerald-50 p-5">
+          <Icon name="credit-card" class="mb-3 text-2xl text-emerald-600" />
+          <h2 class="mb-2 text-base ac-heading">
+            {t(locale, 'pages.schools.bookingPage.flowPaymentTitle')}
+          </h2>
+          <p class="m-0 text-sm leading-relaxed text-slate-600">
+            {t(locale, 'pages.schools.bookingPage.flowPaymentBody')}
+          </p>
+        </div>
+        <div class="rounded-lg border border-slate-200 bg-white p-5">
+          <Icon name="shield-check" class="mb-3 text-2xl text-slate-600" />
+          <h2 class="mb-2 text-base ac-heading">
+            {t(locale, 'pages.schools.bookingPage.flowPortalTitle')}
+          </h2>
+          <p class="m-0 text-sm leading-relaxed text-slate-600">
+            {t(locale, 'pages.schools.bookingPage.flowPortalBody')}
+          </p>
+        </div>
+      </div>
+
+      <div class="grid gap-8 lg:grid-cols-[1fr_20rem]">
+        <form
+          id="schools-booking-form"
+          class="ac-surface space-y-6 p-6"
+          data-locale={locale}
+          data-success-url={u('/schools/portal/')}
+        >
+          <div>
+            <p class="mb-3 text-sm font-700 text-slate-900">
+              {t(locale, 'pages.schools.bookingPage.typeLabel')}
+            </p>
+            <div class="grid gap-3 sm:grid-cols-2">
+              <label
+                class="flex cursor-pointer gap-3 rounded-lg border border-brand-200 bg-brand-50 p-4"
+              >
+                <input
+                  type="radio"
+                  name="bookingType"
+                  value="trial"
+                  checked
+                  class="mt-1"
+                />
+                <span>
+                  <span class="block font-800 text-slate-900">
+                    {t(locale, 'pages.schools.bookingPage.typeTrial')}
+                  </span>
+                  <span class="mt-1 block text-sm text-slate-600">
+                    {t(locale, 'pages.schools.bookingPage.typeTrialBody')}
+                  </span>
+                </span>
+              </label>
+              <label
+                class="flex cursor-pointer gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-4"
+              >
+                <input
+                  type="radio"
+                  name="bookingType"
+                  value="enrollment"
+                  class="mt-1"
+                />
+                <span>
+                  <span class="block font-800 text-slate-900">
+                    {t(locale, 'pages.schools.bookingPage.typeEnrollment')}
+                  </span>
+                  <span class="mt-1 block text-sm text-slate-600">
+                    {t(locale, 'pages.schools.bookingPage.typeEnrollmentBody')}
+                  </span>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div class="grid gap-5 md:grid-cols-2">
+            <label class="block">
+              <span class="mb-2 block text-sm font-700 text-slate-700">
+                {t(locale, 'pages.schools.bookingPage.courseLabel')}
+              </span>
+              <select
+                id="booking-course"
+                name="courseId"
+                class="ac-input"
+                required></select>
+            </label>
+            <label class="block">
+              <span class="mb-2 block text-sm font-700 text-slate-700">
+                {t(locale, 'pages.schools.bookingPage.instructorLabel')}
+              </span>
+              <select
+                id="booking-instructor"
+                name="instructorId"
+                class="ac-input"
+                required></select>
+            </label>
+          </div>
+
+          <label class="block">
+            <span class="mb-2 block text-sm font-700 text-slate-700">
+              {t(locale, 'pages.schools.bookingPage.slotLabel')}
+            </span>
+            <select id="booking-slot" name="slot" class="ac-input" required
+            ></select>
+            <span
+              id="booking-slot-note"
+              class="mt-2 block text-xs text-slate-500"
+            >
+              {t(locale, 'pages.schools.bookingPage.slotNote')}
+            </span>
+          </label>
+
+          <div class="grid gap-5 md:grid-cols-2">
+            <label class="block">
+              <span class="mb-2 block text-sm font-700 text-slate-700">
+                {t(locale, 'pages.schools.bookingPage.guardianName')}
+              </span>
+              <input
+                name="guardianName"
+                required
+                class="ac-input"
+                autocomplete="name"
+              />
+            </label>
+            <label class="block">
+              <span class="mb-2 block text-sm font-700 text-slate-700">
+                {t(locale, 'pages.schools.bookingPage.guardianEmail')}
+              </span>
+              <input
+                name="guardianEmail"
+                type="email"
+                required
+                class="ac-input"
+                autocomplete="email"
+              />
+            </label>
+            <label class="block">
+              <span class="mb-2 block text-sm font-700 text-slate-700">
+                {t(locale, 'pages.schools.bookingPage.guardianPhone')}
+              </span>
+              <input name="guardianPhone" class="ac-input" autocomplete="tel" />
+            </label>
+            <label class="block">
+              <span class="mb-2 block text-sm font-700 text-slate-700">
+                {t(locale, 'pages.schools.bookingPage.studentName')}
+              </span>
+              <input name="studentName" required class="ac-input" />
+            </label>
+            <label class="block md:col-span-2">
+              <span class="mb-2 block text-sm font-700 text-slate-700">
+                {t(locale, 'pages.schools.bookingPage.studentGrade')}
+              </span>
+              <input name="studentGrade" class="ac-input" />
+            </label>
+          </div>
+
+          <label class="block">
+            <span class="mb-2 block text-sm font-700 text-slate-700">
+              {t(locale, 'pages.schools.bookingPage.message')}
+            </span>
+            <textarea name="message" rows="4" class="ac-input resize-y"
+            ></textarea>
+          </label>
+
+          <div
+            id="booking-feedback"
+            class="hidden rounded-lg border p-4 text-sm"
+            role="alert"
+            aria-live="polite"
+          >
+          </div>
+
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <button id="booking-submit" type="submit" class="ac-btn-primary">
+              <Icon name="calendar-check" class="text-base" />
+              {t(locale, 'pages.schools.bookingPage.submit')}
+            </button>
+            <a href={u('/schools/portal/')} class="ac-btn-outline">
+              {t(locale, 'pages.schools.bookingPage.portalLink')}
+            </a>
+          </div>
+        </form>
+
+        <aside class="space-y-4">
+          <div class="ac-surface p-5">
+            <h2 class="mb-3 text-lg ac-heading">
+              {t(locale, 'pages.schools.bookingPage.sideTitle')}
+            </h2>
+            <ul class="m-0 list-none space-y-3 p-0 text-sm text-slate-600">
+              <li class="flex gap-2">
+                <Icon name="check" class="mt-0.5 shrink-0 text-brand-500" />
+                <span>{t(locale, 'pages.schools.bookingPage.sideItem1')}</span>
+              </li>
+              <li class="flex gap-2">
+                <Icon name="check" class="mt-0.5 shrink-0 text-brand-500" />
+                <span>{t(locale, 'pages.schools.bookingPage.sideItem2')}</span>
+              </li>
+              <li class="flex gap-2">
+                <Icon name="check" class="mt-0.5 shrink-0 text-brand-500" />
+                <span>{t(locale, 'pages.schools.bookingPage.sideItem3')}</span>
+              </li>
+            </ul>
+          </div>
+          <div class="rounded-lg border border-slate-200 bg-slate-50 p-5">
+            <p class="mb-2 text-sm font-800 text-slate-900">
+              {t(locale, 'pages.schools.bookingPage.calendarPolicyTitle')}
+            </p>
+            <p class="m-0 text-sm leading-relaxed text-slate-600">
+              {t(locale, 'pages.schools.bookingPage.calendarPolicyBody')}
+            </p>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </section>
+
+  <script is:inline>
+    ;(() => {
+      const form = document.getElementById('schools-booking-form')
+      if (!form) return
+
+      const courseSelect = document.getElementById('booking-course')
+      const instructorSelect = document.getElementById('booking-instructor')
+      const slotSelect = document.getElementById('booking-slot')
+      const submitButton = document.getElementById('booking-submit')
+      const feedback = document.getElementById('booking-feedback')
+      let availability = { courses: [], instructors: [], slots: [] }
+
+      function setFeedback(type, text) {
+        if (!feedback) return
+        feedback.textContent = text
+        feedback.className =
+          type === 'success'
+            ? 'rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-800'
+            : 'rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800'
+      }
+
+      function formatSlot(slot) {
+        const start = new Date(slot.startAt)
+        return start.toLocaleString('ja-JP', {
+          timeZone: 'Asia/Tokyo',
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        })
+      }
+
+      function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, (char) => {
+          return {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+          }[char]
+        })
+      }
+
+      function renderOptions() {
+        courseSelect.innerHTML = availability.courses
+          .map(
+            (course) =>
+              `<option value="${escapeHtml(course.id)}">${escapeHtml(course.title)} - ${escapeHtml(course.frequency)}</option>`,
+          )
+          .join('')
+
+        instructorSelect.innerHTML = availability.instructors
+          .map(
+            (instructor) =>
+              `<option value="${escapeHtml(instructor.id)}">${escapeHtml(instructor.name)}</option>`,
+          )
+          .join('')
+        renderSlots()
+      }
+
+      function renderSlots() {
+        const courseId = courseSelect.value
+        const instructorId = instructorSelect.value
+        const slots = availability.slots.filter(
+          (slot) =>
+            slot.courseId === courseId && slot.instructorId === instructorId,
+        )
+        slotSelect.innerHTML =
+          slots.length > 0
+            ? slots
+                .map(
+                  (slot) =>
+                    `<option value="${escapeHtml(`${slot.startAt}|${slot.endAt}`)}">${escapeHtml(formatSlot(slot))}</option>`,
+                )
+                .join('')
+            : '<option value="">受付可能な枠がありません</option>'
+      }
+
+      async function loadAvailability() {
+        const response = await fetch('/api/schools/availability')
+        const result = await response.json()
+        if (!response.ok || !result.ok) {
+          throw new Error(result.message || '予約枠を読み込めませんでした。')
+        }
+        availability = result
+        renderOptions()
+      }
+
+      courseSelect.addEventListener('change', renderSlots)
+      instructorSelect.addEventListener('change', renderSlots)
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault()
+        const data = new FormData(form)
+        const slot = String(data.get('slot') || '').split('|')
+        if (slot.length !== 2 || !slot[0]) {
+          setFeedback('error', '予約枠を選択してください。')
+          return
+        }
+        submitButton.disabled = true
+        const originalText = submitButton.textContent
+        submitButton.textContent = '送信中...'
+
+        try {
+          const response = await fetch('/api/schools/bookings', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              bookingType: data.get('bookingType'),
+              courseId: data.get('courseId'),
+              instructorId: data.get('instructorId'),
+              startAt: slot[0],
+              endAt: slot[1],
+              guardianName: data.get('guardianName'),
+              guardianEmail: data.get('guardianEmail'),
+              guardianPhone: data.get('guardianPhone'),
+              studentName: data.get('studentName'),
+              studentGrade: data.get('studentGrade'),
+              message: data.get('message'),
+              locale: form.dataset.locale || 'ja',
+            }),
+          })
+          const result = await response.json()
+          if (!response.ok || !result.ok) {
+            throw new Error(result.message || '予約を作成できませんでした。')
+          }
+          if (result.checkoutUrl) {
+            window.location.assign(result.checkoutUrl)
+            return
+          }
+          setFeedback(
+            'success',
+            '無料体験予約を受け付けました。ポータルから変更・キャンセルできます。',
+          )
+          form.reset()
+          await loadAvailability()
+        } catch (error) {
+          setFeedback('error', error.message || '予約を作成できませんでした。')
+        } finally {
+          submitButton.disabled = false
+          submitButton.textContent = originalText
+        }
+      })
+
+      loadAvailability().catch((error) => setFeedback('error', error.message))
+    })()
+  </script>
+</BaseLayout>

--- a/src/views/SchoolsPage.astro
+++ b/src/views/SchoolsPage.astro
@@ -36,6 +36,21 @@ interface RobotProgrammingCourse {
   description: string
 }
 
+interface SchoolCourseDetail {
+  id: string
+  icon: string
+  title: string
+  target: string
+  recommendedAge: string
+  frequency: string
+  schedule: string
+}
+
+interface GuardianFaq {
+  question: string
+  answer: string
+}
+
 const getList = <T,>(key: string): T[] =>
   getTranslationValue<T[]>(locale, key) ?? []
 
@@ -65,6 +80,10 @@ const gedSupports = getList<string>('pages.schools.ged.supports')
 const schoolPricingItems = getList<SchoolPricingItem>(
   'pages.schools.pricing.items',
 )
+const courseDetails = getList<SchoolCourseDetail>('pages.schools.courseDetails')
+const guardianFaqs = getList<GuardianFaq>('pages.schools.guardianFaqs')
+const bookingUrl = u('/schools/book/')
+const portalUrl = u('/schools/portal/')
 
 const schoolsLd = {
   '@context': 'https://schema.org',
@@ -146,6 +165,70 @@ const schoolsLd = {
         items={[{ label: t(locale, 'pages.schools.title') }]}
         locale={locale}
       />
+
+      <section
+        class="mb-12 rounded-lg border border-brand-100 bg-brand-50 p-6 sm:p-8"
+        aria-labelledby="schools-trial-heading"
+      >
+        <div class="grid gap-6 md:grid-cols-[1fr_auto] md:items-center">
+          <div>
+            <p
+              class="mb-2 text-sm font-800 uppercase tracking-wide text-brand-600"
+            >
+              {t(locale, 'pages.schools.trialEyebrow')}
+            </p>
+            <h2 id="schools-trial-heading" class="mb-3 text-2xl ac-heading">
+              {t(locale, 'pages.schools.trialTitle')}
+            </h2>
+            <p class="m-0 leading-relaxed text-slate-600">
+              {t(locale, 'pages.schools.trialBody')}
+            </p>
+          </div>
+          <div class="flex flex-col gap-3">
+            <a
+              href={bookingUrl}
+              class="ac-btn-primary"
+              data-ga-event="schools_booking_click"
+              data-ga-label="free_trial"
+              data-ga-location="schools_first_view"
+            >
+              <Icon name="calendar-check" class="text-base" />
+              {t(locale, 'pages.schools.trialCta')}
+            </a>
+            <a href={portalUrl} class="ac-btn-outline">
+              <Icon name="user-check" class="text-base" />
+              {t(locale, 'pages.schools.portalCta')}
+            </a>
+          </div>
+        </div>
+        <div class="mt-6 grid gap-3 sm:grid-cols-3">
+          <div class="rounded-lg bg-white p-4">
+            <p class="mb-1 text-sm font-800 text-slate-900">
+              {t(locale, 'pages.schools.trialPoint1Title')}
+            </p>
+            <p class="m-0 text-sm text-slate-600">
+              {t(locale, 'pages.schools.trialPoint1Body')}
+            </p>
+          </div>
+          <div class="rounded-lg bg-white p-4">
+            <p class="mb-1 text-sm font-800 text-slate-900">
+              {t(locale, 'pages.schools.trialPoint2Title')}
+            </p>
+            <p class="m-0 text-sm text-slate-600">
+              {t(locale, 'pages.schools.trialPoint2Body')}
+            </p>
+          </div>
+          <div class="rounded-lg bg-white p-4">
+            <p class="mb-1 text-sm font-800 text-slate-900">
+              {t(locale, 'pages.schools.trialPoint3Title')}
+            </p>
+            <p class="m-0 text-sm text-slate-600">
+              {t(locale, 'pages.schools.trialPoint3Body')}
+            </p>
+          </div>
+        </div>
+      </section>
+
       <div class="mb-12">
         <ProcessFigure
           variant="card"
@@ -159,6 +242,59 @@ const schoolsLd = {
       <p class="text-lg text-slate-600 leading-relaxed mb-12">
         {t(locale, 'pages.schools.intro')}
       </p>
+
+      <section class="mb-16" aria-labelledby="schools-course-detail-heading">
+        <div class="mb-6">
+          <p
+            class="mb-2 text-sm font-800 uppercase tracking-wide text-brand-600"
+          >
+            {t(locale, 'pages.schools.courseDetailEyebrow')}
+          </p>
+          <h2 id="schools-course-detail-heading" class="text-2xl ac-heading">
+            {t(locale, 'pages.schools.courseDetailTitle')}
+          </h2>
+        </div>
+        <div class="grid gap-4 md:grid-cols-2">
+          {
+            courseDetails.map((course) => (
+              <article class="ac-surface p-5" id={`course-${course.id}`}>
+                <div class="mb-3 flex items-center gap-3">
+                  <span class="ac-icon-box">
+                    <Icon name={course.icon} class="text-lg" />
+                  </span>
+                  <h3 class="text-lg ac-heading">{course.title}</h3>
+                </div>
+                <dl class="m-0 grid gap-3 text-sm">
+                  <div>
+                    <dt class="font-800 text-slate-900">
+                      {t(locale, 'pages.schools.courseTargetLabel')}
+                    </dt>
+                    <dd class="m-0 text-slate-600">{course.target}</dd>
+                  </div>
+                  <div>
+                    <dt class="font-800 text-slate-900">
+                      {t(locale, 'pages.schools.courseAgeLabel')}
+                    </dt>
+                    <dd class="m-0 text-slate-600">{course.recommendedAge}</dd>
+                  </div>
+                  <div>
+                    <dt class="font-800 text-slate-900">
+                      {t(locale, 'pages.schools.courseFrequencyLabel')}
+                    </dt>
+                    <dd class="m-0 text-slate-600">{course.frequency}</dd>
+                  </div>
+                  <div>
+                    <dt class="font-800 text-slate-900">
+                      {t(locale, 'pages.schools.courseScheduleLabel')}
+                    </dt>
+                    <dd class="m-0 text-slate-600">{course.schedule}</dd>
+                  </div>
+                </dl>
+              </article>
+            ))
+          }
+        </div>
+      </section>
 
       <!-- Juku -->
       <div class="mb-16" id="juku">
@@ -410,6 +546,33 @@ const schoolsLd = {
         </div>
       </div>
 
+      <section class="mb-16" aria-labelledby="schools-faq-heading">
+        <div class="mb-6">
+          <p
+            class="mb-2 text-sm font-800 uppercase tracking-wide text-brand-600"
+          >
+            FAQ
+          </p>
+          <h2 id="schools-faq-heading" class="text-2xl ac-heading">
+            {t(locale, 'pages.schools.guardianFaqTitle')}
+          </h2>
+        </div>
+        <div class="space-y-3">
+          {
+            guardianFaqs.map((faq) => (
+              <details class="rounded-lg border border-slate-200 bg-white p-5">
+                <summary class="cursor-pointer font-800 text-slate-900">
+                  {faq.question}
+                </summary>
+                <p class="mt-3 text-sm leading-relaxed text-slate-600">
+                  {faq.answer}
+                </p>
+              </details>
+            ))
+          }
+        </div>
+      </section>
+
       <!-- CTA -->
       <div class="ac-surface bg-brand-50 p-8 text-center">
         <h2 class="text-xl ac-heading mb-4">
@@ -421,8 +584,11 @@ const schoolsLd = {
         <div
           class="flex flex-col sm:flex-row items-center justify-center gap-4"
         >
-          <a href={u('/contact/')} class="ac-btn-primary"
-            >{t(locale, 'pages.schools.ctaForm')}</a
+          <a href={bookingUrl} class="ac-btn-primary"
+            >{t(locale, 'pages.schools.ctaBook')}</a
+          >
+          <a href={portalUrl} class="ac-btn-outline"
+            >{t(locale, 'pages.schools.ctaPortal')}</a
           >
           <a
             href={SITE.line}

--- a/src/views/SchoolsPortalPage.astro
+++ b/src/views/SchoolsPortalPage.astro
@@ -1,0 +1,387 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro'
+import Hero from '../components/Hero.astro'
+import Breadcrumb from '../components/Breadcrumb.astro'
+import Icon from '../components/Icon.astro'
+import { optimizeImage } from '../utils/image'
+import { t, getLocalizedUrl, type Locale } from '../i18n'
+
+interface Props {
+  locale: Locale
+}
+
+const { locale } = Astro.props
+const u = (path: string) => getLocalizedUrl(path, locale)
+---
+
+<BaseLayout
+  title={t(locale, 'pages.schools.portalPage.title')}
+  description={t(locale, 'pages.schools.portalPage.description')}
+  locale={locale}
+>
+  <Hero
+    title={t(locale, 'pages.schools.portalPage.heroTitle')}
+    subtitle={t(locale, 'pages.schools.portalPage.heroSubtitle')}
+    images={[
+      {
+        src: optimizeImage(
+          'https://images.unsplash.com/photo-1551836022-d5d88e9218df?w=1400&h=600&fit=crop&q=80&fm=webp',
+        ),
+        alt: t(locale, 'pages.schools.portalPage.heroImgAlt'),
+      },
+    ]}
+  />
+
+  <section class="ac-section">
+    <div class="ac-container max-w-5xl">
+      <Breadcrumb
+        items={[
+          { label: t(locale, 'pages.schools.title'), href: u('/schools/') },
+          { label: t(locale, 'pages.schools.portalPage.title') },
+        ]}
+        locale={locale}
+      />
+
+      <div class="grid gap-8 lg:grid-cols-[24rem_1fr]">
+        <aside class="space-y-4">
+          <section
+            class="ac-surface p-5"
+            aria-labelledby="portal-login-heading"
+          >
+            <h2 id="portal-login-heading" class="mb-3 text-lg ac-heading">
+              {t(locale, 'pages.schools.portalPage.loginTitle')}
+            </h2>
+            <p class="mb-4 text-sm leading-relaxed text-slate-600">
+              {t(locale, 'pages.schools.portalPage.loginBody')}
+            </p>
+            <form id="portal-otp-form" class="space-y-3">
+              <input
+                name="name"
+                class="ac-input"
+                placeholder={t(
+                  locale,
+                  'pages.schools.portalPage.namePlaceholder',
+                )}
+                autocomplete="name"
+              />
+              <input
+                name="email"
+                type="email"
+                required
+                class="ac-input"
+                placeholder={t(
+                  locale,
+                  'pages.schools.portalPage.emailPlaceholder',
+                )}
+                autocomplete="email"
+              />
+              <button type="submit" class="ac-btn-primary w-full">
+                <Icon name="mail" class="text-base" />
+                {t(locale, 'pages.schools.portalPage.sendCode')}
+              </button>
+            </form>
+            <form id="portal-session-form" class="mt-4 hidden space-y-3">
+              <input
+                name="email"
+                type="email"
+                required
+                class="ac-input"
+                placeholder={t(
+                  locale,
+                  'pages.schools.portalPage.emailPlaceholder',
+                )}
+                autocomplete="email"
+              />
+              <input
+                name="code"
+                required
+                inputmode="numeric"
+                pattern="[0-9]{6}"
+                class="ac-input"
+                placeholder={t(
+                  locale,
+                  'pages.schools.portalPage.codePlaceholder',
+                )}
+              />
+              <button type="submit" class="ac-btn-secondary w-full">
+                {t(locale, 'pages.schools.portalPage.login')}
+              </button>
+            </form>
+            <div
+              id="portal-feedback"
+              class="mt-4 hidden rounded-lg border p-3 text-sm"
+              role="alert"
+              aria-live="polite"
+            >
+            </div>
+          </section>
+
+          <section class="rounded-lg border border-slate-200 bg-slate-50 p-5">
+            <h2 class="mb-2 text-base ac-heading">
+              {t(locale, 'pages.schools.portalPage.calendarTitle')}
+            </h2>
+            <p class="m-0 text-sm leading-relaxed text-slate-600">
+              {t(locale, 'pages.schools.portalPage.calendarBody')}
+            </p>
+          </section>
+        </aside>
+
+        <section class="ac-surface min-h-120 p-6" aria-live="polite">
+          <div
+            class="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div>
+              <p
+                class="mb-1 text-sm font-700 uppercase tracking-wide text-brand-600"
+              >
+                {t(locale, 'pages.schools.portalPage.dashboardEyebrow')}
+              </p>
+              <h2 class="text-2xl ac-heading">
+                {t(locale, 'pages.schools.portalPage.dashboardTitle')}
+              </h2>
+            </div>
+            <div class="flex flex-col gap-2 sm:flex-row">
+              <button id="portal-refresh" type="button" class="ac-btn-outline">
+                <Icon name="refresh-cw" class="text-base" />
+                {t(locale, 'pages.schools.portalPage.refresh')}
+              </button>
+              <button id="stripe-portal" type="button" class="ac-btn-outline">
+                <Icon name="credit-card" class="text-base" />
+                {t(locale, 'pages.schools.portalPage.billing')}
+              </button>
+            </div>
+          </div>
+
+          <div id="portal-empty" class="rounded-lg bg-slate-50 p-8 text-center">
+            <Icon
+              name="user-check"
+              class="mx-auto mb-3 text-3xl text-slate-500"
+            />
+            <p class="m-0 text-slate-600">
+              {t(locale, 'pages.schools.portalPage.empty')}
+            </p>
+          </div>
+
+          <div id="portal-bookings" class="hidden space-y-4"></div>
+        </section>
+      </div>
+    </div>
+  </section>
+
+  <script is:inline>
+    ;(() => {
+      const tokenKey = 'acecore-schools-portal-token'
+      const otpForm = document.getElementById('portal-otp-form')
+      const sessionForm = document.getElementById('portal-session-form')
+      const feedback = document.getElementById('portal-feedback')
+      const empty = document.getElementById('portal-empty')
+      const list = document.getElementById('portal-bookings')
+      const refresh = document.getElementById('portal-refresh')
+      const stripePortal = document.getElementById('stripe-portal')
+      let availability = null
+
+      function token() {
+        return localStorage.getItem(tokenKey) || ''
+      }
+
+      function setFeedback(type, text) {
+        if (!feedback) return
+        feedback.textContent = text
+        feedback.className =
+          type === 'success'
+            ? 'mt-4 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800'
+            : 'mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800'
+      }
+
+      function formatDate(value) {
+        return new Date(value).toLocaleString('ja-JP', {
+          timeZone: 'Asia/Tokyo',
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        })
+      }
+
+      function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, (char) => {
+          return {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+          }[char]
+        })
+      }
+
+      async function loadAvailability() {
+        if (availability) return availability
+        const response = await fetch('/api/schools/availability')
+        const result = await response.json()
+        if (!response.ok || !result.ok) throw new Error(result.message)
+        availability = result
+        return result
+      }
+
+      function slotOptions(booking) {
+        if (!availability) return ''
+        return availability.slots
+          .filter(
+            (slot) =>
+              slot.courseId === booking.courseId &&
+              slot.instructorId === booking.instructorId,
+          )
+          .map(
+            (slot) =>
+              `<option value="${escapeHtml(`${slot.startAt}|${slot.endAt}`)}">${escapeHtml(formatDate(slot.startAt))}</option>`,
+          )
+          .join('')
+      }
+
+      function renderBookings(bookings) {
+        if (!bookings.length) {
+          empty.classList.remove('hidden')
+          list.classList.add('hidden')
+          list.innerHTML = ''
+          return
+        }
+        empty.classList.add('hidden')
+        list.classList.remove('hidden')
+        list.innerHTML = bookings
+          .map(
+            (
+              booking,
+            ) => `<article class="rounded-lg border border-slate-200 bg-white p-5" data-booking-id="${escapeHtml(booking.id)}">
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p class="mb-1 text-xs font-800 uppercase tracking-wide text-brand-600">${booking.bookingType === 'enrollment' ? '本申込み' : '無料体験'}</p>
+                  <h3 class="text-lg ac-heading">${escapeHtml(booking.courseTitle || booking.courseId)}</h3>
+                  <p class="mt-1 text-sm text-slate-600">${escapeHtml(booking.studentName)} / ${escapeHtml(booking.instructorName || booking.instructorId)}</p>
+                </div>
+                <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-800 text-slate-700">${escapeHtml(booking.status)}</span>
+              </div>
+              <p class="mt-4 text-sm font-700 text-slate-900">${escapeHtml(formatDate(booking.startAt))}</p>
+              <div class="mt-4 grid gap-3 sm:grid-cols-[1fr_auto_auto]">
+                <select class="ac-input" data-reschedule-slot>
+                  ${slotOptions(booking) || '<option value="">変更可能な枠がありません</option>'}
+                </select>
+                <button type="button" class="ac-btn-outline" data-reschedule>日程変更</button>
+                <button type="button" class="inline-flex min-h-10 items-center justify-center rounded-lg border border-red-200 bg-white px-4 py-2.5 text-sm font-800 text-red-700 no-underline hover:bg-red-50" data-cancel>キャンセル</button>
+              </div>
+            </article>`,
+          )
+          .join('')
+      }
+
+      async function loadPortal() {
+        if (!token()) return
+        await loadAvailability()
+        const response = await fetch('/api/schools/portal/session', {
+          headers: { Authorization: `Bearer ${token()}` },
+        })
+        const result = await response.json()
+        if (!response.ok || !result.ok) throw new Error(result.message)
+        renderBookings(result.bookings || [])
+      }
+
+      otpForm.addEventListener('submit', async (event) => {
+        event.preventDefault()
+        const data = new FormData(otpForm)
+        const response = await fetch('/api/schools/portal/otp', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: data.get('name'),
+            email: data.get('email'),
+          }),
+        })
+        const result = await response.json()
+        if (!response.ok || !result.ok) {
+          setFeedback('error', result.message || '認証コードを送信できません。')
+          return
+        }
+        sessionForm.classList.remove('hidden')
+        const sessionEmail = sessionForm.querySelector('input[name="email"]')
+        if (sessionEmail) sessionEmail.value = data.get('email') || ''
+        setFeedback('success', result.message || '認証コードを送信しました。')
+      })
+
+      sessionForm.addEventListener('submit', async (event) => {
+        event.preventDefault()
+        const data = new FormData(sessionForm)
+        const response = await fetch('/api/schools/portal/session', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: data.get('email'),
+            code: data.get('code'),
+          }),
+        })
+        const result = await response.json()
+        if (!response.ok || !result.ok) {
+          setFeedback('error', result.message || 'ログインできません。')
+          return
+        }
+        localStorage.setItem(tokenKey, result.token)
+        setFeedback('success', 'ログインしました。')
+        await loadPortal()
+      })
+
+      list.addEventListener('click', async (event) => {
+        const target = event.target instanceof Element ? event.target : null
+        const button = target?.closest('button')
+        const card = target?.closest('[data-booking-id]')
+        if (!button || !card) return
+        const id = card.dataset.bookingId
+        let payload
+        if (button.hasAttribute('data-cancel')) {
+          payload = { action: 'cancel', reason: 'portal' }
+        } else if (button.hasAttribute('data-reschedule')) {
+          const slotSelect = card.querySelector('[data-reschedule-slot]')
+          const value = slotSelect ? slotSelect.value : ''
+          const parts = value.split('|')
+          if (parts.length !== 2 || !parts[0]) return
+          payload = { action: 'reschedule', startAt: parts[0], endAt: parts[1] }
+        } else {
+          return
+        }
+
+        const response = await fetch(`/api/schools/bookings/${id}`, {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token()}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+        const result = await response.json()
+        if (!response.ok || !result.ok) {
+          setFeedback('error', result.message || '更新できませんでした。')
+          return
+        }
+        setFeedback('success', '予約を更新しました。')
+        availability = null
+        await loadPortal()
+      })
+
+      refresh.addEventListener('click', async () => {
+        availability = null
+        await loadPortal().catch((error) => setFeedback('error', error.message))
+      })
+
+      stripePortal.addEventListener('click', async () => {
+        const response = await fetch('/api/schools/portal/stripe', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token()}` },
+        })
+        const result = await response.json()
+        if (!response.ok || !result.ok) {
+          setFeedback('error', result.message || '請求ポータルを開けません。')
+          return
+        }
+        window.location.assign(result.url)
+      })
+
+      loadPortal().catch(() => {})
+    })()
+  </script>
+</BaseLayout>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,9 @@
   "vars": {
     "OPENAI_MODEL": "gpt-5.4-mini",
     "COMMENT_ALLOWED_HOSTNAMES": "acecore.net,www.acecore.net,acecore-net.pages.dev,localhost,127.0.0.1",
+    "SCHOOLS_SITE_URL": "https://acecore.net",
+    "SCHOOLS_ALLOWED_HOSTNAMES": "acecore.net,www.acecore.net,acecore-net.pages.dev,localhost,127.0.0.1",
+    "SCHOOLS_EMAIL_FROM": "Acecore Schools <noreply@acecore.net>",
   },
   "d1_databases": [
     {
@@ -20,6 +23,9 @@
       "vars": {
         "OPENAI_MODEL": "gpt-5.4-mini",
         "COMMENT_ALLOWED_HOSTNAMES": "acecore.net,www.acecore.net,acecore-net.pages.dev",
+        "SCHOOLS_SITE_URL": "https://acecore.net",
+        "SCHOOLS_ALLOWED_HOSTNAMES": "acecore.net,www.acecore.net,acecore-net.pages.dev",
+        "SCHOOLS_EMAIL_FROM": "Acecore Schools <noreply@acecore.net>",
       },
       "d1_databases": [
         {
@@ -34,6 +40,9 @@
       "vars": {
         "OPENAI_MODEL": "gpt-5.4-mini",
         "COMMENT_ALLOWED_HOSTNAMES": "acecore.net,www.acecore.net,acecore-net.pages.dev",
+        "SCHOOLS_SITE_URL": "https://acecore.net",
+        "SCHOOLS_ALLOWED_HOSTNAMES": "acecore.net,www.acecore.net,acecore-net.pages.dev",
+        "SCHOOLS_EMAIL_FROM": "Acecore Schools <noreply@acecore.net>",
       },
       "d1_databases": [
         {


### PR DESCRIPTION
## 関連 Issue

Closes acecore-systems/acecore-net#11

## 概要

Acecore Schools の無料体験予約、本申込み、会員ポータル、Stripe 決済、表示専用外部カレンダー連携の土台を追加しました。
予約・変更・キャンセルはポータル/API 側で管理し、外部カレンダーは Outlook 等から閲覧するための read-only ICS feed に限定しています。

## 主な変更点

- D1 migration を追加し、保護者・受講者・講師・コース・空き枠・予約・OTP・セッション・Stripe event のテーブルを定義
- `/schools/book/` と `/schools/portal/` を追加し、無料体験予約、本申込み、メール OTP ログイン、予約変更・キャンセル導線を実装
- `/api/schools/*` に空き枠取得、予約作成、予約更新、OTP、ポータル session、Stripe Billing Portal、表示専用 ICS calendar feed を追加
- `/api/stripe/webhook` を追加し、Checkout 完了と subscription 削除を予約状態へ反映
- Schools ページに予約 CTA、コース詳細、保護者向け FAQ、会員ポータル導線を追加
- CMS 設定と i18n JSON に Schools 予約・ポータル関連キーを追加
- `wrangler.jsonc` に Schools 予約機能向けの非 secret 環境変数を追加

## 確認したこと

- `npm run build`
- `npx prettier --check "public/admin/config.yml" "src/i18n/source/ja/pages/schools.json" "src/i18n/translations/{de,en,es,fr,ko,pt,ru,zh-cn}.json" "src/views/SchoolsPage.astro" "src/views/SchoolsBookingPage.astro" "src/views/SchoolsPortalPage.astro" "src/pages/schools/book.astro" "src/pages/schools/portal.astro" "src/pages/[locale]/schools/book.astro" "src/pages/[locale]/schools/portal.astro" "functions/api/schools/**/*.ts" "functions/api/stripe/**/*.ts" "wrangler.jsonc"`
- `git diff --check`
- `C:\Users\gnish\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -c "import pathlib, sqlite3; sql=pathlib.Path('migrations/0002_create_school_booking.sql').read_text(encoding='utf-8'); con=sqlite3.connect(':memory:'); con.executescript(sql); print('migration ok')"`
- `Start-Process -WindowStyle Hidden -FilePath "npm" -ArgumentList @("run","dev","--","--host","127.0.0.1","--port","4321") -WorkingDirectory "C:\Users\gnish\repos\acecore-net\.worktrees\schools-booking" -PassThru | Select-Object -ExpandProperty Id`
- 同梱 Node + Playwright で `http://127.0.0.1:4327/schools/book/` と `http://127.0.0.1:4327/schools/portal/` を desktop/mobile viewport で確認し、両ページとも 200 / h1 / form 表示を確認

## 未確認事項・補足

- Astro dev server では Cloudflare Pages Functions がそのまま配信されないため、`/api/schools/availability` はローカル UI 確認時に 404 になります。D1/Pages Functions 実行環境での E2E は未実施です。
- Stripe / Resend / D1 は実 secret と production binding が必要なため、本番 API の実送信・実決済は未実施です。
- 翻訳 JSON の新規 Schools 予約・ポータル文言は、日本語 source の構造に合わせるため追加しています。既存翻訳済みキーは保持しています。