### PR TITLE
[codex] SEOヘッダーの矛盾を解消

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -2,7 +2,6 @@
 /*
   Cache-Control: public, max-age=0, must-revalidate
   X-Content-Type-Options: nosniff
-  X-Robots-Tag: all
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), interest-cohort=()
   X-Frame-Options: SAMEORIGIN


### PR DESCRIPTION
## 概要
- Cloudflare Pages headers から全体 `X-Robots-Tag: all` を削除

## 背景
全ページに `X-Robots-Tag: all` を付与する必要はなく、ページ単位の meta robots や将来の noindex 指定と競合しやすい状態でした。不要な全体指定を外して、SEO制御をページ側へ寄せます。

## 検証
- `npm ci`
- `npm run format:check`
- `npm run validate:content`
- `npm run build`
- `git diff --check`
- 横断SEO監査スクリプトで `acecore-net` PASS

## 補足
`npm run build` で Astro の `markdown.remarkPlugins` deprecation warning が出ていますが、今回差分とは無関係です。
