### PR TITLE
[codex] 細かい機能料金を表形式に整理

### DIFF
--- a/src/views/PricingPage.astro
+++ b/src/views/PricingPage.astro
@@ -48,6 +48,12 @@ const pricingItems = getList<PricingItem>('pages.pricing.items').map(
     href: resolvePricingHref(item.href),
   }),
 )
+const featurePricingItems = pricingItems.filter((item) =>
+  item.href.includes('/blog/'),
+)
+const servicePricingItems = pricingItems.filter(
+  (item) => !item.href.includes('/blog/'),
+)
 
 const schoolFees = getList<SchoolFee>('pages.pricing.schoolFees')
 const costFactors = getList<string>('pages.pricing.factors')
@@ -111,7 +117,7 @@ const pricingLd = {
 
       <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {
-          pricingItems.map((item) => (
+          servicePricingItems.map((item) => (
             <a
               href={item.href}
               class="ac-surface group flex h-full flex-col p-6 no-underline transition hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-lg"
@@ -134,6 +140,65 @@ const pricingLd = {
           ))
         }
       </div>
+
+      {
+        featurePricingItems.length > 0 && (
+          <div class="mt-8 overflow-x-auto rounded-lg border border-slate-200">
+            <table class="w-full min-w-220 border-collapse text-left text-sm">
+              <thead class="bg-slate-50 text-slate-900">
+                <tr>
+                  <th class="border-b border-slate-200 px-4 py-3 font-700">
+                    {t(locale, 'pages.pricing.feeItem')}
+                  </th>
+                  <th class="border-b border-slate-200 px-4 py-3 font-700">
+                    {t(locale, 'pages.pricing.feeAmount')}
+                  </th>
+                  <th class="border-b border-slate-200 px-4 py-3 font-700">
+                    {t(locale, 'pages.pricing.feeNote')}
+                  </th>
+                  <th class="border-b border-slate-200 px-4 py-3 font-700">
+                    {t(locale, 'pages.pricing.detailLink')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {featurePricingItems.map((item) => (
+                  <tr class="align-top transition hover:bg-brand-50/50">
+                    <th class="border-b border-slate-100 px-4 py-4 font-700 text-slate-900">
+                      <a
+                        href={item.href}
+                        class="group inline-flex items-center gap-3 no-underline"
+                      >
+                        <span class="ac-icon-box shrink-0">
+                          <Icon name={item.icon} class="text-base" />
+                        </span>
+                        <span class="transition group-hover:text-brand-600">
+                          {item.title}
+                        </span>
+                      </a>
+                    </th>
+                    <td class="border-b border-slate-100 px-4 py-4 font-800 text-brand-700">
+                      {item.price}
+                    </td>
+                    <td class="border-b border-slate-100 px-4 py-4 leading-relaxed text-slate-600">
+                      {item.body}
+                    </td>
+                    <td class="border-b border-slate-100 px-4 py-4">
+                      <a
+                        href={item.href}
+                        class="inline-flex items-center gap-1 font-700 text-brand-600 no-underline hover:underline"
+                      >
+                        {t(locale, 'pages.pricing.detailLink')}
+                        <Icon name="arrow-right" class="text-xs" />
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      }
 
       <div id="schools" class="mt-14 scroll-mt-24">
         <div class="mb-6">

--- a/src/views/PricingPage.astro
+++ b/src/views/PricingPage.astro
@@ -48,12 +48,27 @@ const pricingItems = getList<PricingItem>('pages.pricing.items').map(
     href: resolvePricingHref(item.href),
   }),
 )
+const isBlogPricingHref = (href: string) => href.includes('/blog/')
+const isWebPricingHref = (href: string) => href.includes('/services/#web')
+const webBasePricingItem = pricingItems.find((item) =>
+  isWebPricingHref(item.href),
+)
 const featurePricingItems = pricingItems.filter((item) =>
-  item.href.includes('/blog/'),
+  isBlogPricingHref(item.href),
 )
+const webPricingItems = [
+  ...(webBasePricingItem ? [webBasePricingItem] : []),
+  ...featurePricingItems,
+]
 const servicePricingItems = pricingItems.filter(
-  (item) => !item.href.includes('/blog/'),
+  (item) => !isBlogPricingHref(item.href) && !isWebPricingHref(item.href),
 )
+const webPricingTableTitle = webBasePricingItem
+  ? `${webBasePricingItem.title} / ${t(
+      locale,
+      'pages.services.web.featureLinksTitle',
+    )}`
+  : t(locale, 'pages.services.web.featureLinksTitle')
 
 const schoolFees = getList<SchoolFee>('pages.pricing.schoolFees')
 const costFactors = getList<string>('pages.pricing.factors')
@@ -142,60 +157,77 @@ const pricingLd = {
       </div>
 
       {
-        featurePricingItems.length > 0 && (
-          <div class="mt-8 overflow-x-auto rounded-lg border border-slate-200">
-            <table class="w-full min-w-220 border-collapse text-left text-sm">
-              <thead class="bg-slate-50 text-slate-900">
-                <tr>
-                  <th class="border-b border-slate-200 px-4 py-3 font-700">
-                    {t(locale, 'pages.pricing.feeItem')}
-                  </th>
-                  <th class="border-b border-slate-200 px-4 py-3 font-700">
-                    {t(locale, 'pages.pricing.feeAmount')}
-                  </th>
-                  <th class="border-b border-slate-200 px-4 py-3 font-700">
-                    {t(locale, 'pages.pricing.feeNote')}
-                  </th>
-                  <th class="border-b border-slate-200 px-4 py-3 font-700">
-                    {t(locale, 'pages.pricing.detailLink')}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {featurePricingItems.map((item) => (
-                  <tr class="align-top transition hover:bg-brand-50/50">
-                    <th class="border-b border-slate-100 px-4 py-4 font-700 text-slate-900">
-                      <a
-                        href={item.href}
-                        class="group inline-flex items-center gap-3 no-underline"
-                      >
-                        <span class="ac-icon-box shrink-0">
-                          <Icon name={item.icon} class="text-base" />
-                        </span>
-                        <span class="transition group-hover:text-brand-600">
-                          {item.title}
-                        </span>
-                      </a>
+        webPricingItems.length > 0 && (
+          <div class="mt-8">
+            <div class="mb-4">
+              <h3 class="text-xl ac-heading">{webPricingTableTitle}</h3>
+              <p class="mt-2 text-sm leading-relaxed text-slate-600">
+                {t(locale, 'pages.services.web.featureLinksBody')}
+              </p>
+            </div>
+            <div class="overflow-x-auto rounded-lg border border-slate-200">
+              <table class="w-full min-w-220 border-collapse text-left text-sm">
+                <thead class="bg-slate-50 text-slate-900">
+                  <tr>
+                    <th class="border-b border-slate-200 px-4 py-3 font-700">
+                      {t(locale, 'pages.pricing.feeItem')}
                     </th>
-                    <td class="border-b border-slate-100 px-4 py-4 font-800 text-brand-700">
-                      {item.price}
-                    </td>
-                    <td class="border-b border-slate-100 px-4 py-4 leading-relaxed text-slate-600">
-                      {item.body}
-                    </td>
-                    <td class="border-b border-slate-100 px-4 py-4">
-                      <a
-                        href={item.href}
-                        class="inline-flex items-center gap-1 font-700 text-brand-600 no-underline hover:underline"
-                      >
-                        {t(locale, 'pages.pricing.detailLink')}
-                        <Icon name="arrow-right" class="text-xs" />
-                      </a>
-                    </td>
+                    <th class="border-b border-slate-200 px-4 py-3 font-700">
+                      {t(locale, 'pages.pricing.feeAmount')}
+                    </th>
+                    <th class="border-b border-slate-200 px-4 py-3 font-700">
+                      {t(locale, 'pages.pricing.feeNote')}
+                    </th>
+                    <th class="border-b border-slate-200 px-4 py-3 font-700">
+                      {t(locale, 'pages.pricing.detailLink')}
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {webPricingItems.map((item) => (
+                    <tr
+                      class={`align-top transition hover:bg-brand-50/50 ${
+                        isWebPricingHref(item.href) ? 'bg-brand-50/40' : ''
+                      }`}
+                    >
+                      <th class="border-b border-slate-100 px-4 py-4 font-700 text-slate-900">
+                        <a
+                          href={item.href}
+                          class="group inline-flex items-center gap-3 no-underline"
+                        >
+                          <span class="ac-icon-box shrink-0">
+                            <Icon name={item.icon} class="text-base" />
+                          </span>
+                          <span class="transition group-hover:text-brand-600">
+                            {item.title}
+                          </span>
+                        </a>
+                      </th>
+                      <td class="border-b border-slate-100 px-4 py-4 font-800 text-brand-700">
+                        {item.price}
+                      </td>
+                      <td class="border-b border-slate-100 px-4 py-4 leading-relaxed text-slate-600">
+                        {item.body}
+                      </td>
+                      <td class="border-b border-slate-100 px-4 py-4">
+                        <a
+                          href={item.href}
+                          class="inline-flex items-center gap-1 font-700 text-brand-600 no-underline hover:underline"
+                        >
+                          {isBlogPricingHref(item.href)
+                            ? t(
+                                locale,
+                                'pages.services.web.featureLinksArticleLabel',
+                              )
+                            : t(locale, 'pages.pricing.detailLink')}
+                          <Icon name="arrow-right" class="text-xs" />
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         )
       }

--- a/src/views/ServicesPage.astro
+++ b/src/views/ServicesPage.astro
@@ -102,6 +102,9 @@ const servicePricingItems = getList<ServicePricingItem>(
 const webFeatureItems = servicePricingItems.filter((item) =>
   item.href.includes('/blog/'),
 )
+const servicePricingCoreItems = servicePricingItems.filter(
+  (item) => !item.href.includes('/blog/'),
+)
 
 const serviceLd = {
   '@context': 'https://schema.org',
@@ -355,32 +358,65 @@ const serviceLd = {
                   {t(locale, 'pages.services.web.featureLinksBody')}
                 </p>
               </div>
-              <div class="grid gap-3 sm:grid-cols-2">
-                {webFeatureItems.map((item) => (
-                  <a
-                    href={item.href}
-                    class="group flex min-h-24 items-start gap-3 rounded-lg border border-slate-200 bg-white p-4 no-underline transition hover:border-brand-200 hover:shadow-sm"
-                  >
-                    <span class="ac-icon-box shrink-0">
-                      <Icon name={item.icon} class="text-base" />
-                    </span>
-                    <span class="min-w-0">
-                      <span class="block text-sm font-700 text-slate-900 transition group-hover:text-brand-600">
-                        {item.label}
-                      </span>
-                      <span class="mt-1 block text-sm font-800 text-slate-800">
-                        {item.price}
-                      </span>
-                      <span class="mt-1 inline-flex items-center gap-1 text-xs font-700 text-brand-600">
+              <div class="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+                <table class="w-full min-w-220 border-collapse text-left text-sm">
+                  <thead class="bg-slate-50 text-slate-900">
+                    <tr>
+                      <th class="border-b border-slate-200 px-4 py-3 font-700">
+                        {t(locale, 'pages.pricing.feeItem')}
+                      </th>
+                      <th class="border-b border-slate-200 px-4 py-3 font-700">
+                        {t(locale, 'pages.pricing.feeAmount')}
+                      </th>
+                      <th class="border-b border-slate-200 px-4 py-3 font-700">
+                        {t(locale, 'pages.pricing.feeNote')}
+                      </th>
+                      <th class="border-b border-slate-200 px-4 py-3 font-700">
                         {t(
                           locale,
                           'pages.services.web.featureLinksArticleLabel',
                         )}
-                        <Icon name="arrow-right" class="text-xs" />
-                      </span>
-                    </span>
-                  </a>
-                ))}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {webFeatureItems.map((item) => (
+                      <tr class="align-top transition hover:bg-brand-50/50">
+                        <th class="border-b border-slate-100 px-4 py-4 font-700 text-slate-900">
+                          <a
+                            href={item.href}
+                            class="group inline-flex items-center gap-3 no-underline"
+                          >
+                            <span class="ac-icon-box shrink-0">
+                              <Icon name={item.icon} class="text-base" />
+                            </span>
+                            <span class="transition group-hover:text-brand-600">
+                              {item.label}
+                            </span>
+                          </a>
+                        </th>
+                        <td class="border-b border-slate-100 px-4 py-4 font-800 text-brand-700">
+                          {item.price}
+                        </td>
+                        <td class="border-b border-slate-100 px-4 py-4 leading-relaxed text-slate-600">
+                          {item.note}
+                        </td>
+                        <td class="border-b border-slate-100 px-4 py-4">
+                          <a
+                            href={item.href}
+                            class="inline-flex items-center gap-1 font-700 text-brand-600 no-underline hover:underline"
+                          >
+                            {t(
+                              locale,
+                              'pages.services.web.featureLinksArticleLabel',
+                            )}
+                            <Icon name="arrow-right" class="text-xs" />
+                          </a>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
           )
@@ -657,7 +693,7 @@ const serviceLd = {
         </p>
         <div class="grid gap-4 md:grid-cols-2">
           {
-            servicePricingItems.map((item) => (
+            servicePricingCoreItems.map((item) => (
               <a
                 href={item.href}
                 class="ac-surface group p-5 no-underline transition hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-md"
@@ -676,6 +712,67 @@ const serviceLd = {
             ))
           }
         </div>
+        {
+          webFeatureItems.length > 0 && (
+            <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200">
+              <table class="w-full min-w-220 border-collapse text-left text-sm">
+                <thead class="bg-slate-50 text-slate-900">
+                  <tr>
+                    <th class="border-b border-slate-200 px-4 py-3 font-700">
+                      {t(locale, 'pages.pricing.feeItem')}
+                    </th>
+                    <th class="border-b border-slate-200 px-4 py-3 font-700">
+                      {t(locale, 'pages.pricing.feeAmount')}
+                    </th>
+                    <th class="border-b border-slate-200 px-4 py-3 font-700">
+                      {t(locale, 'pages.pricing.feeNote')}
+                    </th>
+                    <th class="border-b border-slate-200 px-4 py-3 font-700">
+                      {t(locale, 'pages.services.web.featureLinksArticleLabel')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {webFeatureItems.map((item) => (
+                    <tr class="align-top transition hover:bg-brand-50/50">
+                      <th class="border-b border-slate-100 px-4 py-4 font-700 text-slate-900">
+                        <a
+                          href={item.href}
+                          class="group inline-flex items-center gap-3 no-underline"
+                        >
+                          <span class="ac-icon-box shrink-0">
+                            <Icon name={item.icon} class="text-base" />
+                          </span>
+                          <span class="transition group-hover:text-brand-600">
+                            {item.label}
+                          </span>
+                        </a>
+                      </th>
+                      <td class="border-b border-slate-100 px-4 py-4 font-800 text-brand-700">
+                        {item.price}
+                      </td>
+                      <td class="border-b border-slate-100 px-4 py-4 leading-relaxed text-slate-600">
+                        {item.note}
+                      </td>
+                      <td class="border-b border-slate-100 px-4 py-4">
+                        <a
+                          href={item.href}
+                          class="inline-flex items-center gap-1 font-700 text-brand-600 no-underline hover:underline"
+                        >
+                          {t(
+                            locale,
+                            'pages.services.web.featureLinksArticleLabel',
+                          )}
+                          <Icon name="arrow-right" class="text-xs" />
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )
+        }
         <div class="ac-surface mt-6 bg-brand-50 p-6">
           <p class="mb-2 font-700 text-slate-900">
             {t(locale, 'pages.services.pricing.ctaHeading')}

--- a/src/views/ServicesPage.astro
+++ b/src/views/ServicesPage.astro
@@ -99,12 +99,27 @@ const servicePricingItems = getList<ServicePricingItem>(
   ...item,
   href: resolvePricingHref(item.href),
 }))
+const isBlogPricingHref = (href: string) => href.includes('/blog/')
+const isWebPricingHref = (href: string) => href.includes('/services/#web')
+const webBasePricingItem = servicePricingItems.find((item) =>
+  isWebPricingHref(item.href),
+)
 const webFeatureItems = servicePricingItems.filter((item) =>
-  item.href.includes('/blog/'),
+  isBlogPricingHref(item.href),
 )
+const webPricingTableItems = [
+  ...(webBasePricingItem ? [webBasePricingItem] : []),
+  ...webFeatureItems,
+]
 const servicePricingCoreItems = servicePricingItems.filter(
-  (item) => !item.href.includes('/blog/'),
+  (item) => !isBlogPricingHref(item.href) && !isWebPricingHref(item.href),
 )
+const webPricingTableTitle = webBasePricingItem
+  ? `${webBasePricingItem.label} / ${t(
+      locale,
+      'pages.services.web.featureLinksTitle',
+    )}`
+  : t(locale, 'pages.services.web.featureLinksTitle')
 
 const serviceLd = {
   '@context': 'https://schema.org',
@@ -348,12 +363,10 @@ const serviceLd = {
           workLink={serviceWorks.web}
         />
         {
-          webFeatureItems.length > 0 && (
+          webPricingTableItems.length > 0 && (
             <div class="mt-6 border-y border-slate-200 py-5">
               <div class="mb-4">
-                <h3 class="text-lg ac-heading">
-                  {t(locale, 'pages.services.web.featureLinksTitle')}
-                </h3>
+                <h3 class="text-lg ac-heading">{webPricingTableTitle}</h3>
                 <p class="mt-2 text-sm leading-relaxed text-slate-600">
                   {t(locale, 'pages.services.web.featureLinksBody')}
                 </p>
@@ -372,16 +385,17 @@ const serviceLd = {
                         {t(locale, 'pages.pricing.feeNote')}
                       </th>
                       <th class="border-b border-slate-200 px-4 py-3 font-700">
-                        {t(
-                          locale,
-                          'pages.services.web.featureLinksArticleLabel',
-                        )}
+                        {t(locale, 'pages.pricing.detailLink')}
                       </th>
                     </tr>
                   </thead>
                   <tbody>
-                    {webFeatureItems.map((item) => (
-                      <tr class="align-top transition hover:bg-brand-50/50">
+                    {webPricingTableItems.map((item) => (
+                      <tr
+                        class={`align-top transition hover:bg-brand-50/50 ${
+                          isWebPricingHref(item.href) ? 'bg-brand-50/40' : ''
+                        }`}
+                      >
                         <th class="border-b border-slate-100 px-4 py-4 font-700 text-slate-900">
                           <a
                             href={item.href}
@@ -406,10 +420,12 @@ const serviceLd = {
                             href={item.href}
                             class="inline-flex items-center gap-1 font-700 text-brand-600 no-underline hover:underline"
                           >
-                            {t(
-                              locale,
-                              'pages.services.web.featureLinksArticleLabel',
-                            )}
+                            {isBlogPricingHref(item.href)
+                              ? t(
+                                  locale,
+                                  'pages.services.web.featureLinksArticleLabel',
+                                )
+                              : t(locale, 'pages.pricing.detailLink')}
                             <Icon name="arrow-right" class="text-xs" />
                           </a>
                         </td>
@@ -713,63 +729,77 @@ const serviceLd = {
           }
         </div>
         {
-          webFeatureItems.length > 0 && (
-            <div class="mt-6 overflow-x-auto rounded-lg border border-slate-200">
-              <table class="w-full min-w-220 border-collapse text-left text-sm">
-                <thead class="bg-slate-50 text-slate-900">
-                  <tr>
-                    <th class="border-b border-slate-200 px-4 py-3 font-700">
-                      {t(locale, 'pages.pricing.feeItem')}
-                    </th>
-                    <th class="border-b border-slate-200 px-4 py-3 font-700">
-                      {t(locale, 'pages.pricing.feeAmount')}
-                    </th>
-                    <th class="border-b border-slate-200 px-4 py-3 font-700">
-                      {t(locale, 'pages.pricing.feeNote')}
-                    </th>
-                    <th class="border-b border-slate-200 px-4 py-3 font-700">
-                      {t(locale, 'pages.services.web.featureLinksArticleLabel')}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {webFeatureItems.map((item) => (
-                    <tr class="align-top transition hover:bg-brand-50/50">
-                      <th class="border-b border-slate-100 px-4 py-4 font-700 text-slate-900">
-                        <a
-                          href={item.href}
-                          class="group inline-flex items-center gap-3 no-underline"
-                        >
-                          <span class="ac-icon-box shrink-0">
-                            <Icon name={item.icon} class="text-base" />
-                          </span>
-                          <span class="transition group-hover:text-brand-600">
-                            {item.label}
-                          </span>
-                        </a>
+          webPricingTableItems.length > 0 && (
+            <div class="mt-6">
+              <div class="mb-4">
+                <h3 class="text-lg ac-heading">{webPricingTableTitle}</h3>
+                <p class="mt-2 text-sm leading-relaxed text-slate-600">
+                  {t(locale, 'pages.services.web.featureLinksBody')}
+                </p>
+              </div>
+              <div class="overflow-x-auto rounded-lg border border-slate-200">
+                <table class="w-full min-w-220 border-collapse text-left text-sm">
+                  <thead class="bg-slate-50 text-slate-900">
+                    <tr>
+                      <th class="border-b border-slate-200 px-4 py-3 font-700">
+                        {t(locale, 'pages.pricing.feeItem')}
                       </th>
-                      <td class="border-b border-slate-100 px-4 py-4 font-800 text-brand-700">
-                        {item.price}
-                      </td>
-                      <td class="border-b border-slate-100 px-4 py-4 leading-relaxed text-slate-600">
-                        {item.note}
-                      </td>
-                      <td class="border-b border-slate-100 px-4 py-4">
-                        <a
-                          href={item.href}
-                          class="inline-flex items-center gap-1 font-700 text-brand-600 no-underline hover:underline"
-                        >
-                          {t(
-                            locale,
-                            'pages.services.web.featureLinksArticleLabel',
-                          )}
-                          <Icon name="arrow-right" class="text-xs" />
-                        </a>
-                      </td>
+                      <th class="border-b border-slate-200 px-4 py-3 font-700">
+                        {t(locale, 'pages.pricing.feeAmount')}
+                      </th>
+                      <th class="border-b border-slate-200 px-4 py-3 font-700">
+                        {t(locale, 'pages.pricing.feeNote')}
+                      </th>
+                      <th class="border-b border-slate-200 px-4 py-3 font-700">
+                        {t(locale, 'pages.pricing.detailLink')}
+                      </th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {webPricingTableItems.map((item) => (
+                      <tr
+                        class={`align-top transition hover:bg-brand-50/50 ${
+                          isWebPricingHref(item.href) ? 'bg-brand-50/40' : ''
+                        }`}
+                      >
+                        <th class="border-b border-slate-100 px-4 py-4 font-700 text-slate-900">
+                          <a
+                            href={item.href}
+                            class="group inline-flex items-center gap-3 no-underline"
+                          >
+                            <span class="ac-icon-box shrink-0">
+                              <Icon name={item.icon} class="text-base" />
+                            </span>
+                            <span class="transition group-hover:text-brand-600">
+                              {item.label}
+                            </span>
+                          </a>
+                        </th>
+                        <td class="border-b border-slate-100 px-4 py-4 font-800 text-brand-700">
+                          {item.price}
+                        </td>
+                        <td class="border-b border-slate-100 px-4 py-4 leading-relaxed text-slate-600">
+                          {item.note}
+                        </td>
+                        <td class="border-b border-slate-100 px-4 py-4">
+                          <a
+                            href={item.href}
+                            class="inline-flex items-center gap-1 font-700 text-brand-600 no-underline hover:underline"
+                          >
+                            {isBlogPricingHref(item.href)
+                              ? t(
+                                  locale,
+                                  'pages.services.web.featureLinksArticleLabel',
+                                )
+                              : t(locale, 'pages.pricing.detailLink')}
+                            <Icon name="arrow-right" class="text-xs" />
+                          </a>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           )
         }


### PR DESCRIPTION
## 関連 Issue

なし

## 概要

- 細かい機能単位の料金をカード表示から表形式へ整理しました。
- 主要サービスの料金カードは維持しつつ、Webサイト制作・運用は基本料金行としてWeb系の料金表に統合しました。
- Web系の表には見出しと説明文を付け、基本料金とブログ記事に紐づく機能メニューを同じ表で比較できるようにしています。
- `origin/main` の `8d90f2b` まで取り込み済みです。

## 主な変更点

- 料金ページで `/blog/` に紐づく機能料金を表に分離
- `Webサイト制作・運用` をWeb系料金表の先頭行へ移動し、基本料金として扱える見せ方に変更
- 料金ページとサービスページのWeb系料金表にタイトルと説明文を追加
- サービスページのWeb機能一覧を、基本料金＋機能単位の表形式へ変更
- サービスページ下部の料金セクションで、主要サービスカードとWeb系料金表を分離
- 既存の i18n キーを再利用し、翻訳/CMS差分は追加なし

## 確認したこと

- `git fetch origin main`
- `git merge origin/main`
- `git diff --check`
- `..\..\node_modules\.bin\prettier.cmd --check src/views/PricingPage.astro src/views/ServicesPage.astro`
- `npm run build`
  - Astro build: 720 pages built
  - Pagefind: 30 pages / 4488 words indexed
- `dist\pricing\index.html` で `Webサイト制作・運用 / 記事で詳しく読める機能メニュー`、`Webサイト制作・運用`、`15万円〜`、`ブログコメント機能`、`/blog/cloudflare-only-blog-comments/` を確認
- `dist\services\index.html` で `Webサイト制作・運用 / 記事で詳しく読める機能メニュー`、`Webサイト制作・運用`、`15万円〜`、`解説記事を見る`、`/blog/cloudflare-only-blog-comments/` を確認

## 未確認事項・補足

- `..\..\node_modules\.bin\prettier.cmd --check src/views/PricingPage.astro src/views/ServicesPage.astro wrangler.jsonc` は、今回取り込んだ main 側の `wrangler.jsonc` で style warning になりました。PR差分は引き続き `src/views/PricingPage.astro` と `src/views/ServicesPage.astro` の2ファイルのみです。
- Browserプラグインは接続初期化時に `windows sandbox failed: spawn setup refresh` となったため、スクリーンショット確認は未実施です。今回は build 後のHTMLを直接確認しました。
