### PR TITLE
[codex] Sveltia CMS記事をブログトップに表示

### DIFF
--- a/src/content/blog/cms-selection-and-turnstile.md
+++ b/src/content/blog/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sveltia CMS導入ガイド'
 description: 'Astroなどの静的サイトにSveltia CMSを導入し、GitHub backend、OAuth Worker、画像アップロード、多言語運用、CMS専用PRフローまで整える手順と反省点をまとめます。'
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']

--- a/src/content/blog/de/cms-selection-and-turnstile.md
+++ b/src/content/blog/de/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sveltia CMS Einrichtungsleitfaden'
 description: 'Praktischer Leitfaden zum Einbau von Sveltia CMS in Astro- und statische Websites: GitHub Backend, OAuth Worker, Medien-Uploads, Mehrsprachigkeit, CMS-PRs und Lessons Learned.'
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']

--- a/src/content/blog/en/cms-selection-and-turnstile.md
+++ b/src/content/blog/en/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sveltia CMS Setup Guide'
 description: 'A practical guide to adding Sveltia CMS to an Astro or static site, covering the GitHub backend, OAuth Worker, media uploads, multilingual operations, CMS pull requests, and lessons from real fixes.'
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']

--- a/src/content/blog/es/cms-selection-and-turnstile.md
+++ b/src/content/blog/es/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: 'Guía de instalación de Sveltia CMS'
 description: 'Guía práctica para añadir Sveltia CMS a un sitio Astro o estático, con GitHub backend, OAuth Worker, subida de imágenes, operación multilingüe, PRs de CMS y lecciones aprendidas.'
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']

--- a/src/content/blog/fr/cms-selection-and-turnstile.md
+++ b/src/content/blog/fr/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: "Guide d'installation de Sveltia CMS"
 description: "Guide pratique pour ajouter Sveltia CMS à un site Astro ou statique : backend GitHub, OAuth Worker, images, multilingue, PRs de CMS et retours d'expérience."
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']

--- a/src/content/blog/ko/cms-selection-and-turnstile.md
+++ b/src/content/blog/ko/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sveltia CMS 도입 가이드'
 description: 'Astro 같은 정적 사이트에 Sveltia CMS를 도입하는 방법을 GitHub backend, OAuth Worker, 이미지 업로드, 다국어 운영, CMS 전용 PR 흐름, 실제 수정에서 얻은 교훈까지 정리합니다.'
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']

--- a/src/content/blog/pt/cms-selection-and-turnstile.md
+++ b/src/content/blog/pt/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: 'Guia de instalação do Sveltia CMS'
 description: 'Guia prático para adicionar Sveltia CMS a um site Astro ou estático, cobrindo GitHub backend, OAuth Worker, uploads de imagem, operação multilíngue, PRs de CMS e aprendizados reais.'
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']

--- a/src/content/blog/ru/cms-selection-and-turnstile.md
+++ b/src/content/blog/ru/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: 'Руководство по внедрению Sveltia CMS'
 description: 'Практическое руководство по добавлению Sveltia CMS в Astro или другой статический сайт: GitHub backend, OAuth Worker, загрузка изображений, многоязычная эксплуатация, CMS PR и выводы из реальных исправлений.'
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']

--- a/src/content/blog/zh-cn/cms-selection-and-turnstile.md
+++ b/src/content/blog/zh-cn/cms-selection-and-turnstile.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sveltia CMS 导入指南'
 description: '总结在 Astro 等静态网站中导入 Sveltia CMS 的方法，涵盖 GitHub backend、OAuth Worker、图片上传、多语言运维、CMS 专用 PR 流程以及实际修正中得到的经验。'
-date: 2026-03-15T00:00
+date: 2026-06-07T16:00
 lastUpdated: 2026-06-07
 author: gui
 tags: ['技術', 'CMS', 'Astro', 'Cloudflare', 'セキュリティ']


### PR DESCRIPTION
## 関連 Issue

なし

## 概要

- Sveltia CMS導入ガイドの公開日時が古いままで、ブログトップの最新記事に出ていなかった問題を修正します。
- 日本語版と8言語版の `date` を `2026-06-07T16:00` に揃え、ブログ一覧・RSS・アーカイブで最新記事として扱われるようにします。

## 主な変更点

- `cms-selection-and-turnstile.md` の9言語版 frontmatter の `date` を更新
- 本文内容の変更はなし

## 確認したこと

- `npx prettier --check src/content/blog/cms-selection-and-turnstile.md src/content/blog/en/cms-selection-and-turnstile.md src/content/blog/zh-cn/cms-selection-and-turnstile.md src/content/blog/es/cms-selection-and-turnstile.md src/content/blog/pt/cms-selection-and-turnstile.md src/content/blog/fr/cms-selection-and-turnstile.md src/content/blog/ko/cms-selection-and-turnstile.md src/content/blog/de/cms-selection-and-turnstile.md src/content/blog/ru/cms-selection-and-turnstile.md`
- `git diff --check`
- `npm run build`
- `dist/blog/index.html` と `dist/rss.xml` で `Sveltia CMS導入ガイド` が先頭に出ることを確認

## 未確認事項・補足

- Volta が `C:\Users\gnish\AppData\Local\Volta` を作成できないため、`npx prettier --check` と `npm run build` は権限付きで再実行して通しています。
- ブラウザ目視確認は未実施です。生成済みHTMLで表示順を確認しています。