### PR TITLE
公式リンク導線をヘッダーに追加

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,6 +2,8 @@
 import Icon from './Icon.astro'
 import { t, getLocalizedUrl, getLocaleFromUrl, type Locale } from '../i18n'
 import LanguageSwitcher from './LanguageSwitcher.astro'
+import { SITE } from '../data/site'
+import { getSchoolsUrl } from '../utils/schools-url'
 
 interface Props {
   locale?: Locale
@@ -28,6 +30,20 @@ const contactLink = {
   href: getLocalizedUrl('/contact/', locale),
   label: t(locale, 'nav.contact'),
 }
+const officialLinks = [
+  {
+    href: getSchoolsUrl(locale),
+    label: t(locale, 'footer.schools'),
+    icon: 'graduation-cap',
+    gaLabel: 'header_schools',
+  },
+  {
+    href: SITE.social.aceserver,
+    label: 'Aceserver Portal',
+    icon: 'gamepad-2',
+    gaLabel: 'header_aceserver_portal',
+  },
+]
 const currentPath = Astro.url.pathname
 ---
 
@@ -105,6 +121,37 @@ const currentPath = Astro.url.pathname
       </button>
     </div>
   </div>
+  <nav
+    class="border-t border-brand-900/10 bg-slate-50/90"
+    aria-label={t(locale, 'footer.relatedLinks')}
+  >
+    <div class="ac-container flex min-h-11 flex-wrap items-center gap-2 py-2">
+      <span
+        class="hidden shrink-0 text-xs font-800 text-slate-500 sm:inline-flex"
+      >
+        {t(locale, 'footer.relatedLinks')}
+      </span>
+      {
+        officialLinks.map((link) => (
+          <a
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-800 text-slate-700 no-underline shadow-sm transition-colors hover:border-brand-200 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2"
+            data-ga-event="external_link_click"
+            data-ga-label={link.gaLabel}
+            data-ga-location="header"
+            data-ga-destination={link.href}
+          >
+            <Icon name={link.icon} class="text-sm text-brand-500" />
+            <span>{link.label}</span>
+            <Icon name="external-link" class="text-xs text-slate-400" />
+            <span class="sr-only">{t(locale, 'common.opensInNewTab')}</span>
+          </a>
+        ))
+      }
+    </div>
+  </nav>
   <nav
     id="mobile-menu"
     class="hidden border-t border-brand-900/10 bg-white lg:hidden"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,14 +21,10 @@ const navLinks = [
   {
     href: getSchoolsUrl(locale),
     label: 'Schools',
-    external: true,
-    gaLabel: 'header_schools',
   },
   {
     href: SITE.social.aceserver,
     label: locale === 'ja' ? 'エースサーバー' : 'Aceserver',
-    external: true,
-    gaLabel: 'header_aceserver_portal',
   },
   {
     href: getLocalizedUrl('/pricing/', locale),
@@ -62,7 +58,7 @@ const currentPath = Astro.url.pathname
     >
       {
         navLinks.map((link) => {
-          const isCurrent = !link.external && currentPath === link.href
+          const isCurrent = currentPath === link.href
 
           return (
             <a
@@ -74,21 +70,8 @@ const currentPath = Astro.url.pathname
                   : 'text-slate-700 hover:bg-slate-50 hover:text-brand-600',
               ]}
               {...(isCurrent ? { 'aria-current': 'page' } : {})}
-              {...(link.external
-                ? {
-                    target: '_blank',
-                    rel: 'noopener noreferrer',
-                    'data-ga-event': 'external_link_click',
-                    'data-ga-label': link.gaLabel,
-                    'data-ga-location': 'header_nav',
-                    'data-ga-destination': link.href,
-                  }
-                : {})}
             >
               <span>{link.label}</span>
-              {link.external && (
-                <span class="sr-only">{t(locale, 'common.opensInNewTab')}</span>
-              )}
             </a>
           )
         })
@@ -144,7 +127,7 @@ const currentPath = Astro.url.pathname
     <div class="ac-container ac-blueprint-soft flex flex-col gap-2 py-4">
       {
         navLinks.map((link) => {
-          const isCurrent = !link.external && currentPath === link.href
+          const isCurrent = currentPath === link.href
 
           return (
             <a
@@ -156,24 +139,9 @@ const currentPath = Astro.url.pathname
                   : 'text-slate-700 hover:border-slate-200 hover:bg-white hover:text-brand-600',
               ]}
               {...(isCurrent ? { 'aria-current': 'page' } : {})}
-              {...(link.external
-                ? {
-                    target: '_blank',
-                    rel: 'noopener noreferrer',
-                    'data-ga-event': 'external_link_click',
-                    'data-ga-label': link.gaLabel,
-                    'data-ga-location': 'mobile_nav',
-                    'data-ga-destination': link.href,
-                  }
-                : {})}
             >
               <span>{link.label}</span>
               <span class="inline-flex items-center gap-1 text-slate-400">
-                {link.external && (
-                  <span class="sr-only">
-                    {t(locale, 'common.opensInNewTab')}
-                  </span>
-                )}
                 <Icon name="arrow-right" class="text-sm" />
               </span>
             </a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,6 +19,18 @@ const navLinks = [
     label: t(locale, 'nav.services'),
   },
   {
+    href: getSchoolsUrl(locale),
+    label: t(locale, 'footer.schools'),
+    external: true,
+    gaLabel: 'header_schools',
+  },
+  {
+    href: SITE.social.aceserver,
+    label: 'Aceserver Portal',
+    external: true,
+    gaLabel: 'header_aceserver_portal',
+  },
+  {
     href: getLocalizedUrl('/pricing/', locale),
     label: t(locale, 'nav.pricing'),
   },
@@ -30,20 +42,6 @@ const contactLink = {
   href: getLocalizedUrl('/contact/', locale),
   label: t(locale, 'nav.contact'),
 }
-const officialLinks = [
-  {
-    href: getSchoolsUrl(locale),
-    label: t(locale, 'footer.schools'),
-    icon: 'graduation-cap',
-    gaLabel: 'header_schools',
-  },
-  {
-    href: SITE.social.aceserver,
-    label: 'Aceserver Portal',
-    icon: 'gamepad-2',
-    gaLabel: 'header_aceserver_portal',
-  },
-]
 const currentPath = Astro.url.pathname
 ---
 
@@ -59,24 +57,46 @@ const currentPath = Astro.url.pathname
       Acecore
     </a>
     <nav
-      class="hidden items-center gap-1 lg:flex"
+      class="hidden items-center gap-0 xl:flex"
       aria-label={t(locale, 'common.mainNav')}
     >
       {
-        navLinks.map((link) => (
-          <a
-            href={link.href}
-            class:list={[
-              'inline-flex min-h-11 items-center rounded-md px-3 text-sm font-800 no-underline transition-colors',
-              currentPath === link.href
-                ? 'bg-brand-50 text-brand-700'
-                : 'text-slate-700 hover:bg-slate-50 hover:text-brand-600',
-            ]}
-            {...(currentPath === link.href ? { 'aria-current': 'page' } : {})}
-          >
-            {link.label}
-          </a>
-        ))
+        navLinks.map((link) => {
+          const isCurrent = !link.external && currentPath === link.href
+
+          return (
+            <a
+              href={link.href}
+              class:list={[
+                'inline-flex min-h-11 items-center gap-1 rounded-md px-2 text-xs font-800 no-underline transition-colors 2xl:px-3 2xl:text-sm',
+                isCurrent
+                  ? 'bg-brand-50 text-brand-700'
+                  : 'text-slate-700 hover:bg-slate-50 hover:text-brand-600',
+              ]}
+              {...(isCurrent ? { 'aria-current': 'page' } : {})}
+              {...(link.external
+                ? {
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                    'data-ga-event': 'external_link_click',
+                    'data-ga-label': link.gaLabel,
+                    'data-ga-location': 'header_nav',
+                    'data-ga-destination': link.href,
+                  }
+                : {})}
+            >
+              <span>{link.label}</span>
+              {link.external && (
+                <>
+                  <Icon name="external-link" class="text-xs text-slate-400" />
+                  <span class="sr-only">
+                    {t(locale, 'common.opensInNewTab')}
+                  </span>
+                </>
+              )}
+            </a>
+          )
+        })
       }
       <button
         data-search-trigger
@@ -95,7 +115,7 @@ const currentPath = Astro.url.pathname
         {contactLink.label}
       </a>
     </nav>
-    <div class="flex items-center gap-1 lg:hidden">
+    <div class="flex items-center gap-1 xl:hidden">
       <button
         data-search-trigger
         class="ac-touch rounded-md text-slate-500 hover:bg-slate-50 hover:text-brand-600"
@@ -122,58 +142,51 @@ const currentPath = Astro.url.pathname
     </div>
   </div>
   <nav
-    class="border-t border-brand-900/10 bg-slate-50/90"
-    aria-label={t(locale, 'footer.relatedLinks')}
-  >
-    <div class="ac-container flex min-h-11 flex-wrap items-center gap-2 py-2">
-      <span
-        class="hidden shrink-0 text-xs font-800 text-slate-500 sm:inline-flex"
-      >
-        {t(locale, 'footer.relatedLinks')}
-      </span>
-      {
-        officialLinks.map((link) => (
-          <a
-            href={link.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-800 text-slate-700 no-underline shadow-sm transition-colors hover:border-brand-200 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2"
-            data-ga-event="external_link_click"
-            data-ga-label={link.gaLabel}
-            data-ga-location="header"
-            data-ga-destination={link.href}
-          >
-            <Icon name={link.icon} class="text-sm text-brand-500" />
-            <span>{link.label}</span>
-            <Icon name="external-link" class="text-xs text-slate-400" />
-            <span class="sr-only">{t(locale, 'common.opensInNewTab')}</span>
-          </a>
-        ))
-      }
-    </div>
-  </nav>
-  <nav
     id="mobile-menu"
-    class="hidden border-t border-brand-900/10 bg-white lg:hidden"
+    class="hidden border-t border-brand-900/10 bg-white xl:hidden"
     aria-label={t(locale, 'common.mobileNav')}
   >
     <div class="ac-container ac-blueprint-soft flex flex-col gap-2 py-4">
       {
-        navLinks.map((link) => (
-          <a
-            href={link.href}
-            class:list={[
-              'flex min-h-11 items-center justify-between rounded-md border border-transparent px-3 text-sm font-800 no-underline transition-colors',
-              currentPath === link.href
-                ? 'border-brand-100 bg-brand-50 text-brand-700'
-                : 'text-slate-700 hover:border-slate-200 hover:bg-white hover:text-brand-600',
-            ]}
-            {...(currentPath === link.href ? { 'aria-current': 'page' } : {})}
-          >
-            <span>{link.label}</span>
-            <Icon name="arrow-right" class="text-sm text-slate-400" />
-          </a>
-        ))
+        navLinks.map((link) => {
+          const isCurrent = !link.external && currentPath === link.href
+
+          return (
+            <a
+              href={link.href}
+              class:list={[
+                'flex min-h-11 items-center justify-between rounded-md border border-transparent px-3 text-sm font-800 no-underline transition-colors',
+                isCurrent
+                  ? 'border-brand-100 bg-brand-50 text-brand-700'
+                  : 'text-slate-700 hover:border-slate-200 hover:bg-white hover:text-brand-600',
+              ]}
+              {...(isCurrent ? { 'aria-current': 'page' } : {})}
+              {...(link.external
+                ? {
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                    'data-ga-event': 'external_link_click',
+                    'data-ga-label': link.gaLabel,
+                    'data-ga-location': 'mobile_nav',
+                    'data-ga-destination': link.href,
+                  }
+                : {})}
+            >
+              <span>{link.label}</span>
+              <span class="inline-flex items-center gap-1 text-slate-400">
+                {link.external && (
+                  <span class="sr-only">
+                    {t(locale, 'common.opensInNewTab')}
+                  </span>
+                )}
+                <Icon
+                  name={link.external ? 'external-link' : 'arrow-right'}
+                  class="text-sm"
+                />
+              </span>
+            </a>
+          )
+        })
       }
       <a href={contactLink.href} class="ac-btn-primary mt-1 w-full">
         {contactLink.label}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -20,13 +20,13 @@ const navLinks = [
   },
   {
     href: getSchoolsUrl(locale),
-    label: t(locale, 'footer.schools'),
+    label: 'Schools',
     external: true,
     gaLabel: 'header_schools',
   },
   {
     href: SITE.social.aceserver,
-    label: 'Aceserver Portal',
+    label: locale === 'ja' ? 'エースサーバー' : 'Aceserver',
     external: true,
     gaLabel: 'header_aceserver_portal',
   },
@@ -57,7 +57,7 @@ const currentPath = Astro.url.pathname
       Acecore
     </a>
     <nav
-      class="hidden items-center gap-0 xl:flex"
+      class="hidden items-center gap-1 xl:flex"
       aria-label={t(locale, 'common.mainNav')}
     >
       {
@@ -68,7 +68,7 @@ const currentPath = Astro.url.pathname
             <a
               href={link.href}
               class:list={[
-                'inline-flex min-h-11 items-center gap-1 rounded-md px-2 text-xs font-800 no-underline transition-colors 2xl:px-3 2xl:text-sm',
+                'inline-flex min-h-11 items-center rounded-md px-3 text-sm font-800 no-underline transition-colors',
                 isCurrent
                   ? 'bg-brand-50 text-brand-700'
                   : 'text-slate-700 hover:bg-slate-50 hover:text-brand-600',
@@ -87,12 +87,7 @@ const currentPath = Astro.url.pathname
             >
               <span>{link.label}</span>
               {link.external && (
-                <>
-                  <Icon name="external-link" class="text-xs text-slate-400" />
-                  <span class="sr-only">
-                    {t(locale, 'common.opensInNewTab')}
-                  </span>
-                </>
+                <span class="sr-only">{t(locale, 'common.opensInNewTab')}</span>
               )}
             </a>
           )
@@ -179,10 +174,7 @@ const currentPath = Astro.url.pathname
                     {t(locale, 'common.opensInNewTab')}
                   </span>
                 )}
-                <Icon
-                  name={link.external ? 'external-link' : 'arrow-right'}
-                  class="text-sm"
-                />
+                <Icon name="arrow-right" class="text-sm" />
               </span>
             </a>
           )


### PR DESCRIPTION
## 関連 Issue

なし

## 概要

Acecore Schools と Aceserver Portal への導線が埋もれないよう、全ページの通常ナビゲーションに短い公式リンクを追加します。

## 主な変更点

- `Header.astro` の通常ナビに `Schools` / `エースサーバー` を追加
- desktop では `xl` 以上で通常ナビに表示し、mobile / tablet 幅では既存メニュー内に同じ 2 項目を表示
- 表示上の外部リンクアイコンは出さず、`target="_blank"` / `rel="noopener noreferrer"` も付けない同一タブ遷移に変更
- 新規タブ用の sr-only 文言とヘッダー専用の external GA 属性を削除

## 確認したこと

- `npx prettier --check src/components/Header.astro`
- `npm run build`
  - サンドボックス内では `spawn EPERM` で失敗したため、通常環境で同じコマンドを再実行して成功
- `git diff --check`
- Browser QA: `http://127.0.0.1:4327/`
  - デスクトップ 1280px で `Schools` / `エースサーバー` が通常ナビ内に表示されること
  - 旧チップ列（関連リンク nav）が表示されないこと
  - モバイル 390x844 でメニュー内に両リンクが表示されること
  - 表示上の外部リンクアイコンが出ないこと
  - 両リンクの `target` / `rel` / `data-ga-event` / `data-ga-location` が付与されていないこと
  - 新規タブ用の読み上げ文が表示・読み上げテキストに残っていないこと

## 未確認事項・補足

- Browser console に Astro ClientRouter の `prefers-reduced-motion` 由来の warning が出ていますが、環境設定に起因する既存挙動で、今回の変更によるエラーは確認していません。