### PR TITLE
CMS画像アップロードの保存先を修正

### DIFF
--- a/.github/workflows/cms-content-pr.yml
+++ b/.github/workflows/cms-content-pr.yml
@@ -1,0 +1,83 @@
+name: CMS Content PR
+
+on:
+  push:
+    branches:
+      - cms-content
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out CMS branch
+        uses: actions/checkout@v4
+        with:
+          ref: cms-content
+          fetch-depth: 0
+
+      - name: Create pull request for CMS changes
+        env:
+          GH_TOKEN: ${{ secrets.CMS_PR_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+          BASE_BRANCH: main
+          HEAD_BRANCH: cms-content
+        run: |
+          set -euo pipefail
+
+          owner="${REPO%%/*}"
+          git fetch origin "$BASE_BRANCH"
+
+          if git diff --quiet "origin/$BASE_BRANCH...HEAD"; then
+            echo "No CMS changes to publish."
+            exit 0
+          fi
+
+          existing_pr="$(
+            gh pr list \
+              --repo "$REPO" \
+              --head "$owner:$HEAD_BRANCH" \
+              --base "$BASE_BRANCH" \
+              --state open \
+              --json number \
+              --jq '.[0].number // ""'
+          )"
+
+          if [ -n "$existing_pr" ]; then
+            echo "CMS pull request already exists: #$existing_pr"
+            exit 0
+          fi
+
+          body_file="${RUNNER_TEMP}/cms-content-pr.md"
+          cat > "$body_file" <<'BODY'
+          ## 関連 Issue
+
+          なし
+
+          ## 概要
+
+          Sveltia CMS から `cms-content` ブランチに保存された編集内容を `main` に反映します。
+
+          ## 主な変更点
+
+          - CMS で保存された記事、ページ文言、著者、タグ、アップロード画像など
+
+          ## 確認したこと
+
+          - 自動作成 PR のため未実施
+
+          ## 未確認事項・補足
+
+          - レビュー後、通常の merge commit または rebase merge でマージしてください。squash merge では `cms: ...` commit subject が失われ、翻訳 PR task の自動検出対象外になる場合があります。
+          BODY
+
+          gh pr create \
+            --repo "$REPO" \
+            --base "$BASE_BRANCH" \
+            --head "$owner:$HEAD_BRANCH" \
+            --title "CMS編集内容を反映" \
+            --body-file "$body_file"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ src/
 7. 著者・タグは「著者」「タグ」から編集
 8. CMS 経由の日本語ソース編集のみ、Copilot translation PR task で翻訳へ反映
 
+#### 本番 CMS の保存と PR 反映
+
+- 本番 CMS の保存先は `cms-content` ブランチです。`main` は protected branch のため、CMS から直接 commit しません。
+- `cms-content` に保存されると `.github/workflows/cms-content-pr.yml` が `main` 向けの「CMS編集内容を反映」PRを作成します。既に open PR がある場合は二重作成しません。
+- 初回セットアップやブランチ再作成が必要な場合は、`main` の最新状態から `git fetch origin main`、`git push origin origin/main:refs/heads/cms-content` で `cms-content` を用意します。
+- CMS PR は通常の merge commit または rebase merge でマージします。squash merge では `cms: ...` commit subject が失われ、翻訳 PR task の自動検出対象外になる場合があります。
+- GitHub Actions の `GITHUB_TOKEN` で PR 作成が許可されていない環境では、Repository settings の Actions 権限を見直すか、PR 作成権限を持つ `CMS_PR_TOKEN` secret を設定します。
+
 #### キャンペーン告知の運用
 
 - 告知やキャンペーンは「告知・キャンペーン」に1件ずつ並びます。新しく追加する場合は一覧右上の追加ボタンから作成します。
@@ -141,18 +149,20 @@ author: 'author-id'
 Sveltia CMS は日本語ソース記事と日本語の固定ページ文言を編集できます。多言語記事本文とページ文言は GitHub Copilot coding agent が作成する Pull Request ベースで管理します。PR 量を抑えるため、push 連動の対象は Sveltia CMS の `cms: ...` commit だけに限定します。
 
 1. 日本語ソースを Sveltia CMS で更新する
-2. CMS commit の本文差分または日本語文言 key 差分だけを GitHub Actions が検出する
-3. Copilot coding agent が該当差分だけに沿って `src/content/blog/{locale}/` または `src/i18n/translations/{locale}.json` を更新する
-4. 完了時に `[translation]` PR が ready for review になったら、内容とビルドを確認してから必要に応じて手動マージする
+2. CMS commit が `cms-content` ブランチに保存され、GitHub Actions が `main` 向け PR を作成する
+3. CMS PR を `main` にマージすると、CMS commit の本文差分または日本語文言 key 差分だけを GitHub Actions が検出する
+4. Copilot coding agent が該当差分だけに沿って `src/content/blog/{locale}/` または `src/i18n/translations/{locale}.json` を更新する
+5. 完了時に `[translation]` PR が ready for review になったら、内容とビルドを確認してから必要に応じて手動マージする
 
 著者情報、タグ定義の多言語フィールドは Sveltia CMS から直接編集できます。ローカル開発や通常の Git commit による日本語ソース変更では、自動翻訳 PR task は作成しません。
 
 ### 自動 PR task workflow
 
 - Workflow: `.github/workflows/create-translation-prs.yml`
+- CMS PR Workflow: `.github/workflows/cms-content-pr.yml`
 - Script: `scripts/create-translation-prs.mjs`
 - Trigger: `src/content/blog/*.md` または `src/i18n/source/ja/**/*.json` の `main` 反映時。ただし自動実行は Sveltia CMS の `cms: ...` commit のみ
-- CMS commit と通常 commit が同じ push に混在した場合は、自動翻訳 PR task を作成せず workflow を止める
+- CMS commit と通常 commit が同じ push に混在した場合は、自動翻訳 PR task を作成せず workflow を止める。CMS PR の merge commit はこの判定から除外する
 - 日本語ソース記事ごとに Copilot translation PR task を作成し、同じソースの open PR があれば重複作成しない
 - ページ文言は変更された JSON key だけを対象に、まとめて 1 つの Copilot translation PR task を作成する
 - blog 記事は frontmatter だけの変更では task を作成せず、Markdown 本文が変わったときだけ PR task を作成する

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -3,7 +3,7 @@
 backend:
   name: github
   repo: acecore-systems/acecore-net
-  branch: main
+  branch: cms-content
   base_url: https://sveltia-cms-auth.sparkling-tree-7cef.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -13,7 +13,7 @@ backend:
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
 
-media_folder: public/uploads
+media_folder: /public/uploads
 public_folder: /uploads
 
 collections:

--- a/scripts/create-translation-prs.mjs
+++ b/scripts/create-translation-prs.mjs
@@ -146,27 +146,37 @@ function parseNameStatusLine(line) {
 }
 
 function isCmsCommitSubject(subject) {
-  return /^cms: (create|update|delete) /.test(subject || '')
+  return /^cms: (create|update|delete|upload) /.test(subject || '')
 }
 
 function listCommitSubjects(baseSha, headSha) {
   const output = baseSha
-    ? safeRunGit(['log', '--format=%H%x00%s', `${baseSha}..${headSha}`])
-    : safeRunGit(['log', '--format=%H%x00%s', '-n', '1', headSha])
+    ? safeRunGit(['log', '--format=%H%x00%P%x00%s', `${baseSha}..${headSha}`])
+    : safeRunGit(['log', '--format=%H%x00%P%x00%s', '-n', '1', headSha])
 
   if (!output) return []
 
   return output.split(/\r?\n/).map((line) => {
-    const [sha, subject] = line.split('\0')
-    return { sha, subject: subject || '' }
+    const [sha, parents, subject] = line.split('\0')
+
+    return {
+      sha,
+      subject: subject || '',
+      parentShas: parents ? parents.split(' ').filter(Boolean) : [],
+    }
   })
+}
+
+function isMergeCommit(commit) {
+  return commit.parentShas.length > 1
 }
 
 function ensureCmsOnlyChangeSet(baseSha, headSha) {
   const commits = listCommitSubjects(baseSha, headSha)
-  if (commits.length === 0) return false
+  const contentCommits = commits.filter((commit) => !isMergeCommit(commit))
+  if (contentCommits.length === 0) return false
 
-  const cmsCommits = commits.filter((commit) =>
+  const cmsCommits = contentCommits.filter((commit) =>
     isCmsCommitSubject(commit.subject),
   )
 
@@ -175,7 +185,7 @@ function ensureCmsOnlyChangeSet(baseSha, headSha) {
     return false
   }
 
-  if (cmsCommits.length !== commits.length) {
+  if (cmsCommits.length !== contentCommits.length) {
     throw new Error(
       'CMS and non-CMS commits are mixed in this push. Skipping automatic translation PR tasks; re-run manually after reviewing the source diff.',
     )

--- a/scripts/write-cms-runtime-config.mjs
+++ b/scripts/write-cms-runtime-config.mjs
@@ -1,12 +1,17 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
-const cmsBranch =
+const defaultCmsBranch = 'cms-content'
+const deploymentBranch =
   process.env.CF_PAGES_BRANCH ||
   process.env.GITHUB_HEAD_REF ||
   process.env.GITHUB_REF_NAME ||
-  process.env.BRANCH ||
-  'main'
+  process.env.BRANCH
+const cmsBranch =
+  process.env.CMS_CONTENT_BRANCH ||
+  (deploymentBranch && deploymentBranch !== 'main'
+    ? deploymentBranch
+    : defaultCmsBranch)
 
 const outputPath = resolve('public/admin/runtime-config.js')
 


### PR DESCRIPTION
## 関連 Issue

なし

## 概要

Sveltia CMS の本番保存先を protected な `main` 直書きから `cms-content` ブランチへ切り替え、CMS保存後に `main` 向けPRを作成する運用に変更します。

## 主な変更点

- 本番CMSの保存先を `cms-content` に変更し、media folder を絶対パス指定に修正
- production/main デプロイ時のCMS runtime branch既定値を `cms-content` に変更し、preview branch と `CMS_CONTENT_BRANCH` override は維持
- `cms-content` push時に「CMS編集内容を反映」PRを作成するGitHub Actions workflowを追加
- CMS画像upload commitを翻訳workflowのCMS commit判定に含め、CMS PRのmerge commitは混在判定から除外
- READMEに本番CMS保存、PR反映、翻訳workflow連携の運用手順を追記

## 確認したこと

- `node scripts/write-cms-runtime-config.mjs` 相当を bundled Node で実行し、`CMS runtime config branch: cms-content` を確認
- `node node_modules/prettier/bin/prettier.cjs --check README.md public/admin/config.yml .github/workflows/cms-content-pr.yml scripts/create-translation-prs.mjs scripts/write-cms-runtime-config.mjs`
- `node --check scripts/create-translation-prs.mjs`
- `node --check scripts/write-cms-runtime-config.mjs`
- `git diff --check`
- `ASTRO_TELEMETRY_DISABLED=1 node node_modules/astro/bin/astro.mjs build`
- `node node_modules/pagefind/lib/runner/bin.cjs --site dist`

## 未確認事項・補足

- この環境では Volta が `C:\Users\gnish\AppData\Local\Volta` に書き込めず `npm run build` と `pagefind.cmd` が失敗するため、同等処理を bundled Node で個別実行しました。
- 本番 `/admin/` への反映は、このPRのマージ後にCloudflare Pagesの本番デプロイが完了してからです。
- 先に `cms-content` ブランチは `main` 最新SHAにfast-forward済みです。