### PR TITLE
[codex] Cloudflareだけでコメント機能を作る記事を追加

### DIFF
--- a/src/content/blog/astro-ai-contact-chat.md
+++ b/src/content/blog/astro-ai-contact-chat.md
@@ -283,7 +283,7 @@ function assertSameOrigin(request: Request) {
 
 ただし、インメモリのレート制限は、複数isolateや再起動をまたぐ永続的な制限にはなりません。小規模サイトの初期ブレーキとしては使えますが、アクセスが増える場合はCloudflare WAF、Turnstile、KV、D1、Durable Objectsなどに寄せるほうが安定します。
 
-コンテンツ更新側のCMS設計は、[Sveltia CMS導入ガイド](/blog/cms-selection-and-turnstile/) に分けて整理しています。フォームやコメントのbot対策はTurnstileなど別レイヤーとして扱います。
+コンテンツ更新側のCMS設計は、[Sveltia CMS導入ガイド](/blog/cms-selection-and-turnstile/) に分けて整理しています。フォームやコメントのbot対策はTurnstileなど別レイヤーとして扱います。Cloudflareだけでコメント機能を作る場合の設計は [CloudflareだけでAstroブログにコメント機能を作る方法](/blog/cloudflare-only-blog-comments/) にまとめました。
 
 ## Markdownリンクは許可リストで描画する
 

--- a/src/content/blog/cloudflare-only-blog-comments.md
+++ b/src/content/blog/cloudflare-only-blog-comments.md
@@ -1,0 +1,528 @@
+---
+title: 'CloudflareだけでAstroブログにコメント機能を作る方法'
+description: '外部コメントサービスに頼らず、Cloudflare Pages Functions、D1、Turnstile、Wrangler設定だけでAstroブログにコメント機能を追加した実装記録です。API設計、保存先、スパム対策、origin制御、preview/production分離、運用時の注意点まで整理します。'
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: 外部コメントサービスなしで完結させる
+  text: 'コメント機能は、外部SaaSや埋め込みウィジェットを使わなくても、Cloudflare Pages Functions、D1、Turnstileを組み合わせれば静的サイトのまま実装できます。重要なのは、投稿API、保存先、bot対策、origin制御、削除運用を最初から分けて設計することです。'
+processFigure:
+  eyebrow: Cloudflare Comments
+  title: Cloudflareだけで作るコメント機能の構成
+  description: 'AstroはUIを描画し、Cloudflare Pages FunctionsがAPI境界になり、D1とTurnstileをCloudflare内の部品としてつなぎます。'
+  variant: inline
+  steps:
+    - title: AstroにUIを置く
+      description: '記事詳細の下にコメント一覧、投稿フォーム、Turnstile widgetを配置する。'
+      icon: i-lucide-message-square-text
+      accent: brand
+    - title: Pages Functionで受ける
+      description: '`/api/comments` がGET/POST/OPTIONSを処理し、入力検証とCORSを担当する。'
+      icon: i-lucide-cloud
+      accent: slate
+    - title: D1に保存する
+      description: '`COMMENTS_DB` bindingでSQLite互換のD1へコメント、hash、作成日時を保存する。'
+      icon: i-lucide-database
+      accent: emerald
+    - title: Turnstileで守る
+      description: 'Cloudflare Turnstile tokenをserver-side validationし、hostname allowlistも確認する。'
+      icon: i-lucide-shield-check
+      accent: amber
+compareTable:
+  title: 外部コメントサービスとCloudflare内製の違い
+  before:
+    label: 外部コメントサービス
+    items:
+      - '導入は速いが、UI、データ保存先、規約、表示速度をサービス側に寄せる'
+      - '外部scriptやiframeが記事ページの読み込みに影響しやすい'
+      - '多言語UIやサイトデザインとの統一に制約が出やすい'
+      - 'コメントデータの扱い、削除、移行がサービス仕様に依存する'
+  after:
+    label: Cloudflareだけで実装
+    items:
+      - 'Pages Functions、D1、TurnstileだけでAPIと保存先を持てる'
+      - 'Astro側のHTML/CSSとしてサイトデザインへ自然に合わせられる'
+      - 'Wrangler設定でpreviewとproductionのD1を分けられる'
+      - 'スパム対策、削除、保存する個人情報の範囲を自分たちで決められる'
+checklist:
+  title: 実装前に決めること
+  items:
+    - text: 'コメントを外部サービスへ預けず、自サイトのCloudflare構成で持つ'
+      checked: true
+    - text: '保存先はD1、API境界はCloudflare Pages Functionsにする'
+      checked: true
+    - text: 'Turnstile tokenは必ずserver-side validationする'
+      checked: true
+    - text: 'URL、メール、HTML、Markdownリンク、宣伝語句を投稿前に拒否する'
+      checked: true
+    - text: 'preview/localとproductionのD1 bindingを分ける'
+      checked: true
+linkCards:
+  - href: /blog/cloudflare-pages-security/
+    title: Cloudflare Pages のセキュリティ設定
+    description: 'Cloudflare Pagesで静的サイトを安全に配信する基本設計です。'
+    icon: i-lucide-shield
+  - href: /blog/cms-selection-and-turnstile/
+    title: Sveltia CMS導入ガイド
+    description: 'Cloudflare Workers上のOAuthやTurnstileを含むCMS導入の実装記録です。'
+    icon: i-lucide-badge-check
+  - href: /blog/astro-ai-contact-chat/
+    title: Astroサイトに問い合わせAIチャットを組み込む技術設計
+    description: 'Cloudflare Pages FunctionsでAPI境界を作る別の実装例です。'
+    icon: i-lucide-bot
+faq:
+  title: よくある質問
+  items:
+    - question: 外部コメントサービスを使わないメリットは何ですか？
+      answer: 'データ保存先、UI、スパム対策、削除運用、preview環境の扱いを自分たちで決められることです。外部scriptやサービス仕様への依存も減ります。'
+    - question: D1だけでコメント機能は足りますか？
+      answer: '記事コメントのように、post_slugで取得し、作成日時順に表示する小規模なリレーショナルデータならD1で扱いやすいです。リアルタイム通知や大規模な権限管理が必要なら別設計を検討します。'
+    - question: Turnstileをフロントに置くだけではだめですか？
+      answer: 'だめです。TurnstileのtokenはPages Function側でSiteverify APIへ送り、成功結果とhostnameを確認してから保存処理へ進めます。'
+---
+
+静的サイトにコメント欄を付けるとき、まず候補に上がりやすいのは外部コメントサービスやGitHub Discussions連携です。
+
+導入だけならそれも速いです。しかし今回は、**外部コメントサービスに頼らず、CloudflareだけでAstroブログのコメント機能を作る** 方針にしました。
+
+実装の中心になったのは [Cloudflare コメント機能を追加したPR](https://github.com/acecore-systems/acecore-net/pull/101) です。この記事では、そのPRで入れた構成をもとに、他のAstroサイトでも再利用しやすい考え方として整理します。
+
+## なぜ外部コメントサービスを使わなかったか
+
+外部コメントサービスにはメリットがあります。
+
+- 導入が速い
+- 管理画面や通知が用意されている
+- 既存のユーザー認証やスパム対策に乗れる場合がある
+- サーバー側の実装を持たなくてよい
+
+一方で、公式サイトのブログに入れる機能として考えると、気になる点もあります。
+
+- 外部scriptやiframeが記事ページの読み込みに入る
+- UIをサイトのデザインに合わせにくい
+- コメントデータの保存先と削除方針をサービス側へ寄せることになる
+- 多言語UIやlocaleごとの見せ方を細かく制御しにくい
+- サービス終了、仕様変更、規約変更の影響を受ける
+
+AcecoreのサイトはすでにCloudflare Pagesで配信しており、問い合わせAIもPages Functions経由で動かしています。
+
+であれば、コメント機能も同じ境界に寄せて、Cloudflare Pages Functions、D1、Turnstileだけで完結させるほうが筋がよいと判断しました。
+
+## 全体構成
+
+今回の構成は次の通りです。
+
+| 役割         | 実装                                                        |
+| ------------ | ----------------------------------------------------------- |
+| 表示UI       | `src/components/BlogComments.astro`                         |
+| 記事への配置 | `src/views/BlogPostPage.astro`                              |
+| API          | `functions/api/comments.ts`                                 |
+| 保存先       | Cloudflare D1 binding `COMMENTS_DB`                         |
+| bot対策      | Cloudflare Turnstile                                        |
+| 環境設定     | `wrangler.jsonc`                                            |
+| schema       | `migrations/0001_create_blog_comments.sql`                  |
+| 文言         | `src/i18n/source/ja/blog.json` と各localeのtranslation JSON |
+
+Astro側はコメント一覧とフォームを出すだけです。読み込みと投稿は `/api/comments` へfetchします。
+
+Cloudflare Pages Functions側は、次の責務を持ちます。
+
+- `GET /api/comments` で記事slugに紐づくコメントを返す
+- `POST /api/comments` で投稿を受ける
+- `OPTIONS` でCORS preflightに返す
+- Originを確認する
+- 入力を正規化する
+- Turnstile tokenをCloudflareへ検証しに行く
+- レート制限と重複投稿チェックを行う
+- D1へ保存する
+- 公開用レスポンスから不要な内部情報を落とす
+
+Cloudflare PagesのFunctions bindingは、Pages FunctionからD1などのCloudflareリソースに接続するための入口です。Cloudflare公式ドキュメントでも、D1 bindingはWrangler設定またはダッシュボードからPages Functionへ接続できるものとして説明されています。
+
+## D1をコメント保存先にする
+
+コメントはリレーショナルデータです。
+
+記事slug、表示名、本文、作成日時、削除日時、重複判定用hash、クライアント判定用hashを持ちます。
+
+今回のschemaはシンプルです。
+
+```sql
+CREATE TABLE IF NOT EXISTS blog_comments (
+  id TEXT PRIMARY KEY,
+  post_slug TEXT NOT NULL,
+  locale TEXT NOT NULL,
+  author_name TEXT NOT NULL,
+  body TEXT NOT NULL,
+  body_hash TEXT NOT NULL,
+  client_hash TEXT NOT NULL,
+  user_agent_hash TEXT NOT NULL,
+  risk_score INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  deleted_at TEXT
+);
+```
+
+表示対象は `deleted_at IS NULL` のコメントだけにします。
+
+物理削除ではなくsoft deleteにしているのは、荒らし投稿を非表示にしつつ、あとから状況を確認できるようにするためです。小規模なコメント機能なら、いきなり管理画面を作るより、まずはD1上の `deleted_at` を運用で更新できる形にするだけでも始められます。
+
+また、取得用、クライアント別制限用、重複検知用にindexを用意しています。
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_blog_comments_post_created
+  ON blog_comments (post_slug, deleted_at, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_blog_comments_client_created
+  ON blog_comments (client_hash, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_blog_comments_duplicate
+  ON blog_comments (post_slug, body_hash, created_at);
+```
+
+D1では、Function側から `env.COMMENTS_DB.prepare(...).bind(...).all()` のようにprepared statementを使います。Cloudflare D1の公式ドキュメントでも、`bind()` で値を渡すprepared statementはSQL injection対策として説明されています。
+
+コメント本文やslugをSQL文字列へ直接連結しないことが重要です。
+
+## Wrangler設定をsource of truthにする
+
+D1 bindingと環境変数は `wrangler.jsonc` に寄せました。
+
+```jsonc
+{
+  "vars": {
+    "COMMENT_ALLOWED_HOSTNAMES": "acecore.net,www.acecore.net,acecore-net.pages.dev,localhost,127.0.0.1",
+  },
+  "d1_databases": [
+    {
+      "binding": "COMMENTS_DB",
+      "database_name": "acecore-comments-preview",
+      "database_id": "...",
+      "migrations_dir": "./migrations",
+    },
+  ],
+  "env": {
+    "preview": {
+      "d1_databases": [
+        {
+          "binding": "COMMENTS_DB",
+          "database_name": "acecore-comments-preview",
+        },
+      ],
+    },
+    "production": {
+      "d1_databases": [
+        {
+          "binding": "COMMENTS_DB",
+          "database_name": "acecore-comments-production",
+        },
+      ],
+    },
+  },
+}
+```
+
+Cloudflare PagesのWrangler設定は、Pages project configurationのsource of truthとして扱われます。つまり、bindingや環境変数をダッシュボードの手作業だけに散らさず、リポジトリ側でレビューできる形にできます。
+
+ここで大事なのは、**preview/localとproductionのD1を分けること** です。
+
+コメント機能は投稿データを持つので、preview環境で本番D1へ書き込むと事故になります。今回も `acecore-comments-preview` と `acecore-comments-production` を分け、同じ `COMMENTS_DB` binding名で環境ごとに向き先を変えています。
+
+## Turnstileはサーバー側で検証する
+
+フロント側にはTurnstile widgetを置きます。
+
+ただし、widgetを表示するだけでは不十分です。投稿時に取得したtokenをPages Functionへ送り、Function側からCloudflareのSiteverify APIへ検証しに行きます。
+
+実装では次のようにしています。
+
+```ts
+const formData = new FormData()
+formData.append('secret', env.TURNSTILE_SECRET_KEY)
+formData.append('response', token)
+if (remoteIp) formData.append('remoteip', remoteIp)
+
+const response = await fetch(
+  'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+  {
+    method: 'POST',
+    body: formData,
+  },
+)
+```
+
+Cloudflare Turnstileの公式ドキュメントでも、tokenはSiteverify APIでserver-side validationする前提で説明されています。tokenには有効期限があり、期限切れや再利用されたtokenは失敗します。
+
+さらに、Siteverifyの結果に含まれるhostnameも確認します。
+
+```ts
+return Boolean(
+  result.success &&
+  (!result.hostname || isAllowedVerifiedHostname(result.hostname, env)),
+)
+```
+
+これは、Turnstile tokenだけを見ると「どのhostnameで発行されたtokenか」を見落とすためです。CloudflareのAny Hostnameに関するドキュメントでも、server-side codeでhostnameを検証する必要があると説明されています。
+
+## Originとhostname allowlistを分けて考える
+
+コメントAPIはブラウザから呼ばれます。つまり、CORSとOriginの扱いを決める必要があります。
+
+今回の実装では、次の2段階で守っています。
+
+1. リクエストの `Origin` が許可されたhostnameか見る
+2. Turnstileの検証結果のhostnameも許可されたhostnameか見る
+
+許可対象は `COMMENT_ALLOWED_HOSTNAMES` で管理します。
+
+```txt
+acecore.net,www.acecore.net,acecore-net.pages.dev
+```
+
+ここで `acecore-net.pages.dev` を許可すると、その配下のGit preview URLも通せます。
+
+ただし、これは便利な反面、許可範囲を広げすぎると別環境から投稿できる面が増えます。外部サービスを使わずに自前で作る場合、このような許可リストの粒度も自分たちで責任を持つ必要があります。
+
+## 投稿内容はかなり絞る
+
+コメント欄は荒らされやすい場所です。
+
+今回は、機能を広げるより先に「投稿できる内容」を絞りました。
+
+投稿payloadは次だけです。
+
+```ts
+type CommentPayload = {
+  slug?: unknown
+  locale?: unknown
+  authorName?: unknown
+  body?: unknown
+  website?: unknown
+  turnstileToken?: unknown
+}
+```
+
+`website` はハニーポットです。通常ユーザーには見えないhidden inputに値が入っていたらbot投稿として拒否します。
+
+本文側では、次のような内容を拒否します。
+
+- URL
+- メールアドレス
+- HTMLタグ
+- Markdownリンク
+- 極端な連続文字
+- 宣伝やスパムで使われやすい語句
+
+```ts
+function isBlockedText(value: string): boolean {
+  return (
+    URL_PATTERN.test(value) ||
+    EMAIL_PATTERN.test(value) ||
+    HTML_TAG_PATTERN.test(value) ||
+    MARKDOWN_LINK_PATTERN.test(value) ||
+    REPEATED_CHARACTER_PATTERN.test(value) ||
+    SPAM_WORD_PATTERN.test(value)
+  )
+}
+```
+
+かなり強めの制限ですが、公式サイトのブログコメントではこれで十分です。
+
+リンクを貼れるコメント欄にすると、スパム投稿の動機が一気に増えます。まずは感想や補足だけを書けるコメント欄として設計し、必要になったら承認制や管理画面を足すほうが安全です。
+
+## レート制限は二層にする
+
+Cloudflareだけで実装する場合でも、rate limitは考える必要があります。
+
+今回は、2種類の制限を入れました。
+
+| 種類           | 役割                                                |
+| -------------- | --------------------------------------------------- |
+| メモリ上の制限 | 短時間の連続POST/GETをその場で抑える                |
+| D1上の制限     | isolateや再起動をまたいで、同じclientの連投を抑える |
+
+メモリ上の制限だけだと、Cloudflareの実行環境が変わったときに状態が消えます。そこで、D1にも `client_hash` と `created_at` を保存し、直近の投稿数を見ます。
+
+```sql
+SELECT COUNT(*) AS count
+FROM blog_comments
+WHERE client_hash = ?
+  AND created_at >= ?
+  AND deleted_at IS NULL
+```
+
+`client_hash` はIPアドレスとUser-Agentから作ります。ただし、生のIPやUser-Agentをそのまま保存するのではなく、`COMMENT_HASH_SALT` を混ぜてSHA-256でhash化しています。
+
+これにより、運用に必要な連投判定はできる一方で、不要に生の識別情報を保存しない設計にできます。
+
+## 重複投稿もD1で見る
+
+Turnstileを入れても、同じ本文を何度も投稿される可能性はあります。
+
+そこで、本文を正規化して `body_hash` を作り、同じ記事に同じ本文が一定期間内に入っていないか確認します。
+
+```sql
+SELECT id
+FROM blog_comments
+WHERE post_slug = ?
+  AND body_hash = ?
+  AND created_at >= ?
+  AND deleted_at IS NULL
+LIMIT 1
+```
+
+これもD1に向いている処理です。
+
+KVでも単純なrate limitはできますが、記事slug、作成日時、削除状態、重複判定を組み合わせて見るなら、SQLで扱えるD1のほうが実装が素直になります。
+
+## コメントは記事slugに紐づける
+
+記事側では `BlogPostPage.astro` にコメントコンポーネントを追加しました。
+
+```astro
+<BlogComments locale={locale} slug={baseSlug} />
+```
+
+ここで渡すのはlocale付きのパスではなく、記事のbase slugです。
+
+つまり、`/blog/cloudflare-only-blog-comments/` と `/en/blog/cloudflare-only-blog-comments/` のような言語違いがあっても、同じslugに紐づくコメントとして扱えます。
+
+もちろん、言語別にコメント欄を完全に分けたいなら、D1の取得条件に `locale` を入れればよいです。今回は、コメントを記事単位で共有しつつ、UI文言や日時表示だけlocaleに合わせる設計にしました。
+
+## コメントを検索indexに入れるか
+
+今回のUIには `data-pagefind-ignore` を付けています。
+
+コメントはブラウザ側で `/api/comments` から読み込みます。つまり、Astro build時のHTMLにはコメント本文が入りません。
+
+この設計では、Pagefindや静的HTML上のSEO対象としてコメントを扱わないことになります。
+
+これは意図的です。
+
+公式ブログの本文は編集・レビュー済みのコンテンツとして検索対象にします。一方、コメントは訪問者の補足であり、スパムや雑談が混ざる可能性があります。検索流入を狙う本文と、コミュニケーションのためのコメント欄は分けて考えたほうが運用しやすいです。
+
+もしコメント本文も検索対象にしたいなら、次のような別設計が必要です。
+
+- コメントをbuild時に取得してHTMLへ埋め込む
+- 定期buildや再生成の仕組みを持つ
+- 承認済みコメントだけを静的HTMLへ出す
+- Pagefind対象にするコメントと対象外にするコメントを分ける
+
+最初の実装では、ここまでやらない判断にしました。
+
+## 即時公開か承認制か
+
+今回は、承認待ちにせず即時公開にしました。
+
+ただし、これは何もしないという意味ではありません。API側で次を通した投稿だけを保存します。
+
+- Originが許可されている
+- Turnstileがserver-side validationを通っている
+- hostnameがallowlistに入っている
+- ハニーポットが空
+- URLやメールアドレスを含まない
+- 本文が短すぎない
+- rate limitにかかっていない
+- 同じ本文の重複投稿ではない
+
+承認制にする場合は、schemaに `approved_at` や `status` を追加し、表示クエリを `approved_at IS NOT NULL` に変えれば実現できます。
+
+今回のような小規模な公式サイトでは、まずは強めの投稿制限とsoft deleteで始め、必要になったら管理画面を足すほうが実装量と運用負荷のバランスがよいです。
+
+## Cloudflareだけで完結させたときのよさ
+
+この構成の一番の利点は、**コメント機能の境界がサイトの既存構成と揃うこと** です。
+
+Cloudflare Pagesで静的HTMLを配信し、動的な最小部分だけPages Functionsで受ける。保存先はD1。bot対策はTurnstile。設定はWrangler。すべてCloudflare内で説明できます。
+
+外部コメントサービスを使う場合、便利な反面、コメント欄だけ別の設計思想になります。
+
+- 表示UIが外部サービスに寄る
+- コメントデータの持ち主が変わる
+- 外部scriptの読み込みが増える
+- 削除や移行がサービス仕様に依存する
+- プライバシー説明が複雑になる
+
+Cloudflare内に閉じると、その代わりに自分たちで作る責任は増えます。
+
+しかし、公式サイトのように「コメント機能はほしいが、大規模コミュニティ機能まではいらない」ケースでは、Cloudflareだけで作る構成はかなり相性がよいです。
+
+## 導入手順のまとめ
+
+他のAstroサイトに入れるなら、流れはこうです。
+
+1. Cloudflare D1 databaseをpreview用とproduction用に作る
+2. `wrangler.jsonc` に `COMMENTS_DB` bindingを追加する
+3. `TURNSTILE_SECRET_KEY` と `COMMENT_HASH_SALT` をPages secretに設定する
+4. `COMMENT_ALLOWED_HOSTNAMES` に本番hostとPages preview hostを入れる
+5. `migrations/0001_create_blog_comments.sql` を作る
+6. `npx wrangler d1 execute ... --remote --file=...` でschemaを適用する
+7. `functions/api/comments.ts` でGET/POST/OPTIONSを実装する
+8. `BlogComments.astro` で一覧、フォーム、Turnstile widgetを実装する
+9. `BlogPostPage.astro` の本文下へコメントコンポーネントを置く
+10. productionとpreviewで別D1に書き込まれることを確認する
+
+Cloudflare D1のWrangler commandでは、SQLファイルを実行する `d1 execute` や、versioned migration fileを作る `d1 migrations create` / `d1 migrations apply` が用意されています。プロジェクトの運用に合わせて、単発のschema適用にするか、migrations applyに寄せるかを決めます。
+
+## ローカルとpreviewで確認すること
+
+コメント機能は、静的HTMLだけ見ても確認しきれません。
+
+最低限、次を見ます。
+
+- 記事詳細にコメント欄が表示される
+- `/api/comments?slug=...` が空配列または既存コメントを返す
+- Turnstile未完了ではPOSTできない
+- URLやメールアドレス入りの本文が拒否される
+- 同じ本文の連投が拒否される
+- production previewで本番D1へ書き込まない
+- `COMMENT_ALLOWED_HOSTNAMES` にないoriginから拒否される
+- `deleted_at` を入れたコメントが表示されない
+
+Astroの通常dev serverだけでは、Cloudflare Pages FunctionsやD1 bindingの挙動とズレます。Cloudflare binding込みで見るときは、`wrangler pages dev` かCloudflare Pagesのpreview環境で確認します。
+
+## 今後足すなら
+
+今回の実装は、小さく始めるコメント機能です。
+
+今後拡張するなら、候補はあります。
+
+- 管理者用の承認・削除UI
+- `approved_at` を使った承認制
+- 通知メール
+- 管理者返信
+- 記事ごとのコメント受付ON/OFF
+- さらに細かいrate limit
+- Cloudflare Queuesを使った非同期moderation
+
+ただし、最初から全部入れると、コメント欄ではなく小さなコミュニティサービスを作ることになります。
+
+今回の目的は、公式ブログに軽いコメント欄を置くことです。その範囲なら、Cloudflare Pages Functions、D1、Turnstileの組み合わせで十分に実用になります。
+
+## 参考
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [Cloudflare コメント機能を追加したPR](https://github.com/acecore-systems/acecore-net/pull/101)
+
+## まとめ
+
+静的サイトにコメント機能を入れるとき、外部コメントサービスを使うのは自然な選択肢です。
+
+ただ、すでにCloudflare Pagesで配信しているサイトなら、Cloudflareだけで作る選択肢もかなり現実的です。
+
+Pages FunctionsでAPI境界を作り、D1に保存し、Turnstileでbot対策をし、Wranglerで環境ごとのbindingを管理する。これで、静的サイトの強みを残したまま、必要な部分だけ動的にできます。
+
+外部サービスに頼らない分、入力検証、rate limit、hostname allowlist、削除運用は自分たちで設計する必要があります。
+
+その代わり、コメント欄のUI、データ、セキュリティ境界、preview/production分離をサイトの方針に合わせられます。
+
+公式サイトのブログに小さくコメント機能を足したいなら、Cloudflareだけで作る構成は十分に候補になります。

--- a/src/content/blog/cloudflare-pages-security.md
+++ b/src/content/blog/cloudflare-pages-security.md
@@ -37,7 +37,7 @@ faq:
 
 Cloudflare Pages は静的サイトのホスティングに最適なプラットフォームです。この記事では、実際のデプロイ構成と、`_headers` ファイルを使ったセキュリティ設定について紹介します。
 
-SSL 証明書まわりの選定は、[Cloudflare の Advanced Certificate Manager 解説](/blog/cloudflare-ssl-advanced-certificate-manager/)もあわせて確認してください。CMS 管理画面を静的サイトに追加する設計は[Sveltia CMS導入ガイド](/blog/cms-selection-and-turnstile/)にまとめています。
+SSL 証明書まわりの選定は、[Cloudflare の Advanced Certificate Manager 解説](/blog/cloudflare-ssl-advanced-certificate-manager/)もあわせて確認してください。CMS 管理画面を静的サイトに追加する設計は[Sveltia CMS導入ガイド](/blog/cms-selection-and-turnstile/)にまとめています。外部コメントサービスに頼らず、Cloudflare Pages Functions と D1 でコメント機能を足す設計は [CloudflareだけでAstroブログにコメント機能を作る方法](/blog/cloudflare-only-blog-comments/) に分けました。
 
 ## デプロイ構成：Worker をやめて Pages に戻した理由
 
@@ -49,7 +49,7 @@ SSL 証明書まわりの選定は、[Cloudflare の Advanced Certificate Manage
 - **デバッグの手間**：ローカルでの `wrangler dev` と本番の挙動差異
 - **キャッシュ制御**：Pages のほうが Cloudflare CDN との統合が自然
 
-最終的に、お問い合わせフォームは [ssgform.com](https://ssgform.com/) という外部サービスを利用することで、サーバーサイド処理を完全に排除しました。これにより、Worker の必要がなくなり、純粋な静的サイトとして Pages にデプロイできるようになりました。
+最終的に、お問い合わせフォームは [ssgform.com](https://ssgform.com/) という外部サービスを利用することで、フォーム送信のためだけにWorkerを持つ必要をなくしました。この時点では、純粋な静的サイトとして Pages にデプロイできる状態へ戻せました。現在は、コメント機能のように最小限の動的処理だけを Cloudflare Pages Functions で追加しています。
 
 ## \_headers によるセキュリティ設定
 

--- a/src/content/blog/cms-selection-and-turnstile.md
+++ b/src/content/blog/cms-selection-and-turnstile.md
@@ -458,4 +458,4 @@ Sveltia CMSの導入は、`public/admin` に管理画面を置くだけなら簡
 
 どのbranchに保存するのか、誰がOAuthでログインするのか、画像はどこに置くのか、日本語sourceと翻訳をどう分けるのか、CMS commitを後続ワークフローがどう解釈するのか。ここまで決めると、静的サイトの軽さを保ったまま、更新しやすいCMS運用にできます。
 
-問い合わせAIのような動的機能は [AstroサイトにAIチャットを組み込む実装記録](/blog/astro-ai-contact-chat/) に、翻訳PRの自動化は [Sveltia CMSで多言語ブログを運用する方法](/blog/copilot-translation-pipeline/) に分けて整理しています。CMS導入は、その2つの土台になる「コンテンツを安全に更新する仕組み」として考えるのがちょうどよいです。
+問い合わせAIのような動的機能は [AstroサイトにAIチャットを組み込む実装記録](/blog/astro-ai-contact-chat/) に、外部コメントサービスに頼らないCloudflare構成は [CloudflareだけでAstroブログにコメント機能を作る方法](/blog/cloudflare-only-blog-comments/) に、翻訳PRの自動化は [Sveltia CMSで多言語ブログを運用する方法](/blog/copilot-translation-pipeline/) に分けて整理しています。CMS導入は、それらの土台になる「コンテンツを安全に更新する仕組み」として考えるのがちょうどよいです。

--- a/src/content/blog/de/cloudflare-only-blog-comments.md
+++ b/src/content/blog/de/cloudflare-only-blog-comments.md
@@ -1,0 +1,118 @@
+---
+title: 'Astro-Blogkommentare nur mit Cloudflare umsetzen'
+description: 'Wie wir Kommentare in einem Astro-Blog ohne externen Kommentardienst umgesetzt haben: Cloudflare Pages Functions, D1, Turnstile und Wrangler.'
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: Kein externer Kommentardienst
+  text: 'Ein statischer Astro-Blog kann eigene Kommentare haben. Pages Functions bilden die API, D1 speichert die Daten, Turnstile schützt Einreichungen und Wrangler verwaltet die Bindings.'
+linkCards:
+  - href: /de/blog/cloudflare-pages-security/
+    title: Cloudflare Pages Sicherheit
+    description: Sicherheitsheader und statische Auslieferung mit Cloudflare Pages.
+    icon: i-lucide-shield
+  - href: /de/blog/cms-selection-and-turnstile/
+    title: Sveltia CMS Einrichtungsleitfaden
+    description: CMS und Cloudflare-Bausteine der Website.
+    icon: i-lucide-badge-check
+  - href: /de/blog/astro-ai-contact-chat/
+    title: KI-Kontaktchat mit Astro
+    description: Ein weiteres API-Beispiel mit Pages Functions.
+    icon: i-lucide-bot
+faq:
+  title: FAQ
+  items:
+    - question: Warum kein externer Dienst?
+      answer: 'Externe Dienste sind schnell integriert, aber UI, Daten, Scripts, Moderation und Migration hängen vom Dienst ab. Hier bleibt alles in der Website und bei Cloudflare.'
+    - question: Reicht D1 für Kommentare?
+      answer: 'Für post_slug-Abfragen, Sortierung, Soft Delete, Rate Limits und Duplikate passt D1 gut.'
+    - question: Reicht Turnstile im Browser?
+      answer: 'Nein. Die Pages Function muss den Token per Siteverify prüfen, bevor sie in D1 schreibt.'
+---
+
+Kommentare bringen Zustand in eine statische Website.
+
+Acecore hat keinen externen Kommentardienst eingebettet. In [PR #101](https://github.com/acecore-systems/acecore-net/pull/101) wurde die Funktion nur mit Cloudflare umgesetzt.
+
+- Astro rendert die UI.
+- Cloudflare Pages Functions stellt `/api/comments` bereit.
+- Cloudflare D1 speichert Kommentare.
+- Cloudflare Turnstile schützt POST-Anfragen.
+- `wrangler.jsonc` trennt preview und production.
+
+Der Vorteil: Der Kommentarbereich bleibt Teil der bestehenden Cloudflare-Architektur.
+
+## Aufbau
+
+| Ebene      | Datei oder Dienst                          |
+| ---------- | ------------------------------------------ |
+| UI         | `src/components/BlogComments.astro`        |
+| Einbindung | `src/views/BlogPostPage.astro`             |
+| API        | `functions/api/comments.ts`                |
+| Speicher   | D1-Binding `COMMENTS_DB`                   |
+| Schutz     | Cloudflare Turnstile                       |
+| Schema     | `migrations/0001_create_blog_comments.sql` |
+
+Die UI lädt mit `GET /api/comments?slug=...&locale=...` und sendet mit `POST /api/comments`.
+
+Die Function validiert Origin, Payload, Turnstile, Limits, Duplikate und blockierte Inhalte.
+
+## Warum D1
+
+Kommentare brauchen SQL-nahe Operationen: nach Artikel filtern, nach Zeit sortieren, mit `deleted_at` ausblenden, Duplikate finden und Clients begrenzen.
+
+Sichtbar sind nur Zeilen mit `deleted_at IS NULL`. Spam kann so ausgeblendet werden, ohne die Zeile sofort zu löschen.
+
+Prepared Statements mit `bind()` verhindern, dass Benutzereingaben direkt in SQL-Strings landen.
+
+## Wrangler als Vertrag
+
+`COMMENTS_DB` wird in `wrangler.jsonc` definiert. Preview nutzt `acecore-comments-preview`, production nutzt `acecore-comments-production`.
+
+So schreibt eine PR-Preview nicht in die Produktionsdatenbank.
+
+## Turnstile serverseitig prüfen
+
+Das Browser-Widget reicht nicht aus. Die Pages Function validiert den Token über Cloudflare Siteverify mit `TURNSTILE_SECRET_KEY`.
+
+Außerdem wird der zurückgegebene Hostname gegen eine Allowlist geprüft.
+
+## Spam-Schutz
+
+Die erste Version ist bewusst streng:
+
+- keine URLs
+- keine E-Mail-Adressen
+- kein HTML
+- keine Markdown-Links
+- keine langen Wiederholungen
+- keine typischen Werbewörter
+- Honeypot-Feld
+
+Rate Limits laufen im Speicher und zusätzlich persistent über D1. Der Client wird als gesalzener Hash gespeichert, nicht als rohe IP.
+
+## SEO
+
+Kommentare werden clientseitig geladen und der Bereich nutzt `data-pagefind-ignore`. Sie werden also nicht als Hauptinhalt indexiert.
+
+Für einen Unternehmensblog ist diese Trennung sinnvoll.
+
+## Fazit
+
+Externe Kommentardienste sind bequem, aber nicht zwingend.
+
+Mit Cloudflare Pages, Pages Functions, D1, Turnstile und Wrangler lässt sich eine leichte Kommentarfunktion vollständig innerhalb von Cloudflare betreiben.
+
+## Referenzen
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [PR #101: Cloudflare-Kommentare](https://github.com/acecore-systems/acecore-net/pull/101)

--- a/src/content/blog/en/cloudflare-only-blog-comments.md
+++ b/src/content/blog/en/cloudflare-only-blog-comments.md
@@ -1,0 +1,153 @@
+---
+title: 'Build Astro Blog Comments with Cloudflare Only'
+description: 'How we added comments to an Astro blog without an external comment service, using only Cloudflare Pages Functions, D1, Turnstile, and Wrangler configuration.'
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: No external comment service
+  text: 'A static Astro site can still own its comment system. Cloudflare Pages Functions handle the API boundary, D1 stores comments, Turnstile protects submissions, and Wrangler keeps environment bindings reviewable.'
+linkCards:
+  - href: /en/blog/cloudflare-pages-security/
+    title: Cloudflare Pages Security Settings
+    description: 'Security headers and Cloudflare Pages delivery for a static site.'
+    icon: i-lucide-shield
+  - href: /en/blog/cms-selection-and-turnstile/
+    title: Sveltia CMS Setup Guide
+    description: 'How we added Sveltia CMS and related Cloudflare pieces.'
+    icon: i-lucide-badge-check
+  - href: /en/blog/astro-ai-contact-chat/
+    title: AI Contact Chat on Astro
+    description: 'Another Pages Functions API boundary used on the same site.'
+    icon: i-lucide-bot
+faq:
+  title: FAQ
+  items:
+    - question: Why not use an external comment widget?
+      answer: 'External widgets are quick, but UI, data ownership, script loading, moderation, and migration all depend on the service. This implementation keeps those decisions inside the site.'
+    - question: Is D1 enough for comments?
+      answer: 'For post_slug based reads, created_at ordering, duplicate checks, and soft deletion, D1 is a good fit. Larger community features need a broader design.'
+    - question: Is client-side Turnstile enough?
+      answer: 'No. The Pages Function must verify the Turnstile token with Cloudflare Siteverify before writing to D1.'
+---
+
+Static sites usually avoid server-side state. Comments are the moment that rule becomes inconvenient.
+
+For Acecore, we did not add an external comment SaaS or embedded widget. The implementation in [PR #101](https://github.com/acecore-systems/acecore-net/pull/101) keeps the whole feature inside Cloudflare:
+
+- Astro renders the comment UI.
+- Cloudflare Pages Functions expose `/api/comments`.
+- Cloudflare D1 stores comments.
+- Cloudflare Turnstile protects POST requests.
+- `wrangler.jsonc` defines production and preview bindings.
+
+That is the main point: **the comment feature is not a third-party island inside the page**. It uses the same Cloudflare boundary as the rest of the static site.
+
+## Architecture
+
+The implementation has a small surface area.
+
+| Layer          | File or service                            |
+| -------------- | ------------------------------------------ |
+| UI             | `src/components/BlogComments.astro`        |
+| Page placement | `src/views/BlogPostPage.astro`             |
+| API            | `functions/api/comments.ts`                |
+| Storage        | D1 binding `COMMENTS_DB`                   |
+| Bot protection | Cloudflare Turnstile                       |
+| Schema         | `migrations/0001_create_blog_comments.sql` |
+
+The UI fetches comments with `GET /api/comments?slug=...&locale=...` and submits with `POST /api/comments`.
+
+The Pages Function validates origin, payload, Turnstile, rate limits, duplicates, and blocked content before inserting into D1.
+
+## Why D1
+
+Comments are relational enough to benefit from SQL:
+
+- select by `post_slug`
+- order by `created_at`
+- hide rows with `deleted_at`
+- count recent rows by `client_hash`
+- detect duplicate `body_hash` values
+
+The schema stores a soft delete timestamp instead of physically removing rows. That keeps moderation simple: visible comments are rows where `deleted_at IS NULL`.
+
+Cloudflare D1 supports prepared statements from Workers and Pages Functions. Using `prepare(...).bind(...)` keeps comment input out of raw SQL strings.
+
+## Wrangler As The Contract
+
+Bindings are defined in `wrangler.jsonc`.
+
+```jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "COMMENTS_DB",
+      "database_name": "acecore-comments-preview",
+    },
+  ],
+  "env": {
+    "production": {
+      "d1_databases": [
+        {
+          "binding": "COMMENTS_DB",
+          "database_name": "acecore-comments-production",
+        },
+      ],
+    },
+  },
+}
+```
+
+The important part is separating preview and production. A PR preview should never write to the production comments database.
+
+Cloudflare Pages documentation treats Wrangler configuration as the source of truth for a Pages project, which is exactly what we want for reviewable infrastructure changes.
+
+## Turnstile Must Be Verified Server-Side
+
+The widget in the browser is only the beginning. The Pages Function sends the token to Cloudflare Siteverify with the secret key.
+
+It also checks the hostname returned by the verification result. This matters for preview URLs and for preventing tokens from an unexpected hostname from being accepted.
+
+## Spam Controls
+
+The first version is intentionally strict.
+
+It rejects:
+
+- URLs
+- email addresses
+- HTML tags
+- Markdown links
+- repeated-character spam
+- common promotional terms
+- honeypot field submissions
+
+It also applies in-memory rate limits and persistent D1-backed limits. The persistent limit uses a salted hash of IP and User-Agent instead of storing raw values.
+
+## SEO And Search
+
+The comment UI is marked with `data-pagefind-ignore`, and comments are loaded client-side. That means comments are not treated as indexed article content.
+
+For a corporate blog, that is intentional. The article body is reviewed content; comments are interaction. If comments should become searchable content, they need approval and static rendering as a separate design.
+
+## Summary
+
+External comment services are convenient, but they are not the only option.
+
+If a site already runs on Cloudflare Pages, a lightweight comment feature can live entirely inside Cloudflare: Pages Functions for the API, D1 for storage, Turnstile for abuse prevention, and Wrangler for bindings.
+
+That keeps UI, data, security boundaries, and preview/production separation under the same operational model as the site itself.
+
+## References
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [PR #101: Cloudflare comments](https://github.com/acecore-systems/acecore-net/pull/101)

--- a/src/content/blog/es/cloudflare-only-blog-comments.md
+++ b/src/content/blog/es/cloudflare-only-blog-comments.md
@@ -1,0 +1,122 @@
+---
+title: 'Cómo añadir comentarios a un blog Astro usando solo Cloudflare'
+description: 'Implementación de comentarios en un blog Astro sin servicio externo: Cloudflare Pages Functions, D1, Turnstile y configuración con Wrangler.'
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: Sin servicio externo de comentarios
+  text: 'Un sitio Astro estático puede tener comentarios propios. Pages Functions define la API, D1 guarda los datos, Turnstile protege los envíos y Wrangler mantiene los bindings por entorno.'
+linkCards:
+  - href: /es/blog/cloudflare-pages-security/
+    title: Seguridad en Cloudflare Pages
+    description: Headers de seguridad y entrega estática con Cloudflare Pages.
+    icon: i-lucide-shield
+  - href: /es/blog/cms-selection-and-turnstile/
+    title: Guía de instalación de Sveltia CMS
+    description: CMS y piezas de Cloudflare usadas en el sitio.
+    icon: i-lucide-badge-check
+  - href: /es/blog/astro-ai-contact-chat/
+    title: Chat de contacto con IA en Astro
+    description: Otro ejemplo de API con Pages Functions.
+    icon: i-lucide-bot
+faq:
+  title: Preguntas frecuentes
+  items:
+    - question: ¿Por qué no usar un widget externo?
+      answer: 'Porque la UI, los datos, la carga de scripts, la moderación y la migración quedan bajo control del servicio. Aquí todo queda dentro del sitio y Cloudflare.'
+    - question: ¿D1 basta para comentarios?
+      answer: 'Para leer por post_slug, ordenar por created_at, ocultar con deleted_at, limitar por cliente y detectar duplicados, D1 encaja bien.'
+    - question: ¿Turnstile en el cliente es suficiente?
+      answer: 'No. La Function debe validar el token con Siteverify antes de escribir en D1.'
+---
+
+Los sitios estáticos son sencillos hasta que necesitan guardar estado. Un sistema de comentarios es un buen ejemplo.
+
+En Acecore no usamos un servicio externo de comentarios. En [PR #101](https://github.com/acecore-systems/acecore-net/pull/101) lo resolvimos solo con Cloudflare:
+
+- Astro muestra la UI.
+- Cloudflare Pages Functions expone `/api/comments`.
+- Cloudflare D1 guarda los comentarios.
+- Cloudflare Turnstile protege el POST.
+- `wrangler.jsonc` separa preview y production.
+
+La ventaja es que el comentario no queda como una isla de terceros dentro de la página.
+
+## Arquitectura
+
+| Capa                  | Archivo o servicio                         |
+| --------------------- | ------------------------------------------ |
+| UI                    | `src/components/BlogComments.astro`        |
+| Inserción en artículo | `src/views/BlogPostPage.astro`             |
+| API                   | `functions/api/comments.ts`                |
+| Datos                 | D1 binding `COMMENTS_DB`                   |
+| Protección            | Cloudflare Turnstile                       |
+| Schema                | `migrations/0001_create_blog_comments.sql` |
+
+La UI lee con `GET /api/comments?slug=...&locale=...` y publica con `POST /api/comments`.
+
+La Function valida origin, payload, Turnstile, límites, duplicados y contenido bloqueado antes de insertar.
+
+## D1 como almacenamiento
+
+Los comentarios necesitan consultas simples pero relacionales:
+
+- filtrar por `post_slug`
+- ordenar por `created_at`
+- ocultar con `deleted_at`
+- detectar duplicados con `body_hash`
+- limitar por `client_hash`
+
+Por eso D1 es más cómodo que un almacén key-value. Además, las consultas usan prepared statements con `bind()`, evitando concatenar input del usuario en SQL.
+
+## Configuración por Wrangler
+
+El binding `COMMENTS_DB` se define en `wrangler.jsonc`. Preview apunta a `acecore-comments-preview`; production apunta a `acecore-comments-production`.
+
+Esta separación evita que una preview de Pull Request escriba en la base real.
+
+## Turnstile en servidor
+
+El widget del navegador no basta. El token se envía a Pages Functions y allí se valida contra Cloudflare Siteverify con `TURNSTILE_SECRET_KEY`.
+
+También se comprueba el hostname devuelto. Esto es importante para aceptar previews legítimas y rechazar tokens emitidos desde orígenes inesperados.
+
+## Controles anti-spam
+
+La primera versión es estricta:
+
+- rechaza URLs
+- rechaza emails
+- rechaza HTML
+- rechaza enlaces Markdown
+- rechaza texto repetitivo
+- rechaza palabras promocionales
+- usa honeypot
+
+También combina límites en memoria con límites persistentes en D1. El identificador del cliente se guarda como hash con salt, no como IP sin procesar.
+
+## SEO
+
+Los comentarios se cargan en cliente y la sección usa `data-pagefind-ignore`. Por tanto, no se indexan como contenido principal.
+
+Para un blog corporativo, esto es razonable: el artículo es contenido revisado; los comentarios son interacción.
+
+## Resumen
+
+Un servicio externo puede ser práctico, pero si el sitio ya vive en Cloudflare Pages, una función de comentarios ligera puede vivir enteramente en Cloudflare.
+
+Pages Functions, D1, Turnstile y Wrangler son suficientes para mantener UI, datos, seguridad y entornos bajo el mismo modelo operativo.
+
+## Referencias
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [PR #101: Comentarios con Cloudflare](https://github.com/acecore-systems/acecore-net/pull/101)

--- a/src/content/blog/fr/cloudflare-only-blog-comments.md
+++ b/src/content/blog/fr/cloudflare-only-blog-comments.md
@@ -1,0 +1,122 @@
+---
+title: 'Ajouter des commentaires à un blog Astro avec Cloudflare uniquement'
+description: "Retour d'expérience sur l'ajout de commentaires à un blog Astro sans service externe, avec Cloudflare Pages Functions, D1, Turnstile et Wrangler."
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: Sans service externe de commentaires
+  text: "Un site Astro statique peut gérer ses propres commentaires. Pages Functions fournit l'API, D1 stocke les données, Turnstile protège les envois et Wrangler versionne les bindings."
+linkCards:
+  - href: /fr/blog/cloudflare-pages-security/
+    title: Sécurité avec Cloudflare Pages
+    description: Headers de sécurité et diffusion statique avec Cloudflare Pages.
+    icon: i-lucide-shield
+  - href: /fr/blog/cms-selection-and-turnstile/
+    title: Guide d'installation de Sveltia CMS
+    description: CMS et composants Cloudflare utilisés sur le site.
+    icon: i-lucide-badge-check
+  - href: /fr/blog/astro-ai-contact-chat/
+    title: Chat de contact IA sur Astro
+    description: Un autre exemple d'API avec Pages Functions.
+    icon: i-lucide-bot
+faq:
+  title: Questions fréquentes
+  items:
+    - question: Pourquoi ne pas utiliser un widget externe ?
+      answer: "Parce que l'UI, les données, les scripts, la modération et la migration dépendent alors du service. Ici, tout reste dans le site et Cloudflare."
+    - question: D1 suffit-il pour des commentaires ?
+      answer: 'Pour lire par post_slug, trier par date, masquer avec deleted_at, limiter par client et détecter les doublons, D1 convient bien.'
+    - question: Turnstile côté client suffit-il ?
+      answer: "Non. La Pages Function doit vérifier le token avec Siteverify avant d'écrire dans D1."
+---
+
+Ajouter des commentaires à un site statique revient à ajouter de l'état.
+
+Pour Acecore, nous n'avons pas utilisé de service externe de commentaires. Dans [PR #101](https://github.com/acecore-systems/acecore-net/pull/101), la fonctionnalité reste entièrement sur Cloudflare.
+
+- Astro affiche l'interface.
+- Cloudflare Pages Functions expose `/api/comments`.
+- Cloudflare D1 stocke les commentaires.
+- Cloudflare Turnstile protège les envois.
+- `wrangler.jsonc` sépare preview et production.
+
+Le point fort est clair : la zone de commentaires n'est pas un îlot tiers dans la page.
+
+## Architecture
+
+| Couche     | Fichier ou service                         |
+| ---------- | ------------------------------------------ |
+| UI         | `src/components/BlogComments.astro`        |
+| Placement  | `src/views/BlogPostPage.astro`             |
+| API        | `functions/api/comments.ts`                |
+| Stockage   | Binding D1 `COMMENTS_DB`                   |
+| Protection | Cloudflare Turnstile                       |
+| Schéma     | `migrations/0001_create_blog_comments.sql` |
+
+L'interface lit avec `GET /api/comments?slug=...&locale=...` et publie avec `POST /api/comments`.
+
+La Function valide origin, payload, Turnstile, limites, doublons et contenu bloqué avant insertion.
+
+## Pourquoi D1
+
+Les commentaires demandent des requêtes simples mais relationnelles : filtrer par article, trier par date, masquer avec `deleted_at`, limiter par client et détecter les doublons.
+
+D1 permet de le faire en SQL. Les lignes visibles sont celles où `deleted_at IS NULL`.
+
+Les requêtes passent par des prepared statements et `bind()`, sans concaténer les entrées utilisateur dans le SQL.
+
+## Wrangler comme contrat
+
+Le binding `COMMENTS_DB` est défini dans `wrangler.jsonc`. Preview pointe vers `acecore-comments-preview`; production vers `acecore-comments-production`.
+
+C'est important : une preview de Pull Request ne doit pas écrire dans la base de production.
+
+La documentation Cloudflare Pages indique aussi que la configuration Wrangler devient la source de vérité du projet Pages.
+
+## Turnstile côté serveur
+
+Le widget visible dans le navigateur ne suffit pas.
+
+Le token est envoyé à la Pages Function, puis validé via Cloudflare Siteverify avec `TURNSTILE_SECRET_KEY`.
+
+Le hostname retourné est également vérifié pour éviter d'accepter un token émis depuis un domaine inattendu.
+
+## Anti-spam
+
+La première version est stricte :
+
+- pas d'URL
+- pas d'adresse e-mail
+- pas de HTML
+- pas de lien Markdown
+- pas de répétitions excessives
+- pas de termes promotionnels courants
+- champ honeypot
+
+Le rate limit existe en mémoire et dans D1. Le client est identifié par un hash salé, pas par une IP brute stockée telle quelle.
+
+## SEO
+
+Les commentaires sont chargés côté client et la section utilise `data-pagefind-ignore`. Ils ne sont pas indexés comme contenu principal.
+
+Pour un blog d'entreprise, c'est un choix sain : l'article est éditorial, les commentaires sont interactifs.
+
+## Résumé
+
+Un service externe de commentaires est pratique, mais pas obligatoire.
+
+Avec Cloudflare Pages, Pages Functions, D1, Turnstile et Wrangler suffisent pour une fonctionnalité légère et maîtrisée.
+
+## Références
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [PR #101: Commentaires avec Cloudflare](https://github.com/acecore-systems/acecore-net/pull/101)

--- a/src/content/blog/ko/cloudflare-only-blog-comments.md
+++ b/src/content/blog/ko/cloudflare-only-blog-comments.md
@@ -1,0 +1,118 @@
+---
+title: 'Cloudflare만으로 Astro 블로그 댓글 기능 만들기'
+description: '외부 댓글 서비스를 쓰지 않고 Cloudflare Pages Functions, D1, Turnstile, Wrangler 설정만으로 Astro 블로그 댓글 기능을 구현한 기록입니다.'
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: 외부 댓글 서비스 없이 구현
+  text: 'Astro 정적 사이트도 자체 댓글 기능을 가질 수 있습니다. Pages Functions가 API 경계를 만들고, D1이 데이터를 저장하고, Turnstile이 제출을 보호하며, Wrangler가 환경별 binding을 관리합니다.'
+linkCards:
+  - href: /ko/blog/cloudflare-pages-security/
+    title: Cloudflare Pages 보안 설정
+    description: 정적 사이트 배포와 보안 header 설정입니다.
+    icon: i-lucide-shield
+  - href: /ko/blog/cms-selection-and-turnstile/
+    title: Sveltia CMS 도입 가이드
+    description: CMS와 Cloudflare 구성 요소를 다룬 글입니다.
+    icon: i-lucide-badge-check
+  - href: /ko/blog/astro-ai-contact-chat/
+    title: Astro 문의 AI 채팅
+    description: Pages Functions로 API 경계를 만든 다른 예시입니다.
+    icon: i-lucide-bot
+faq:
+  title: 자주 묻는 질문
+  items:
+    - question: 왜 외부 댓글 서비스를 쓰지 않았나요?
+      answer: '외부 서비스는 빠르지만 UI, 데이터, script 로딩, 삭제와 이전이 서비스에 의존합니다. 이번 구현은 사이트와 Cloudflare 안에 통제권을 둡니다.'
+    - question: D1로 충분한가요?
+      answer: 'post_slug 조회, created_at 정렬, deleted_at soft delete, 중복 검사, rate limit에는 D1이 잘 맞습니다.'
+    - question: Turnstile을 프런트에만 두면 되나요?
+      answer: '아니요. Pages Function에서 Siteverify로 token을 검증한 뒤 D1에 저장해야 합니다.'
+---
+
+정적 사이트에 댓글을 넣으면 상태 저장과 spam 대책이 필요해집니다.
+
+Acecore는 외부 댓글 SaaS나 widget을 쓰지 않았습니다. [PR #101](https://github.com/acecore-systems/acecore-net/pull/101)에서 Cloudflare 안의 기능만으로 구현했습니다.
+
+- Astro가 UI를 렌더링합니다.
+- Cloudflare Pages Functions가 `/api/comments`를 제공합니다.
+- Cloudflare D1이 댓글을 저장합니다.
+- Cloudflare Turnstile이 POST를 보호합니다.
+- `wrangler.jsonc`가 preview와 production을 나눕니다.
+
+핵심은 댓글 영역이 페이지 안의 외부 서비스가 아니라, 기존 Cloudflare 구성의 일부라는 점입니다.
+
+## 구조
+
+| 계층      | 파일 또는 서비스                           |
+| --------- | ------------------------------------------ |
+| UI        | `src/components/BlogComments.astro`        |
+| 기사 배치 | `src/views/BlogPostPage.astro`             |
+| API       | `functions/api/comments.ts`                |
+| 저장소    | D1 binding `COMMENTS_DB`                   |
+| 보호      | Cloudflare Turnstile                       |
+| schema    | `migrations/0001_create_blog_comments.sql` |
+
+UI는 `GET /api/comments?slug=...&locale=...`로 읽고, `POST /api/comments`로 제출합니다.
+
+Function은 origin, payload, Turnstile, rate limit, 중복, 금지 내용을 검증한 뒤 저장합니다.
+
+## D1을 선택한 이유
+
+댓글은 기사별 조회, 시간순 정렬, soft delete, 중복 검사, client별 제한이 필요합니다. SQL로 표현하기 쉬운 작업입니다.
+
+보이는 댓글은 `deleted_at IS NULL`인 행입니다. spam은 물리 삭제하지 않고 `deleted_at`만 채워 숨길 수 있습니다.
+
+쿼리는 prepared statement와 `bind()`를 사용해 사용자 입력을 SQL 문자열에 직접 붙이지 않습니다.
+
+## Wrangler로 환경을 나누기
+
+`COMMENTS_DB`는 `wrangler.jsonc`에 정의합니다. preview는 `acecore-comments-preview`, production은 `acecore-comments-production`을 사용합니다.
+
+PR preview가 production DB에 쓰지 않도록 하는 것이 중요합니다.
+
+## Turnstile은 서버에서 검증
+
+브라우저의 widget만으로는 부족합니다.
+
+Pages Function이 token을 Cloudflare Siteverify로 보내고, 성공한 경우에만 저장합니다. 반환된 hostname도 allowlist와 비교합니다.
+
+## spam 대책
+
+첫 버전은 엄격합니다.
+
+- URL 금지
+- 이메일 주소 금지
+- HTML 금지
+- Markdown 링크 금지
+- 과도한 반복 문자 금지
+- 홍보성 단어 금지
+- honeypot 사용
+
+또한 메모리 rate limit과 D1 기반 rate limit을 함께 둡니다. IP는 원문 저장 대신 salt를 섞은 hash로 사용합니다.
+
+## SEO
+
+댓글은 클라이언트에서 읽고, 영역에는 `data-pagefind-ignore`를 붙였습니다. 따라서 댓글은 본문 검색 index에 들어가지 않습니다.
+
+기업 블로그에서는 본문과 댓글의 역할을 분리하는 편이 안전합니다.
+
+## 정리
+
+외부 댓글 서비스는 편하지만 필수는 아닙니다.
+
+Cloudflare Pages를 쓰는 사이트라면 Pages Functions, D1, Turnstile, Wrangler만으로 가벼운 댓글 기능을 만들 수 있습니다.
+
+## 참고
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [PR #101: Cloudflare 댓글 기능](https://github.com/acecore-systems/acecore-net/pull/101)

--- a/src/content/blog/pt/cloudflare-only-blog-comments.md
+++ b/src/content/blog/pt/cloudflare-only-blog-comments.md
@@ -1,0 +1,118 @@
+---
+title: 'Como adicionar comentários a um blog Astro usando apenas Cloudflare'
+description: 'Como implementamos comentários em um blog Astro sem serviço externo, usando Cloudflare Pages Functions, D1, Turnstile e configuração Wrangler.'
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: Sem serviço externo de comentários
+  text: 'Um site Astro estático pode ter comentários próprios. Pages Functions cuida da API, D1 armazena os dados, Turnstile protege envios e Wrangler mantém os bindings por ambiente.'
+linkCards:
+  - href: /pt/blog/cloudflare-pages-security/
+    title: Segurança no Cloudflare Pages
+    description: Headers de segurança e entrega estática no Cloudflare Pages.
+    icon: i-lucide-shield
+  - href: /pt/blog/cms-selection-and-turnstile/
+    title: Guia de instalação do Sveltia CMS
+    description: CMS e componentes Cloudflare usados no site.
+    icon: i-lucide-badge-check
+  - href: /pt/blog/astro-ai-contact-chat/
+    title: Chat de contato com IA no Astro
+    description: Outro exemplo de API com Pages Functions.
+    icon: i-lucide-bot
+faq:
+  title: Perguntas frequentes
+  items:
+    - question: Por que não usar comentários externos?
+      answer: 'Serviços externos são rápidos, mas UI, dados, scripts, moderação e migração ficam dependentes deles. Aqui tudo fica no site e no Cloudflare.'
+    - question: D1 é suficiente?
+      answer: 'Para comentários por post_slug, ordenação por data, soft delete, rate limit e duplicados, D1 funciona bem.'
+    - question: Turnstile só no cliente basta?
+      answer: 'Não. A Pages Function precisa validar o token no Siteverify antes de gravar no D1.'
+---
+
+Comentários adicionam estado a um site estático. Por isso, muita gente usa widgets externos.
+
+No Acecore, escolhemos outro caminho: em [PR #101](https://github.com/acecore-systems/acecore-net/pull/101), implementamos a função apenas com Cloudflare.
+
+- Astro renderiza a interface.
+- Cloudflare Pages Functions expõe `/api/comments`.
+- Cloudflare D1 armazena comentários.
+- Cloudflare Turnstile protege o envio.
+- `wrangler.jsonc` separa preview e production.
+
+O ponto principal é que a área de comentários não vira uma dependência externa dentro da página.
+
+## Arquitetura
+
+| Camada   | Arquivo ou serviço                         |
+| -------- | ------------------------------------------ |
+| UI       | `src/components/BlogComments.astro`        |
+| Artigo   | `src/views/BlogPostPage.astro`             |
+| API      | `functions/api/comments.ts`                |
+| Banco    | D1 binding `COMMENTS_DB`                   |
+| Proteção | Cloudflare Turnstile                       |
+| Schema   | `migrations/0001_create_blog_comments.sql` |
+
+A UI lê com `GET /api/comments?slug=...&locale=...` e envia com `POST /api/comments`.
+
+A Function valida origin, payload, Turnstile, limites, duplicados e conteúdo bloqueado antes de inserir.
+
+## Por que D1
+
+Comentários precisam de consultas por artigo, ordenação por data, soft delete, duplicidade e rate limit por cliente. SQL deixa isso simples.
+
+Os comentários visíveis são `deleted_at IS NULL`. Para ocultar spam, basta preencher `deleted_at`, sem apagar fisicamente a linha.
+
+As queries usam prepared statements com `bind()`, evitando concatenar input de usuário no SQL.
+
+## Wrangler e ambientes
+
+`COMMENTS_DB` fica em `wrangler.jsonc`. Preview aponta para `acecore-comments-preview`; production aponta para `acecore-comments-production`.
+
+Isso evita que uma preview de PR grave dados reais de produção.
+
+## Turnstile no servidor
+
+O widget no browser não é suficiente. A Function envia o token para o Cloudflare Siteverify usando `TURNSTILE_SECRET_KEY`.
+
+Também validamos o hostname retornado, para aceitar apenas domínios esperados e previews autorizadas.
+
+## Anti-spam
+
+A primeira versão é restrita:
+
+- sem URLs
+- sem emails
+- sem HTML
+- sem links Markdown
+- sem caracteres repetidos em excesso
+- sem termos promocionais comuns
+- honeypot no formulário
+
+Também há rate limit em memória e rate limit persistente em D1 com `client_hash`. O hash usa salt; o IP bruto não precisa ser armazenado.
+
+## SEO
+
+Comentários são carregados no cliente e a área usa `data-pagefind-ignore`. Eles não entram no índice como conteúdo principal.
+
+Para um blog corporativo, isso separa conteúdo editorial revisado de interação dos visitantes.
+
+## Resumo
+
+Serviços externos de comentários são úteis, mas não obrigatórios.
+
+Se o site já roda em Cloudflare Pages, Pages Functions + D1 + Turnstile + Wrangler formam uma base suficiente para comentários leves, com UI, dados e segurança sob o mesmo modelo operacional.
+
+## Referências
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [PR #101: Comentários com Cloudflare](https://github.com/acecore-systems/acecore-net/pull/101)

--- a/src/content/blog/ru/cloudflare-only-blog-comments.md
+++ b/src/content/blog/ru/cloudflare-only-blog-comments.md
@@ -1,0 +1,118 @@
+---
+title: 'Как добавить комментарии в Astro-блог только на Cloudflare'
+description: 'Как мы добавили комментарии в Astro-блог без внешнего сервиса: Cloudflare Pages Functions, D1, Turnstile и конфигурация Wrangler.'
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: Без внешнего сервиса комментариев
+  text: 'Статический Astro-сайт может иметь собственные комментарии. Pages Functions дает API, D1 хранит данные, Turnstile защищает отправку, а Wrangler управляет bindings.'
+linkCards:
+  - href: /ru/blog/cloudflare-pages-security/
+    title: Безопасность Cloudflare Pages
+    description: Заголовки безопасности и статическая доставка через Cloudflare Pages.
+    icon: i-lucide-shield
+  - href: /ru/blog/cms-selection-and-turnstile/
+    title: Руководство по внедрению Sveltia CMS
+    description: CMS и компоненты Cloudflare на сайте.
+    icon: i-lucide-badge-check
+  - href: /ru/blog/astro-ai-contact-chat/
+    title: AI-чат для контактов на Astro
+    description: Другой пример API на Pages Functions.
+    icon: i-lucide-bot
+faq:
+  title: Вопросы
+  items:
+    - question: Почему не внешний виджет?
+      answer: 'Внешний сервис быстро подключается, но UI, данные, скрипты, модерация и миграция зависят от него. Здесь все остается в сайте и Cloudflare.'
+    - question: Достаточно ли D1?
+      answer: 'Для выборки по post_slug, сортировки, soft delete, rate limit и дубликатов D1 хорошо подходит.'
+    - question: Достаточно ли Turnstile в браузере?
+      answer: 'Нет. Pages Function должна проверить token через Siteverify перед записью в D1.'
+---
+
+Комментарии добавляют состояние в статический сайт.
+
+Acecore не стал подключать внешний сервис комментариев. В [PR #101](https://github.com/acecore-systems/acecore-net/pull/101) функция реализована только на Cloudflare.
+
+- Astro показывает UI.
+- Cloudflare Pages Functions предоставляет `/api/comments`.
+- Cloudflare D1 хранит комментарии.
+- Cloudflare Turnstile защищает POST.
+- `wrangler.jsonc` разделяет preview и production.
+
+Главное преимущество: комментарии не становятся сторонним виджетом внутри страницы.
+
+## Архитектура
+
+| Слой             | Файл или сервис                            |
+| ---------------- | ------------------------------------------ |
+| UI               | `src/components/BlogComments.astro`        |
+| Вставка в статью | `src/views/BlogPostPage.astro`             |
+| API              | `functions/api/comments.ts`                |
+| Хранилище        | D1 binding `COMMENTS_DB`                   |
+| Защита           | Cloudflare Turnstile                       |
+| Schema           | `migrations/0001_create_blog_comments.sql` |
+
+UI читает через `GET /api/comments?slug=...&locale=...` и отправляет через `POST /api/comments`.
+
+Function проверяет origin, payload, Turnstile, лимиты, дубликаты и запрещенный контент.
+
+## Почему D1
+
+Комментарии удобно хранить в SQL: фильтр по статье, сортировка по времени, soft delete через `deleted_at`, дубликаты через `body_hash`, лимиты через `client_hash`.
+
+Видимые строки имеют `deleted_at IS NULL`. Spam можно скрыть без физического удаления.
+
+Запросы используют prepared statements и `bind()`, поэтому пользовательский ввод не склеивается с SQL.
+
+## Wrangler и окружения
+
+`COMMENTS_DB` задается в `wrangler.jsonc`. Preview пишет в `acecore-comments-preview`, production — в `acecore-comments-production`.
+
+Это защищает production от случайных записей из PR preview.
+
+## Turnstile на сервере
+
+Widget в браузере недостаточен.
+
+Pages Function отправляет token в Cloudflare Siteverify с `TURNSTILE_SECRET_KEY`, а также проверяет hostname из результата.
+
+## Anti-spam
+
+Первая версия строгая:
+
+- без URL
+- без email
+- без HTML
+- без Markdown-ссылок
+- без длинных повторов
+- без рекламных слов
+- honeypot поле
+
+Rate limit есть в памяти и в D1. IP не сохраняется напрямую; используется salted hash.
+
+## SEO
+
+Комментарии загружаются на клиенте, а блок помечен `data-pagefind-ignore`. Они не индексируются как основной текст статьи.
+
+Для корпоративного блога это безопаснее: статья — редакционный контент, комментарии — взаимодействие.
+
+## Итог
+
+Внешний сервис комментариев удобен, но не обязателен.
+
+Если сайт уже работает на Cloudflare Pages, Pages Functions + D1 + Turnstile + Wrangler достаточно для легкой системы комментариев.
+
+## Ссылки
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [PR #101: комментарии на Cloudflare](https://github.com/acecore-systems/acecore-net/pull/101)

--- a/src/content/blog/zh-cn/cloudflare-only-blog-comments.md
+++ b/src/content/blog/zh-cn/cloudflare-only-blog-comments.md
@@ -1,0 +1,128 @@
+---
+title: '只用 Cloudflare 为 Astro 博客添加评论功能'
+description: '不依赖外部评论服务，只使用 Cloudflare Pages Functions、D1、Turnstile 和 Wrangler 配置，为 Astro 博客实现评论功能的实践记录。'
+date: 2026-06-07T18:00
+lastUpdated: 2026-06-07
+author: gui
+tags: ['技術', 'Cloudflare', 'Astro', 'セキュリティ', 'Webサイト']
+image: /uploads/acecore-generated/blog-cloudflare-pages-security.webp
+callout:
+  type: tip
+  title: 不使用外部评论服务
+  text: 'Astro 静态网站也可以拥有自己的评论系统。Pages Functions 负责 API 边界，D1 保存评论，Turnstile 防止 bot 投稿，Wrangler 管理环境绑定。'
+linkCards:
+  - href: /zh-cn/blog/cloudflare-pages-security/
+    title: Cloudflare Pages 安全设置
+    description: 静态网站的安全 header 与 Cloudflare Pages 配信设计。
+    icon: i-lucide-shield
+  - href: /zh-cn/blog/cms-selection-and-turnstile/
+    title: Sveltia CMS 导入指南
+    description: Sveltia CMS 与 Cloudflare 相关配置的实现记录。
+    icon: i-lucide-badge-check
+  - href: /zh-cn/blog/astro-ai-contact-chat/
+    title: Astro 网站的 AI 咨询聊天
+    description: 同样使用 Pages Functions 作为 API 边界的实现例。
+    icon: i-lucide-bot
+faq:
+  title: 常见问题
+  items:
+    - question: 为什么不用外部评论服务？
+      answer: '外部服务导入很快，但 UI、数据保存、脚本加载、删除和迁移都会依赖服务方。这个实现把控制权留在网站和 Cloudflare 内。'
+    - question: D1 适合保存评论吗？
+      answer: '按 post_slug 查询、按 created_at 排序、soft delete、重复检测和速率限制都很适合用 D1 处理。'
+    - question: 只在前端放 Turnstile 可以吗？
+      answer: '不可以。Pages Function 必须把 token 发送到 Cloudflare Siteverify，并在验证成功后再写入 D1。'
+---
+
+静态网站一旦需要评论功能，就会遇到状态保存和防 spam 的问题。
+
+Acecore 没有引入外部评论 SaaS 或嵌入式 widget，而是在 [PR #101](https://github.com/acecore-systems/acecore-net/pull/101) 中用 Cloudflare 内的组件完成了实现。
+
+- Astro 显示评论 UI
+- Cloudflare Pages Functions 提供 `/api/comments`
+- Cloudflare D1 保存评论
+- Cloudflare Turnstile 保护投稿
+- `wrangler.jsonc` 区分 preview 和 production
+
+重点是：评论栏不是页面里的第三方孤岛，而是站点现有 Cloudflare 架构的一部分。
+
+## 结构
+
+实现范围很小。
+
+| 层       | 文件或服务                                 |
+| -------- | ------------------------------------------ |
+| UI       | `src/components/BlogComments.astro`        |
+| 页面位置 | `src/views/BlogPostPage.astro`             |
+| API      | `functions/api/comments.ts`                |
+| 保存     | D1 binding `COMMENTS_DB`                   |
+| bot 对策 | Cloudflare Turnstile                       |
+| schema   | `migrations/0001_create_blog_comments.sql` |
+
+UI 通过 `GET /api/comments?slug=...&locale=...` 读取评论，并通过 `POST /api/comments` 投稿。
+
+Pages Function 在写入前验证 origin、payload、Turnstile、rate limit、重复投稿和禁止内容。
+
+## 为什么使用 D1
+
+评论数据需要按文章查询、按时间排序、soft delete、重复检测和限流统计。D1 可以用 SQL 很直接地表达这些操作。
+
+显示时只取 `deleted_at IS NULL` 的行。遇到 spam 时，不需要物理删除，只要给 `deleted_at` 写入时间即可隐藏。
+
+查询使用 `prepare(...).bind(...)`，避免把用户输入直接拼接到 SQL 里。
+
+## Wrangler 管理绑定
+
+`wrangler.jsonc` 中定义 `COMMENTS_DB`。
+
+preview 使用 `acecore-comments-preview`，production 使用 `acecore-comments-production`。这样 PR preview 不会误写 production 数据库。
+
+Cloudflare Pages 文档也说明，使用 Wrangler 配置时，它会成为 Pages project configuration 的 source of truth。
+
+## Turnstile 必须服务端验证
+
+前端显示 Turnstile widget 只是第一步。
+
+投稿时，Pages Function 会把 token 和 secret key 发送到 Cloudflare Siteverify API。验证结果成功后，才进入保存流程。
+
+实现还会检查 Siteverify 返回的 hostname 是否在 allowlist 中。Cloudflare 的 Any Hostname 文档也要求在 server-side code 中验证 hostname。
+
+## spam 对策
+
+第一版故意保持严格。
+
+拒绝的内容包括：
+
+- URL
+- 邮箱地址
+- HTML 标签
+- Markdown 链接
+- 过度重复字符
+- 常见宣传词
+- honeypot 字段
+
+限流也分两层：内存中的短期限流，以及 D1 中基于 `client_hash` 的持久限流。`client_hash` 使用 salt 后的 SHA-256，不保存原始 IP。
+
+## SEO 与搜索
+
+评论区域标记为 `data-pagefind-ignore`，评论内容通过客户端读取。因此评论不会成为文章正文的一部分，也不会进入 Pagefind 索引。
+
+企业博客中，正文是审核过的内容，评论是互动内容。两者分开管理更安全。
+
+## 总结
+
+外部评论服务很方便，但不是唯一选择。
+
+如果网站已经运行在 Cloudflare Pages 上，那么 Pages Functions、D1、Turnstile 和 Wrangler 就足以构成一个轻量评论系统。
+
+这样可以把 UI、数据、preview/production 分离和安全边界都放在同一个 Cloudflare 运维模型中。
+
+## 参考
+
+- [Cloudflare Pages: Configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
+- [Cloudflare Pages Functions: Bindings](https://developers.cloudflare.com/pages/functions/bindings/)
+- [Cloudflare D1: Prepared statement methods](https://developers.cloudflare.com/d1/worker-api/prepared-statements/)
+- [Cloudflare D1: Wrangler commands](https://developers.cloudflare.com/d1/wrangler-commands/)
+- [Cloudflare Turnstile: Server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Cloudflare Turnstile: Any Hostname](https://developers.cloudflare.com/turnstile/additional-configuration/hostname-management/any-hostname/)
+- [PR #101: Cloudflare 评论功能](https://github.com/acecore-systems/acecore-net/pull/101)


### PR DESCRIPTION
## 関連 Issue

なし

## 概要

外部コメントサービスに頼らず、Cloudflare Pages Functions、D1、Turnstile、Wrangler設定だけでAstroブログにコメント機能を組み込む実装記事を追加しました。

## 主な変更点

- 日本語記事 `CloudflareだけでAstroブログにコメント機能を作る方法` を追加
- 英語、簡体字中国語、スペイン語、ポルトガル語、フランス語、韓国語、ドイツ語、ロシア語の記事を追加
- Pages Functions、D1 schema、prepared statement、Wrangler binding、preview/production DB分離、Turnstile server-side validation、Origin/hostname allowlist、rate limit、重複投稿検知、Pagefind除外の観点を記事内で整理
- 関連する既存記事から新記事へ内部リンクを追加

## 確認したこと

- `npx prettier --write src/content/blog/cloudflare-only-blog-comments.md src/content/blog/en/cloudflare-only-blog-comments.md src/content/blog/zh-cn/cloudflare-only-blog-comments.md src/content/blog/es/cloudflare-only-blog-comments.md src/content/blog/pt/cloudflare-only-blog-comments.md src/content/blog/fr/cloudflare-only-blog-comments.md src/content/blog/ko/cloudflare-only-blog-comments.md src/content/blog/de/cloudflare-only-blog-comments.md src/content/blog/ru/cloudflare-only-blog-comments.md src/content/blog/cloudflare-pages-security.md src/content/blog/cms-selection-and-turnstile.md src/content/blog/astro-ai-contact-chat.md`
- `npx prettier --check src/content/blog/cloudflare-only-blog-comments.md src/content/blog/en/cloudflare-only-blog-comments.md src/content/blog/zh-cn/cloudflare-only-blog-comments.md src/content/blog/es/cloudflare-only-blog-comments.md src/content/blog/pt/cloudflare-only-blog-comments.md src/content/blog/fr/cloudflare-only-blog-comments.md src/content/blog/ko/cloudflare-only-blog-comments.md src/content/blog/de/cloudflare-only-blog-comments.md src/content/blog/ru/cloudflare-only-blog-comments.md src/content/blog/cloudflare-pages-security.md src/content/blog/cms-selection-and-turnstile.md src/content/blog/astro-ai-contact-chat.md`
- `git diff --check`
- `npm run build`
- `rg -l "CloudflareだけでAstroブログにコメント機能を作る方法" dist/blog/index.html dist/blog/tags/Cloudflare/index.html dist/rss.xml`
- `rg -n "Build Astro Blog Comments with Cloudflare Only" dist/en/blog/cloudflare-only-blog-comments/index.html`
- `rg -n "^title:" src/content/blog/zh-cn/cloudflare-only-blog-comments.md src/content/blog/es/cloudflare-only-blog-comments.md src/content/blog/de/cloudflare-only-blog-comments.md`
- `rg -n "Cloudflare" dist/zh-cn/blog/cloudflare-only-blog-comments/index.html`
- `rg -n "href: /blog/" src/content/blog/en/cloudflare-only-blog-comments.md src/content/blog/zh-cn/cloudflare-only-blog-comments.md src/content/blog/es/cloudflare-only-blog-comments.md src/content/blog/pt/cloudflare-only-blog-comments.md src/content/blog/fr/cloudflare-only-blog-comments.md src/content/blog/ko/cloudflare-only-blog-comments.md src/content/blog/de/cloudflare-only-blog-comments.md src/content/blog/ru/cloudflare-only-blog-comments.md`（該当なしを確認）

## 未確認事項・補足

- ブラウザでの目視確認は未実施です。生成HTML上のブログ一覧、Cloudflareタグ、RSS、英語・中国語記事ページは確認済みです。
- `npm run build` は初回、記事内の `processFigure.steps[].accent` に未定義値 `sky` があり失敗しました。`slate` に修正後、再実行して成功しています。
- Prettier/buildはVoltaのユーザーディレクトリ利用により権限付きで実行しました。