### PR TITLE
Bing向けにルートURLのcanonical判定を安定化

### DIFF
--- a/scripts/validate-seo.mjs
+++ b/scripts/validate-seo.mjs
@@ -68,6 +68,33 @@ function extractCanonical(html) {
   return decodeHtmlEntities(match?.[2] ?? '')
 }
 
+function extractAttribute(tag, name) {
+  const match = tag.match(new RegExp(`\\b${name}=(['"])([\\s\\S]*?)\\1`, 'i'))
+  return decodeHtmlEntities(match?.[2] ?? '')
+}
+
+function extractHreflangLinks(html) {
+  return new Map(
+    Array.from(html.matchAll(/<link\s+[^>]*>/gi), (match) => match[0])
+      .filter((tag) => extractAttribute(tag, 'rel') === 'alternate')
+      .filter((tag) => extractAttribute(tag, 'hreflang'))
+      .map((tag) => [
+        extractAttribute(tag, 'hreflang'),
+        extractAttribute(tag, 'href'),
+      ]),
+  )
+}
+
+function getImageAltIssues(html, url) {
+  return Array.from(html.matchAll(/<img\s+[^>]*>/gi), (match) => match[0])
+    .filter((tag) => !extractAttribute(tag, 'alt').trim())
+    .map((tag) => ({
+      label: 'image alt is empty or missing',
+      url,
+      value: extractAttribute(tag, 'src') || '(missing src)',
+    }))
+}
+
 async function getSitemapUrls() {
   const sitemapIndex = await readFile(
     path.join(distDirectory, 'sitemap-index.xml'),
@@ -169,6 +196,38 @@ for (const url of urls) {
       value: canonical || '(missing)',
     })
   }
+
+  issues.push(...getImageAltIssues(html, url))
+}
+
+const rootUrl = 'https://acecore.net/'
+const rootHtml = await readFile(getHtmlPath(rootUrl), 'utf8')
+const rootHreflangLinks = extractHreflangLinks(rootHtml)
+const expectedRootHreflangLinks = new Map([
+  ['ja', rootUrl],
+  ['en', 'https://acecore.net/en/'],
+  ['x-default', rootUrl],
+])
+
+for (const [hreflang, expectedUrl] of expectedRootHreflangLinks) {
+  const actualUrl = rootHreflangLinks.get(hreflang)
+  if (actualUrl === expectedUrl) continue
+  issues.push({
+    label: 'root hreflang does not match the default locale policy',
+    url: rootUrl,
+    value: `${hreflang}: ${actualUrl || '(missing)'} (expected ${expectedUrl})`,
+  })
+}
+
+if (
+  rootHtml.includes('navigator.language') &&
+  rootHtml.includes('location.replace')
+) {
+  issues.push({
+    label: 'root page contains an automatic locale redirect',
+    url: rootUrl,
+    value: 'Use explicit hreflang links and the language switcher instead.',
+  })
 }
 
 const expectedContextualCorePages =

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -50,8 +50,8 @@ const currentPath = Astro.url.pathname
       href={getLocalizedUrl('/', locale)}
       class="ac-touch gap-2 rounded-md pr-3 font-800 text-xl text-slate-950 no-underline transition-colors hover:text-brand-600"
     >
-      <img src="/favicon.svg" alt="" class="h-8 w-8" />
-      Acecore
+      <img src="/favicon.svg" alt="Acecore" class="h-8 w-8" />
+      <span aria-hidden="true">Acecore</span>
     </a>
     <nav
       class="hidden items-center gap-1 xl:flex"

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -70,15 +70,6 @@ const showLabel = Astro.props.showLabel ?? false
           btn.setAttribute('aria-expanded', String(expanded))
         })
 
-        list
-          .querySelectorAll<HTMLAnchorElement>('a[data-locale]')
-          .forEach((a) => {
-            a.addEventListener('click', () => {
-              const locale = a.dataset.locale
-              if (locale) localStorage.setItem('preferred-locale', locale)
-            })
-          })
-
         document.addEventListener('click', (e) => {
           if (!sw.contains(e.target as Node)) {
             list.classList.add('hidden')

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -400,31 +400,6 @@ import { SITE } from '../data/site'
     <ClientRouter />
     <script is:inline>
       ;(function () {
-        if (localStorage.getItem('preferred-locale')) return
-        var path = location.pathname
-        if (path !== '/' && path !== '') return
-        var lang = (navigator.language || '').toLowerCase()
-        var map = {
-          en: 'en',
-          de: 'de',
-          fr: 'fr',
-          es: 'es',
-          pt: 'pt',
-          ko: 'ko',
-          ru: 'ru',
-          'zh-cn': 'zh-cn',
-          'zh-hans': 'zh-cn',
-          zh: 'zh-cn',
-        }
-        var detected = map[lang] || map[lang.split('-')[0]]
-        if (detected && detected !== 'ja') {
-          localStorage.setItem('preferred-locale', detected)
-          location.replace('/' + detected + '/')
-        }
-      })()
-    </script>
-    <script is:inline>
-      ;(function () {
         if (window.__aceAnalyticsClickTrackingInitialized) return
         window.__aceAnalyticsClickTrackingInitialized = true
 


### PR DESCRIPTION
関連 Issue: なし

## 概要

- ルートURLでブラウザ言語を推測して `/en/` などへ移動するクライアント側自動転送を削除
- 明示的な言語切替リンクと既存の相互 `hreflang` は維持し、`/` を日本語既定・`x-default`・self canonicalとして安定化
- ヘッダーロゴを `alt="Acecore"` とし、隣接する表示テキストを `aria-hidden` にしてBingの空alt指摘と読み上げ重複を同時に解消
- SEO検証へルートの `ja` / `en` / `x-default`、自動言語転送の不在、全サイトマップURLの画像altを追加

Bingbot/Googlebot/通常UAと `Accept-Language` の組み合わせでは、本番HTTPはいずれも `200`・`https://acecore.net/` のself canonicalでした。一方、HTML内の `navigator.language` と `location.replace` はJavaScriptレンダラーを英語版へ遷移させるため、Bing Webmaster Toolsの「英語版canonicalの代替」判定と整合します。

Google検索セントラルも言語推測による自動転送を避け、言語別URL・hreflang・明示的な切替リンクを推奨しています。
https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites

## 確認

- `npm ci`
- `npx prettier --check scripts/validate-seo.mjs src/components/Header.astro src/components/LanguageSwitcher.astro src/layouts/BaseLayout.astro`
- `npm run validate:content`
- `npm run validate:tag-redirects`
- `npm run validate:legacy-redirects`
- `npm run build`（Windows sandbox内の初回は `spawn EPERM`、同一コマンドを権限付きで再実行して651ページ成功）
- `npm run validate:seo`（サイトマップ308 URL、core 54 URL、問題0）
- `git diff --check`
- 本番 `https://acecore.net/` と `/en/` を通常UA・Googlebot・Bingbot、日英Accept-LanguageでHTTP監査
- GitHub Actions `Build and Format`: success
- Cloudflare Pages: success
- Preview `https://e374a50f.acecore-net.pages.dev/` を通常日英UA・Googlebot・Bingbotで実配信監査
  - 全ケース `200`、canonical `https://acecore.net/`
  - `ja` / `en` / 全言語 / `x-default` hreflang正常
  - 自動言語転送なし
  - 空alt・alt属性欠落ともに0件
  - Previewの `x-robots-tag: noindex` はCloudflareのPreview保護として正常

## 補足

マージ後にBing Webmaster ToolsのLive URL検査とインデックス再要求を実施します。