### PR TITLE
SEOタイトル補足をCMS編集項目へ同期

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1218,6 +1218,10 @@ collections:
             label: 'タイトル'
             hint: 'title'
             widget: string
+          - name: 'seoTitleContext'
+            label: 'SEOタイトル補足'
+            hint: 'seoTitleContext'
+            widget: string
           - name: 'description'
             label: '説明'
             hint: 'description'
@@ -1546,6 +1550,10 @@ collections:
             label: 'タイトル'
             hint: 'title'
             widget: string
+          - name: 'seoTitleContext'
+            label: 'SEOタイトル補足'
+            hint: 'seoTitleContext'
+            widget: string
           - name: 'description'
             label: '説明'
             hint: 'description'
@@ -1723,6 +1731,10 @@ collections:
           - name: 'title'
             label: 'タイトル'
             hint: 'title'
+            widget: string
+          - name: 'seoTitleContext'
+            label: 'SEOタイトル補足'
+            hint: 'seoTitleContext'
             widget: string
           - name: 'description'
             label: '説明'
@@ -1935,6 +1947,10 @@ collections:
             label: 'タイトル'
             hint: 'title'
             widget: string
+          - name: 'seoTitleContext'
+            label: 'SEOタイトル補足'
+            hint: 'seoTitleContext'
+            widget: string
           - name: 'description'
             label: '説明'
             hint: 'description'
@@ -2069,6 +2085,10 @@ collections:
             label: 'タイトル'
             hint: 'title'
             widget: string
+          - name: 'seoTitleContext'
+            label: 'SEOタイトル補足'
+            hint: 'seoTitleContext'
+            widget: string
           - name: 'description'
             label: '説明'
             hint: 'description'
@@ -2173,6 +2193,10 @@ collections:
           - name: 'title'
             label: 'タイトル'
             hint: 'title'
+            widget: string
+          - name: 'seoTitleContext'
+            label: 'SEOタイトル補足'
+            hint: 'seoTitleContext'
             widget: string
           - name: 'subtitle'
             label: 'サブタイトル'

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -38,6 +38,23 @@ function isAllowedCmsContentPath(contentPath) {
   )
 }
 
+const contextualTitleFiles = [
+  'src/i18n/source/ja/pages/services.json',
+  'src/i18n/source/ja/pages/about.json',
+  'src/i18n/source/ja/pages/contact.json',
+  'src/i18n/source/ja/pages/acestudio.json',
+  'src/i18n/source/ja/pages/privacy.json',
+  'src/i18n/source/ja/blog.json',
+]
+
+function extractCmsFileDefinition(config, contentPath) {
+  const start = config.indexOf(`file: ${contentPath}`)
+  if (start < 0) return ''
+
+  const nextDefinition = config.indexOf('\n      - name:', start)
+  return config.slice(start, nextDefinition < 0 ? undefined : nextDefinition)
+}
+
 async function validateCmsConfig() {
   const scope = 'public/admin/config.yml'
   const config = await readFile(path.join(root, scope), 'utf8')
@@ -65,6 +82,23 @@ async function validateCmsConfig() {
     }
     if (!(await fileExists(contentPath))) {
       fail(scope, `CMS content path does not exist (${contentPath})`)
+    }
+  }
+
+  for (const contentPath of contextualTitleFiles) {
+    const source = JSON.parse(
+      await readFile(path.join(root, contentPath), 'utf8'),
+    )
+    if (
+      typeof source.seoTitleContext !== 'string' ||
+      source.seoTitleContext.trim() === ''
+    ) {
+      fail(contentPath, 'seoTitleContext must be a non-empty string')
+    }
+
+    const definition = extractCmsFileDefinition(config, contentPath)
+    if (!/^\s*-\s*name:\s*['"]seoTitleContext['"]\s*$/m.test(definition)) {
+      fail(scope, `seoTitleContext field is missing for ${contentPath}`)
     }
   }
 }


### PR DESCRIPTION
関連: #159

## 概要

- #159で追加した主要6ページの `seoTitleContext` をCMS編集項目へ登録
- 日本語source側の値が空文字でなく、対応するCMS fieldも存在することを `validate:content` で継続検証
- 配信タイトルやページ本文は変更しない

## 確認

- `npm run validate:content`: 成功
- `npm run build`: 成功（651ページ）
- `npm run validate:seo`: 成功（sitemap 308 URL、固有文脈54 URL）
- 対象2ファイルのPrettier確認: 成功
- `git diff --check`: 成功
