### PR TITLE
docs: CMS運用をeditorial workflowへ統一

### DIFF
--- a/src/content/blog/cms-selection-and-turnstile.md
+++ b/src/content/blog/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: 運用を自動化する
-      description: cms-contentブランチ、CMS編集PR、翻訳PR taskをつなぎ、通常開発とCMS更新を分離します。
+      description: mainをpublication branchにし、editorial workflowの短命branch、CMS編集PR、翻訳PR taskをつなぎます。
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -101,11 +101,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> GitHub OAuth用のCloudflare Worker
 
-cms-content branch
-  -> CMSが保存する作業ブランチ
+main branch
+  -> 公開ソースの唯一の正
 
-.github/workflows/cms-content-pr.yml
-  -> cms-content へのpushからmain向けPRを作成
+Sveltia CMS editorial workflow
+  -> 保存ごとに短命branchとmain向けPRを作成
 
 .github/workflows/create-translation-prs.yml
   -> cms: commitだけを翻訳PR taskの対象にする
@@ -162,7 +162,7 @@ Sveltia CMSでGitHubリポジトリを編集する最小設定は `backend.name`
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -171,11 +171,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-`branch` を `main` にするか、CMS専用ブランチにするかは運用の分かれ目です。
+publication branchは `main` に固定し、`publish_mode: editorial_workflow` で保存ごとの短命branchとPRを作るのが現在の構成です。`main` を本番ソースの唯一の正にしながら、CMS変更を直接commitせずレビューできます。
 
-小規模な個人サイトなら `main` へ直接保存しても成立します。ただし、会社サイトや多言語サイトでは、CMS保存を `cms-content` のような専用ブランチに逃がし、自動でPRを作る構成のほうがレビューしやすくなります。
+`cms-content` のような恒久branchを別本流にすると、`main` との同期、競合、deploy元の誤設定を継続的に管理する必要があります。受け皿branchを常設せず、短命branchをPRごとに閉じるほうが運用を単純にできます。
 
 ## 3. OAuth Workerを用意する
 
@@ -187,9 +189,11 @@ Acecoreでは、Sveltia CMS AuthenticatorをCloudflare Workersで動かし、`ba
 backend:
   name: github
   repo: acecore-systems/acecore-net
-  branch: cms-content
+  branch: main
   base_url: https://sveltia-cms-auth.example.workers.dev
   auth_methods: [oauth]
+
+publish_mode: editorial_workflow
 ```
 
 GitHub OAuth App側では、callback URLをWorkerの `/callback` に向けます。Worker側には `GITHUB_CLIENT_ID`、`GITHUB_CLIENT_SECRET`、必要なら `ALLOWED_DOMAINS` を環境変数として設定します。
@@ -317,18 +321,20 @@ CMS.init({
 
 この形にしておくと、設定ファイル本体は共有したまま、previewだけ対象ブランチを切り替えられます。
 
-## 9. CMS専用ブランチからPRを作る
+## 9. Editorial workflowで短命branchとPRを作る
 
-CMSで保存した内容をそのまま本番反映するより、`cms-content` branchに保存し、GitHub Actionsでmain向けPRを作るほうが安全です。
+CMSで保存した内容をそのまま本番反映せず、Sveltia CMSのeditorial workflowで保存ごとの短命branchとmain向けPRを作ります。
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
 
-ワークフローでは、`cms-content` と `main` の差分があるときだけPRを作ります。既に開いているCMS PRがあれば追加作成しません。
+publication branchは `main` ですが、editorial workflowの保存は `main` への直接commitではありません。CMSが短命branchとPRを管理し、レビュー後にmergeします。merge後のbranch自動削除も有効にして、恒久的な別本流を残しません。
 
 ここで重要なのがmerge方法です。Acecoreの翻訳PR taskは `cms: create ...` や `cms: update ...` というcommit subjectを見て、CMS由来の日本語source更新だけを対象にしています。
 
@@ -417,13 +423,15 @@ public/admin/runtime-config.js
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
     update: 'cms: update {{collection}} "{{slug}}"'
     delete: 'cms: delete {{collection}} "{{slug}}"'
+
+publish_mode: editorial_workflow
 
 media_folder: public/uploads
 public_folder: /uploads
@@ -441,7 +449,7 @@ collections:
       - { name: body, label: 本文, widget: markdown }
 ```
 
-ここから、著者relation、タグrelation、画像フィールド、固定ページJSON、CMS専用PR、翻訳PR taskの順で広げれば、導入直後から運用破綻しにくくなります。
+ここから、著者relation、タグrelation、画像フィールド、固定ページJSON、editorial workflow、翻訳PR taskの順で広げれば、導入直後から運用破綻しにくくなります。
 
 ## 参考リンク
 

--- a/src/content/blog/de/cms-selection-and-turnstile.md
+++ b/src/content/blog/de/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Betrieb automatisieren
-      description: cms-content-Branch, CMS-PRs und Übersetzungs-Tasks verbinden, ohne normalen Entwicklungsfluss zu vermischen.
+      description: main als Veröffentlichungsbranch nutzen und kurzlebige Editorial-Workflow-Branches, CMS-PRs und Übersetzungs-Tasks verbinden.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -99,11 +99,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> Cloudflare Worker für GitHub OAuth
 
-cms-content branch
-  -> Branch, auf dem das CMS Änderungen speichert
+main branch
+  -> einzige Quelle für die Produktion
 
-.github/workflows/cms-content-pr.yml
-  -> öffnet PR von cms-content nach main
+Sveltia CMS editorial workflow
+  -> erstellt pro Änderung einen kurzlebigen Branch und PR
 
 .github/workflows/create-translation-prs.yml
   -> erzeugt Übersetzungs-Tasks nur für cms:-Commits
@@ -152,7 +152,7 @@ Minimal braucht man `backend.name` und `backend.repo`. Für den Betrieb sollten 
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -161,9 +161,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-Für persönliche Websites kann `main` reichen. Für Unternehmens- oder mehrsprachige Websites ist ein eigener Branch wie `cms-content` besser reviewbar.
+`main` bleibt der Veröffentlichungsbranch. Mit `publish_mode: editorial_workflow` speichert jede Änderung in einem kurzlebigen Branch und PR statt direkt in der Produktion.
+
+Ein dauerhafter Branch wie `cms-content` erfordert laufende Synchronisierung und erhöht das Risiko für Konflikte oder eine falsche Deployment-Quelle. Kurzlebige Branches halten `main` als einzige Quelle der Wahrheit.
 
 ## 3. OAuth Worker ergänzen
 
@@ -233,16 +237,20 @@ CMS.init({
 })
 ```
 
-## 9. PRs aus dem CMS-Branch erstellen
+## 9. Kurzlebige Branches mit Editorial Workflow verwenden
 
-Änderungen in `cms-content` zu speichern und PRs nach `main` zu öffnen, hält Inhalte reviewbar.
+Sveltia CMS erstellt mit Editorial Workflow für jede Änderung einen kurzlebigen Branch und einen PR nach `main`.
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
+
+Der Veröffentlichungsbranch ist `main`, aber CMS-Änderungen werden nicht direkt dorthin committed. Nach Review und Merge wird der kurzlebige Branch automatisch gelöscht.
 
 Die Merge-Methode ist wichtig. Übersetzungs-Tasks hängen an Commit-Subjects wie `cms: create ...`. Wenn Squash-Merge diese entfernt, kann Automatisierung den Source-Change übersehen. Für CMS-PRs sind Merge-Commit oder Rebase-Merge geeigneter.
 

--- a/src/content/blog/en/cms-selection-and-turnstile.md
+++ b/src/content/blog/en/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Automate operations
-      description: Connect the cms-content branch, CMS edit PRs, and translation PR tasks without mixing them with normal development.
+      description: Use main as the publication branch and connect editorial workflow branches, CMS edit PRs, and translation PR tasks.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -101,11 +101,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> Cloudflare Worker for GitHub OAuth
 
-cms-content branch
-  -> branch where CMS edits are saved
+main branch
+  -> the single source of truth for production
 
-.github/workflows/cms-content-pr.yml
-  -> opens a pull request from cms-content to main
+Sveltia CMS editorial workflow
+  -> creates a short-lived branch and pull request for each edit
 
 .github/workflows/create-translation-prs.yml
   -> creates translation PR tasks only for cms: commits
@@ -162,7 +162,7 @@ The minimal GitHub backend needs `backend.name` and `backend.repo`. In productio
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -171,9 +171,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-The branch choice is important. A personal site may save directly to `main`, but a business site is easier to review when CMS edits are saved to a dedicated `cms-content` branch and then turned into a pull request.
+Keep `main` as the publication branch and enable `publish_mode: editorial_workflow`. Each save then goes to a short-lived branch and pull request instead of committing directly to production.
+
+A permanent branch such as `cms-content` creates ongoing synchronization, conflict, and deployment-source risks. Closing a short-lived branch with each pull request keeps `main` as the only source of truth.
 
 ## 3. Add an OAuth Worker
 
@@ -185,9 +189,11 @@ Acecore uses Sveltia CMS Authenticator on Cloudflare Workers and points `backend
 backend:
   name: github
   repo: acecore-systems/acecore-net
-  branch: cms-content
+  branch: main
   base_url: https://sveltia-cms-auth.example.workers.dev
   auth_methods: [oauth]
+
+publish_mode: editorial_workflow
 ```
 
 The GitHub OAuth App callback points to the Worker's `/callback` URL. The Worker receives `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and optionally `ALLOWED_DOMAINS` as environment variables.
@@ -301,18 +307,20 @@ CMS.init({
 
 This keeps the shared YAML config stable while still making preview environments point at the right branch.
 
-## 9. Create PRs From a CMS Branch
+## 9. Use Editorial Workflow for Short-Lived Branches
 
-Saving CMS edits to `cms-content` and opening a pull request to `main` keeps content changes reviewable.
+Do not publish CMS saves directly. Sveltia CMS editorial workflow creates a short-lived branch and pull request for each edit.
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
 
-The workflow checks whether a CMS PR already exists and avoids opening duplicates.
+Although the publication branch is `main`, editorial workflow does not commit saves directly to it. Review and merge the generated pull request, then delete the merged branch automatically.
 
 The merge method matters. Acecore's translation task detection relies on commit subjects such as `cms: create ...` and `cms: update ...`. If a CMS PR is squash merged and those subjects disappear, the translation workflow may not detect the source change. For CMS PRs, keep the `cms:` commits through merge commit or rebase merge.
 
@@ -391,13 +399,15 @@ public/admin/runtime-config.js
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
     update: 'cms: update {{collection}} "{{slug}}"'
     delete: 'cms: delete {{collection}} "{{slug}}"'
+
+publish_mode: editorial_workflow
 
 media_folder: public/uploads
 public_folder: /uploads

--- a/src/content/blog/es/cms-selection-and-turnstile.md
+++ b/src/content/blog/es/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Automatizar la operación
-      description: Conecta la rama cms-content, los PRs de CMS y las tareas de traducción sin mezclarlas con desarrollo normal.
+      description: Usa main como rama de publicación y conecta ramas temporales del flujo editorial, PRs de CMS y tareas de traducción.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -101,11 +101,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> Cloudflare Worker para GitHub OAuth
 
-cms-content branch
-  -> rama donde el CMS guarda cambios
+main branch
+  -> única fuente de verdad para producción
 
-.github/workflows/cms-content-pr.yml
-  -> crea PR desde cms-content hacia main
+Sveltia CMS editorial workflow
+  -> crea una rama temporal y un PR por cada cambio
 
 .github/workflows/create-translation-prs.yml
   -> crea tareas de traducción solo para commits cms:
@@ -154,7 +154,7 @@ Lo mínimo es `backend.name` y `backend.repo`, pero en producción conviene defi
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -163,9 +163,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-Para un sitio personal, guardar en `main` puede bastar. Para un sitio corporativo o multilingüe, una rama dedicada como `cms-content` facilita revisión y rollback.
+Mantén `main` como rama de publicación y activa `publish_mode: editorial_workflow`. Cada guardado usa una rama temporal y un PR en vez de escribir directamente en producción.
+
+Una rama permanente como `cms-content` exige sincronización continua y aumenta el riesgo de conflictos o de configurar mal el origen del despliegue. Las ramas temporales mantienen `main` como única fuente de verdad.
 
 ## 3. Añadir OAuth Worker
 
@@ -235,16 +239,20 @@ CMS.init({
 })
 ```
 
-## 9. Crear PRs desde una rama CMS
+## 9. Usar ramas temporales con editorial workflow
 
-Guardar cambios en `cms-content` y crear PR hacia `main` conserva revisión y trazabilidad.
+Sveltia CMS crea una rama temporal y un PR hacia `main` para cada cambio mediante editorial workflow.
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
+
+Aunque la rama de publicación es `main`, el CMS no escribe directamente en ella. Tras revisar y fusionar el PR, la rama temporal se elimina automáticamente.
 
 La forma de merge importa. Las tareas de traducción dependen de subjects como `cms: create ...` o `cms: update ...`. Si se hace squash y se pierden, la automatización puede no detectar el cambio. Para PRs CMS, conviene merge commit o rebase merge.
 

--- a/src/content/blog/fr/cms-selection-and-turnstile.md
+++ b/src/content/blog/fr/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Automatiser l'exploitation
-      description: Relier la branche cms-content, les PRs de CMS et les tâches de traduction sans les mélanger au développement.
+      description: Utiliser main comme branche de publication et relier les branches temporaires du workflow éditorial, les PRs CMS et les tâches de traduction.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -99,11 +99,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> Cloudflare Worker pour GitHub OAuth
 
-cms-content branch
-  -> branche où le CMS enregistre les modifications
+main branch
+  -> source unique pour la production
 
-.github/workflows/cms-content-pr.yml
-  -> ouvre une PR de cms-content vers main
+Sveltia CMS editorial workflow
+  -> crée une branche temporaire et une PR par modification
 
 .github/workflows/create-translation-prs.yml
   -> crée des tâches de traduction seulement pour les commits cms:
@@ -152,7 +152,7 @@ Le minimum est `backend.name` et `backend.repo`. En production, il faut aussi d�
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -161,9 +161,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-Sur un site personnel, sauvegarder vers `main` peut suffire. Pour un site d'entreprise ou multilingue, une branche dédiée comme `cms-content` rend la revue plus sûre.
+Conservez `main` comme branche de publication et activez `publish_mode: editorial_workflow`. Chaque sauvegarde passe alors par une branche temporaire et une PR, sans écrire directement en production.
+
+Une branche permanente comme `cms-content` impose une synchronisation continue et augmente le risque de conflits ou d'une mauvaise source de déploiement. Les branches temporaires gardent `main` comme source unique.
 
 ## 3. Ajouter un OAuth Worker
 
@@ -233,16 +237,20 @@ CMS.init({
 })
 ```
 
-## 9. Créer des PRs depuis une branche CMS
+## 9. Utiliser des branches temporaires avec editorial workflow
 
-Enregistrer dans `cms-content` puis ouvrir une PR vers `main` garde la revue claire.
+Sveltia CMS crée une branche temporaire et une PR vers `main` pour chaque modification avec editorial workflow.
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
+
+Même si la branche de publication est `main`, le CMS n'y écrit pas directement. Après revue et fusion de la PR, la branche temporaire est supprimée automatiquement.
 
 La méthode de merge compte. Les tâches de traduction dépendent de subjects comme `cms: create ...`. Si un squash les supprime, l'automatisation peut rater le changement. Pour les PRs CMS, préférez merge commit ou rebase merge.
 

--- a/src/content/blog/ko/cms-selection-and-turnstile.md
+++ b/src/content/blog/ko/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: 운영 자동화
-      description: cms-content 브랜치, CMS 편집 PR, 번역 PR task를 일반 개발과 분리해 연결합니다.
+      description: main을 publication branch로 사용하고 editorial workflow의 단기 branch, CMS 편집 PR, 번역 PR task를 연결합니다.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -99,11 +99,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> GitHub OAuth용 Cloudflare Worker
 
-cms-content branch
-  -> CMS 편집 내용 저장 브랜치
+main branch
+  -> 운영 환경의 유일한 기준
 
-.github/workflows/cms-content-pr.yml
-  -> cms-content에서 main으로 PR 생성
+Sveltia CMS editorial workflow
+  -> 변경마다 단기 branch와 main 대상 PR 생성
 
 .github/workflows/create-translation-prs.yml
   -> cms: commit에만 번역 PR task 생성
@@ -152,7 +152,7 @@ CMS.init({
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -161,9 +161,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-개인 사이트라면 `main`에 바로 저장해도 됩니다. 회사 사이트나 다국어 사이트라면 `cms-content` 같은 전용 branch에 저장하고 PR로 검토하는 구성이 안전합니다.
+`main`을 publication branch로 유지하고 `publish_mode: editorial_workflow`를 사용합니다. 각 저장은 운영 환경에 직접 기록되지 않고 단기 branch와 PR을 거칩니다.
+
+`cms-content` 같은 영구 branch는 지속적인 동기화가 필요하며 충돌이나 잘못된 배포 source 설정 위험을 높입니다. PR마다 단기 branch를 닫으면 `main`을 유일한 기준으로 유지할 수 있습니다.
 
 ## 3. OAuth Worker 준비
 
@@ -233,16 +237,20 @@ CMS.init({
 })
 ```
 
-## 9. CMS branch에서 PR 만들기
+## 9. Editorial workflow로 단기 branch와 PR 만들기
 
-CMS 저장을 `cms-content`로 보내고 main으로 PR을 열면 리뷰가 가능합니다.
+Sveltia CMS editorial workflow는 변경마다 단기 branch와 `main` 대상 PR을 만듭니다.
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
+
+publication branch는 `main`이지만 CMS가 여기에 직접 commit하지는 않습니다. PR을 검토하고 merge한 뒤 단기 branch를 자동으로 삭제합니다.
 
 merge 방식도 중요합니다. 번역 workflow는 `cms: create ...`, `cms: update ...` 같은 commit subject를 봅니다. squash merge로 subject가 사라지면 자동화가 감지하지 못할 수 있으므로 CMS PR은 merge commit 또는 rebase merge가 적합합니다.
 

--- a/src/content/blog/pt/cms-selection-and-turnstile.md
+++ b/src/content/blog/pt/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Automatizar a operação
-      description: Conecte a branch cms-content, PRs de CMS e tarefas de tradução sem misturar com desenvolvimento normal.
+      description: Use main como branch de publicação e conecte branches temporárias do editorial workflow, PRs de CMS e tarefas de tradução.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -99,11 +99,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> Cloudflare Worker para GitHub OAuth
 
-cms-content branch
-  -> branch onde o CMS salva edições
+main branch
+  -> única fonte de verdade para produção
 
-.github/workflows/cms-content-pr.yml
-  -> abre PR de cms-content para main
+Sveltia CMS editorial workflow
+  -> cria uma branch temporária e um PR para cada alteração
 
 .github/workflows/create-translation-prs.yml
   -> cria tarefas de tradução apenas para commits cms:
@@ -152,7 +152,7 @@ O mínimo é `backend.name` e `backend.repo`, mas em produção defina também b
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -161,9 +161,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-Para sites pessoais, salvar direto na `main` pode bastar. Para sites corporativos ou multilíngues, uma branch dedicada como `cms-content` ajuda na revisão.
+Mantenha `main` como branch de publicação e ative `publish_mode: editorial_workflow`. Cada salvamento passa por uma branch temporária e um PR, sem gravar diretamente em produção.
+
+Uma branch permanente como `cms-content` exige sincronização contínua e aumenta o risco de conflitos ou de configurar a origem de deploy incorretamente. Branches temporárias mantêm `main` como única fonte de verdade.
 
 ## 3. Adicionar OAuth Worker
 
@@ -233,16 +237,20 @@ CMS.init({
 })
 ```
 
-## 9. Criar PRs de uma branch CMS
+## 9. Usar branches temporárias com editorial workflow
 
-Salvar em `cms-content` e abrir PR para `main` mantém a revisão clara.
+O Sveltia CMS cria uma branch temporária e um PR para `main` a cada alteração usando editorial workflow.
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
+
+Embora a branch de publicação seja `main`, o CMS não grava diretamente nela. Após revisar e fazer merge do PR, a branch temporária é removida automaticamente.
 
 O modo de merge importa. As traduções dependem de subjects como `cms: create ...` e `cms: update ...`. Se um squash merge apaga esses subjects, a automação pode não detectar a mudança. Para PRs de CMS, preserve os commits `cms:` com merge commit ou rebase merge.
 

--- a/src/content/blog/ru/cms-selection-and-turnstile.md
+++ b/src/content/blog/ru/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Автоматизировать эксплуатацию
-      description: Связать ветку cms-content, CMS PR и задачи перевода, не смешивая их с обычной разработкой.
+      description: Использовать main как ветку публикации и связать временные ветки editorial workflow, CMS PR и задачи перевода.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -99,11 +99,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> Cloudflare Worker для GitHub OAuth
 
-cms-content branch
-  -> ветка, куда CMS сохраняет изменения
+main branch
+  -> единственный источник для production
 
-.github/workflows/cms-content-pr.yml
-  -> открывает PR из cms-content в main
+Sveltia CMS editorial workflow
+  -> создаёт временную ветку и PR для каждого изменения
 
 .github/workflows/create-translation-prs.yml
   -> создаёт задачи перевода только для cms: commits
@@ -152,7 +152,7 @@ CMS.init({
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -161,9 +161,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-Для личного сайта можно сохранять прямо в `main`. Для корпоративного или многоязычного сайта удобнее сохранять в отдельную ветку `cms-content` и создавать PR.
+Оставьте `main` веткой публикации и включите `publish_mode: editorial_workflow`. Каждое сохранение проходит через временную ветку и PR, а не записывается напрямую в production.
+
+Постоянная ветка вроде `cms-content` требует непрерывной синхронизации и повышает риск конфликтов или неверной настройки источника deploy. Временные ветки сохраняют `main` единственным источником истины.
 
 ## 3. Добавить OAuth Worker
 
@@ -233,16 +237,20 @@ CMS.init({
 })
 ```
 
-## 9. Создавать PR из CMS-ветки
+## 9. Использовать временные ветки editorial workflow
 
-Сохранение в `cms-content` и PR в `main` сохраняют ревью контента.
+Sveltia CMS создаёт временную ветку и PR в `main` для каждого изменения через editorial workflow.
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
+
+Хотя ветка публикации — `main`, CMS не записывает изменения прямо в неё. После ревью и merge временная ветка удаляется автоматически.
 
 Способ merge важен. Задачи перевода зависят от commit subjects вроде `cms: create ...`. Если squash merge их удалит, автоматизация может не увидеть изменение source. Для CMS PR лучше merge commit или rebase merge.
 

--- a/src/content/blog/zh-cn/cms-selection-and-turnstile.md
+++ b/src/content/blog/zh-cn/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: 自动化运维
-      description: 将 cms-content 分支、CMS 编辑 PR 与翻译 PR task 连接起来，并与普通开发分离。
+      description: 将 main 作为发布分支，并连接 editorial workflow 的短期分支、CMS 编辑 PR 与翻译 PR task。
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -101,11 +101,11 @@ public/admin/config.yml
 workers/sveltia-cms-auth
   -> GitHub OAuth 用 Cloudflare Worker
 
-cms-content branch
-  -> CMS 保存编辑内容的分支
+main branch
+  -> 生产环境唯一的真实来源
 
-.github/workflows/cms-content-pr.yml
-  -> 从 cms-content 自动创建 main 向 PR
+Sveltia CMS editorial workflow
+  -> 每次修改创建短期分支和 main 向 PR
 
 .github/workflows/create-translation-prs.yml
   -> 只为 cms: commit 创建翻译 PR task
@@ -156,7 +156,7 @@ CMS.init({
 backend:
   name: github
   repo: owner/repository
-  branch: cms-content
+  branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
   auth_methods: [oauth]
   commit_messages:
@@ -165,9 +165,13 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
+
+publish_mode: editorial_workflow
 ```
 
-个人网站可以直接保存到 `main`。公司网站或多语言网站则更适合保存到 `cms-content`，再自动创建 PR。
+将 `main` 保持为发布分支，并启用 `publish_mode: editorial_workflow`。每次保存都会进入短期分支和 PR，而不是直接写入生产环境。
+
+像 `cms-content` 这样的常设分支需要持续同步，并会增加冲突或错误配置部署来源的风险。按 PR 关闭短期分支，可以让 `main` 始终是唯一的真实来源。
 
 ## 3. 准备 OAuth Worker
 
@@ -255,16 +259,20 @@ CMS.init({
 
 这样可以保持 YAML 配置共通，同时让 preview 指向正确分支。
 
-## 9. 从 CMS 专用分支创建 PR
+## 9. 使用 editorial workflow 的短期分支
 
-CMS 保存到 `cms-content` 后，通过 GitHub Actions 创建 main 向 PR，可以让内容修改保持可审核。
+Sveltia CMS 通过 editorial workflow 为每次修改创建短期分支和 main 向 PR。
 
 ```yaml
-on:
-  push:
-    branches:
-      - cms-content
+backend:
+  name: github
+  repo: owner/repository
+  branch: main
+
+publish_mode: editorial_workflow
 ```
+
+虽然发布分支是 `main`，CMS 并不会直接提交到它。审核并合并 PR 后，短期分支会自动删除。
 
 这里的 merge 方法很重要。Acecore 的翻译任务依赖 `cms: create ...`、`cms: update ...` 等 commit subject。如果 squash merge 抹掉这些 subject，翻译 workflow 可能无法检测到 source 更新。CMS PR 应使用保留 `cms:` commit 的 merge commit 或 rebase merge。
 


### PR DESCRIPTION
関連 Issue: なし

## 概要

- CMS導入記事の恒久cms-content branch推奨を廃止
- mainをpublication branchの唯一の正とする構成へ統一
- Sveltia CMSのeditorial workflowによる短命branchとPR運用を9言語で反映

## 確認

- npm ci
- npx prettier --check 対象9ファイル
- npm run validate:content
- npm run build
- git diff --check

## 補足

通常権限のbuildはWindows環境のEPERMになったため、同一コマンドを権限付きで再実行し、651ページ生成とPagefind索引まで成功しました。