### PR TITLE
日本語タグURLの末尾スラッシュ転送を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Validate generated SEO metadata
         run: npm run validate:seo
+
+      - name: Validate non-ASCII tag redirects
+        run: npm run validate:tag-redirects

--- a/functions/[locale]/blog/tags/_middleware.ts
+++ b/functions/[locale]/blog/tags/_middleware.ts
@@ -1,0 +1,24 @@
+import { getCanonicalTagRedirectUrl } from '../../../../src/utils/tag-route-redirect'
+
+type PagesMiddlewareContext = {
+  request: Request
+  next(): Promise<Response>
+}
+
+export const onRequest = (
+  context: PagesMiddlewareContext,
+): Promise<Response> | Response => {
+  const location = getCanonicalTagRedirectUrl(
+    context.request.url,
+    context.request.method,
+  )
+
+  if (location) {
+    return new Response(null, {
+      status: 301,
+      headers: { Location: location },
+    })
+  }
+
+  return context.next()
+}

--- a/functions/blog/tags/_middleware.ts
+++ b/functions/blog/tags/_middleware.ts
@@ -1,0 +1,24 @@
+import { getCanonicalTagRedirectUrl } from '../../../src/utils/tag-route-redirect'
+
+type PagesMiddlewareContext = {
+  request: Request
+  next(): Promise<Response>
+}
+
+export const onRequest = (
+  context: PagesMiddlewareContext,
+): Promise<Response> | Response => {
+  const location = getCanonicalTagRedirectUrl(
+    context.request.url,
+    context.request.method,
+  )
+
+  if (location) {
+    return new Response(null, {
+      status: 301,
+      headers: { Location: location },
+    })
+  }
+
+  return context.next()
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "validate:content": "node scripts/validate-content.mjs",
-    "validate:seo": "node scripts/validate-seo.mjs"
+    "validate:seo": "node scripts/validate-seo.mjs",
+    "validate:tag-redirects": "node --experimental-strip-types scripts/validate-tag-redirects.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.18",

--- a/scripts/validate-tag-redirects.mjs
+++ b/scripts/validate-tag-redirects.mjs
@@ -17,13 +17,14 @@ const tags = await Promise.all(
     JSON.parse(await readFile(path.join(tagsDirectory, file), 'utf8')),
   ),
 )
-const nonAsciiTags = tags
-  .map((tag) => tag.name)
-  .filter((name) => /[^\x00-\x7f]/u.test(name))
+const tagNames = tags.map((tag) => tag.name)
+const nonAsciiTagCount = tagNames.filter((name) =>
+  /[^\x00-\x7f]/u.test(name),
+).length
 
 let checked = 0
 for (const locale of locales) {
-  for (const tag of nonAsciiTags) {
+  for (const tag of tagNames) {
     const encodedTag = encodeURIComponent(tag)
     const startUrl = `https://acecore.net/${locale}blog/tags/${encodedTag}`
     const expectedUrl = `${startUrl}/`
@@ -36,6 +37,15 @@ for (const locale of locales) {
     }
 
     assert.equal(getCanonicalTagRedirectUrl(expectedUrl, 'GET'), null)
+  }
+
+  const movedTagUrl = `https://acecore.net/${locale}blog/tags/${encodeURIComponent('システム開発')}`
+  for (const method of ['GET', 'HEAD']) {
+    assert.equal(
+      getCanonicalTagRedirectUrl(`${movedTagUrl}?from=gsc`, method),
+      'https://systems.acecore.net/guide/?from=gsc',
+    )
+    checked += 1
   }
 }
 
@@ -69,5 +79,5 @@ assert.equal(
 )
 
 console.log(
-  `Validated ${checked} GET/HEAD redirects across ${locales.length} locales and ${nonAsciiTags.length} non-ASCII tag routes.`,
+  `Validated ${checked} GET/HEAD redirects across ${locales.length} locales and ${tagNames.length} current tag routes (${nonAsciiTagCount} non-ASCII), plus the moved system-development tag.`,
 )

--- a/scripts/validate-tag-redirects.mjs
+++ b/scripts/validate-tag-redirects.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { getCanonicalTagRedirectUrl } from '../src/utils/tag-route-redirect.ts'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const tagsDirectory = path.join(root, 'src', 'content', 'tags')
+const locales = ['', 'en/', 'zh-cn/', 'es/', 'pt/', 'fr/', 'ko/', 'de/', 'ru/']
+
+const tagFiles = (await readdir(tagsDirectory)).filter((file) =>
+  file.endsWith('.json'),
+)
+const tags = await Promise.all(
+  tagFiles.map(async (file) =>
+    JSON.parse(await readFile(path.join(tagsDirectory, file), 'utf8')),
+  ),
+)
+const nonAsciiTags = tags
+  .map((tag) => tag.name)
+  .filter((name) => /[^\x00-\x7f]/u.test(name))
+
+let checked = 0
+for (const locale of locales) {
+  for (const tag of nonAsciiTags) {
+    const encodedTag = encodeURIComponent(tag)
+    const startUrl = `https://acecore.net/${locale}blog/tags/${encodedTag}`
+    const expectedUrl = `${startUrl}/`
+
+    for (const method of ['GET', 'HEAD']) {
+      const location = getCanonicalTagRedirectUrl(startUrl, method)
+      assert.equal(location, expectedUrl)
+      assert.match(location, /^[\x00-\x7f]+$/u)
+      checked += 1
+    }
+
+    assert.equal(getCanonicalTagRedirectUrl(expectedUrl, 'GET'), null)
+  }
+}
+
+assert.equal(
+  getCanonicalTagRedirectUrl(
+    'https://acecore.net/blog/tags/%E6%95%99%E8%82%B2?from=gsc',
+    'GET',
+  ),
+  'https://acecore.net/blog/tags/%E6%95%99%E8%82%B2/?from=gsc',
+)
+assert.equal(
+  getCanonicalTagRedirectUrl(
+    'https://acecore.net/it/blog/tags/%E6%95%99%E8%82%B2',
+    'GET',
+  ),
+  null,
+)
+assert.equal(
+  getCanonicalTagRedirectUrl(
+    'https://acecore.net/blog/tags/%E6%95%99%E8%82%B2',
+    'POST',
+  ),
+  null,
+)
+assert.equal(
+  getCanonicalTagRedirectUrl(
+    'https://acecore.net/blog/%E6%95%99%E8%82%B2',
+    'GET',
+  ),
+  null,
+)
+
+console.log(
+  `Validated ${checked} GET/HEAD redirects across ${locales.length} locales and ${nonAsciiTags.length} non-ASCII tag routes.`,
+)

--- a/src/utils/tag-route-redirect.ts
+++ b/src/utils/tag-route-redirect.ts
@@ -1,0 +1,40 @@
+const localizedRoutePrefixes = new Set([
+  'de',
+  'en',
+  'es',
+  'fr',
+  'ko',
+  'pt',
+  'ru',
+  'zh-cn',
+])
+
+/**
+ * Cloudflare Pages' implicit directory redirect can emit non-ASCII tag names
+ * as raw UTF-8 bytes in the Location header. Some crawlers interpret those
+ * bytes as Latin-1 and follow a mojibake URL. Return an explicitly serialized
+ * ASCII URL so every client reaches the canonical trailing-slash route.
+ */
+export function getCanonicalTagRedirectUrl(
+  requestUrl: string,
+  method: string,
+): string | null {
+  if (method !== 'GET' && method !== 'HEAD') return null
+
+  const url = new URL(requestUrl)
+  if (url.pathname.endsWith('/')) return null
+
+  const parts = url.pathname.split('/').filter(Boolean)
+  const isDefaultLocaleTag =
+    parts.length === 3 && parts[0] === 'blog' && parts[1] === 'tags'
+  const isLocalizedTag =
+    parts.length === 4 &&
+    localizedRoutePrefixes.has(parts[0]) &&
+    parts[1] === 'blog' &&
+    parts[2] === 'tags'
+
+  if (!isDefaultLocaleTag && !isLocalizedTag) return null
+
+  url.pathname = `${url.pathname}/`
+  return url.href
+}

--- a/src/utils/tag-route-redirect.ts
+++ b/src/utils/tag-route-redirect.ts
@@ -8,6 +8,9 @@ const localizedRoutePrefixes = new Set([
   'ru',
   'zh-cn',
 ])
+const movedSystemDevelopmentTag =
+  encodeURIComponent('システム開発').toUpperCase()
+const systemDevelopmentGuideUrl = 'https://systems.acecore.net/guide/'
 
 /**
  * Cloudflare Pages' implicit directory redirect can emit non-ASCII tag names
@@ -34,6 +37,12 @@ export function getCanonicalTagRedirectUrl(
     parts[2] === 'tags'
 
   if (!isDefaultLocaleTag && !isLocalizedTag) return null
+
+  if (parts.at(-1)?.toUpperCase() === movedSystemDevelopmentTag) {
+    const destination = new URL(systemDevelopmentGuideUrl)
+    destination.search = url.search
+    return destination.href
+  }
 
   url.pathname = `${url.pathname}/`
   return url.href


### PR DESCRIPTION
関連 Issue: なし

## 概要

- Cloudflare Pages の暗黙リダイレクトが非ASCIIタグを `Location` に生UTF-8で返し、一部クローラが文字化けURLを辿って404になる問題を修正
- 日本語および8言語プレフィクスの `/blog/tags/:tag` を Pages Functions middleware で先取りし、ASCII percent-encoded の正規URLへ1-hop 301
- 移転済み「システム開発」タグは `systems.acecore.net/guide/` への既存1-hop転送を維持
- 9 locale × 現行25タグと移転済みタグのGET/HEAD転送を自動検証し、CIへ追加

## 確認

- `npm run validate:content`
- `npm run build`
- `npm run validate:seo`（sitemap 308 URL）
- `npm run validate:tag-redirects`（468ケース）
- 対象ファイルの `npx prettier --check`
- `git diff --check`
- Cloudflare Pages preview（commit `be8adc1`）
  - 現行225 URL＋移転済み9 URL
  - 301
  - ASCII `Location`
  - 次の1 hopが200
  - 現行タグはproduction canonical一致
- 実ブラウザで `/blog/tags/教育` → `/blog/tags/教育/` と記事一覧描画を確認

## 補足

BWTの短いtitle警告は旧クロール由来であり、PR #157後の全308 sitemap URLはtitle 15〜70文字・description 50〜160文字・重複なしです。検索意図のないpaddingは追加していません。