### PR TITLE
ブログカード画像の表示比率を調整

### DIFF
--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -40,7 +40,7 @@ const tags = await getAllTags()
 const rawAuthor = findAuthorById(authors, post.data.author)
 const author = rawAuthor ? getLocalizedAuthor(rawAuthor, locale) : null
 const cardImageWidths = [320, 640, 960, 1200]
-const cardImageOptions = { aspectRatio: 1, quality: 80 }
+const cardImageOptions = { aspectRatio: 16 / 9, quality: 80 }
 ---
 
 <article
@@ -53,11 +53,11 @@ const cardImageOptions = { aspectRatio: 1, quality: 80 }
   <div class="flex flex-col sm:flex-row">
     {
       postImage && (
-        <div class="overflow-hidden border-b border-slate-200 bg-slate-100 sm:w-56 sm:shrink-0 sm:self-start sm:border-b-0 sm:border-r">
+        <div class="aspect-video overflow-hidden border-b border-slate-200 bg-slate-100 sm:aspect-auto sm:w-56 sm:shrink-0 sm:self-stretch sm:border-b-0 sm:border-r">
           <img
             src={optimizeImage(postImage, {
               width: 640,
-              height: 640,
+              height: 360,
               quality: 80,
             })}
             srcset={generateSrcSet(
@@ -65,11 +65,11 @@ const cardImageOptions = { aspectRatio: 1, quality: 80 }
               cardImageWidths,
               cardImageOptions,
             )}
-            sizes="(min-width: 640px) 224px, 100vw"
+            sizes="(min-width: 640px) 224px, calc(100vw - 2rem)"
             alt={post.data.title}
-            class="h-44 w-full object-cover transition-transform duration-300 group-hover:scale-[1.03] sm:h-56"
+            class="h-full w-full object-cover object-center transition-transform duration-300 group-hover:scale-[1.03]"
             width="640"
-            height="640"
+            height="360"
             decoding="async"
             loading="lazy"
           />


### PR DESCRIPTION
## 関連 Issue

なし

## 概要

- ブログ一覧カードのサムネイル画像まわりで、横並び時に左カラム下へ無駄な白い余白が残らないよう調整しました。

## 主な変更点

- `BlogPostCard.astro` のカード画像生成比率を 1:1 から 16:9 に変更
- モバイルでは 16:9 の画像枠を維持
- 横並びになる幅ではサムネイル枠を本文側の高さまで `self-stretch` させ、`object-cover` のまま余白なしで表示
- `sizes` と `width` / `height` を表示比率に合わせて更新

## 確認したこと

- `npx prettier --check src/components/BlogPostCard.astro`
- `git diff --check`
  - Windows の LF/CRLF 変換警告のみ、whitespace error はなし
- `npm run build`
- Playwright CLI / Edge: `http://127.0.0.1:4336/blog/`
  - desktop 1365x768
  - mobile 390x844
  - desktop の先頭 3 カードで画像枠とカード高さの差は 2px 程度、`object-fit: cover`
  - mobile では画像枠 348x196、画像 348x195、`object-fit: cover`
- Console: 外部広告スクリプトの DNS エラーのみ

## 未確認事項・補足

- Browser プラグインはこの環境で `windows sandbox failed: spawn setup refresh` が再現したため、Playwright CLI / Edge で代替確認しました。