### PR TITLE
D1コメントDBをpreview/production共通にする

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,8 +10,8 @@
   "d1_databases": [
     {
       "binding": "COMMENTS_DB",
-      "database_name": "acecore-comments-preview",
-      "database_id": "03ad2e45-fdc9-43f6-a685-db0ee1513913",
+      "database_name": "acecore-comments-production",
+      "database_id": "10bb4e84-2c31-427f-931c-fcb123c57501",
       "migrations_dir": "./migrations",
     },
   ],
@@ -24,8 +24,8 @@
       "d1_databases": [
         {
           "binding": "COMMENTS_DB",
-          "database_name": "acecore-comments-preview",
-          "database_id": "03ad2e45-fdc9-43f6-a685-db0ee1513913",
+          "database_name": "acecore-comments-production",
+          "database_id": "10bb4e84-2c31-427f-931c-fcb123c57501",
           "migrations_dir": "./migrations",
         },
       ],


### PR DESCRIPTION
## 関連 Issue

なし

## 概要

D1 の preview / production 分割をやめ、コメント用 D1 を 1 つに統一します。
削除済みの `acecore-comments-preview` を `wrangler.jsonc` から参照しないようにします。

## 主な変更点

- top-level の `COMMENTS_DB` を `acecore-comments-production` に変更
- `env.preview` の `COMMENTS_DB` も `acecore-comments-production` に変更
- `env.production` は既に同じ DB を参照していたため変更なし

## 確認したこと

- `npx prettier --check wrangler.jsonc`
- `git diff --check`
- `https://acecore.net/api/comments?slug=d1-consolidation-check` が 200 を返すこと
- `https://acecore-net.pages.dev/api/comments?slug=d1-consolidation-check` が 200 を返すこと
- Cloudflare Pages の production / preview が同じ D1 ID `10bb4e84-2c31-427f-931c-fcb123c57501` を参照していること

## 未確認事項・補足

- サイト出力に影響しない Cloudflare binding 設定のみの変更のため、`npm run build` は未実施です。