### PR TITLE
CMS保存をcontent-only PR経路へ切り替える

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,6 @@
 - Issue URL が渡された場合は、本文とチェックリストを受け入れ条件として扱う。
 - Issue template は `不具合` と `タスク` を基本にし、必要以上に入力項目を増やさない。
 - 多言語対応では日本語ソースを正とし、CMS と翻訳構成を崩さない。
-- CMS 認証は GitHub 認証型とし、Cloudflare Access は必要に応じて入口保護として扱う。
+- CMS 認証は GitHub 認証型とし、保存は同一origin proxyが `cms/acecore/*` の短命branchとPRへ変換する。Sveltia未実装のEditorial Workflow設定だけに依存しない。
 - 差分は目的に必要な範囲に絞り、既存の Astro、TypeScript、UnoCSS 構成を尊重する。
 - サイト出力に影響する変更では `npm run build` を実行する。docs/template のみなら対象ファイルの format check と `git diff --check` を行う。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Validate CMS content
         run: npm run validate:content
 
+      - name: Test CMS proxy
+        run: npm run test:cms
+
+      - name: Type-check Pages Functions
+        run: npm run typecheck:functions
+
       - name: Build site
         run: npm run build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,9 @@
 - サイト文言を CMS から編集可能にする場合は `public/admin/config.yml` も更新し、対応する JSON key とフィールド名を揃える。
 - CMS の日時、キャンペーン、告知、募集枠など期間制御が必要な情報は、表示開始と表示終了を CMS から扱える設計にする。
 - このリポジトリの CMS 認証は GitHub 認証型とする。Cloudflare Access を前段に置く場合も、保存認証は GitHub OAuth Worker を使う。
-- Cherry のような Cloudflare Access 型 proxy へ寄せる場合は、別途 backend actor、書き込み path 制限、CI 経由 PR 作成まで設計してから行う。
-- CMS backend の publication branch は `main` にし、`publish_mode: editorial_workflow` で短命な CMS branch と PR を作らせる。
+- CMS のpublication branchは `main` にし、同一originのREST / GraphQL proxyがGitHub user、repository権限、書き込みpath、最新HEADを検証して `cms/acecore/*` の短命branchとPRだけを作る。
+- Sveltia CMSではEditorial Workflowが未実装のため、`publish_mode: editorial_workflow` の設定だけでPR運用を成立させたと判断しない。
+- Cherry / HattのCloudflare Access認証型とは認証情報とbackend actorを共用しない。短命branch、content-only制約、PR、CIという書き込み方針だけを揃える。
 - `cms-content` のような恒久的な CMS 投稿受け皿 branch は使わない。
 - CMS PR は merge commit または rebase merge で `main` に入れる。squash merge では `cms: ...` commit subject が失われ、翻訳 PR task の自動検出対象外になる場合がある。
 - 翻訳作業だけを依頼された場合は、日本語 source を勝手に変更しない。placeholder、URL、コード風 token、製品名は壊さない。

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ src/
 #### 本番 CMS の保存と PR 反映
 
 - 本番ソースの正は `main` です。Cloudflare Pages の production deploy 元も GitHub 連携の `main` にします。
-- Sveltia CMS は `backend.branch: main` と `publish_mode: editorial_workflow` で運用します。
-- CMS 保存時は `cms/...` のような短命 branch と PR が作られ、`main` に直接 commit しません。
+- Sveltia CMS は `backend.branch: main` と同一originのGitHub API proxyで運用します。現行SveltiaではEditorial Workflowが未実装のため、`publish_mode` には依存しません。
+- proxyがGitHub OAuth userのwrite権限と変更pathを検証し、保存ごとに `cms/acecore/*` の短命branchとPRを作ります。`main` へ直接commitしません。
 - 恒久的な `cms-content` 投稿受け皿 branch は使いません。
 - CMS PR は通常の merge commit または rebase merge でマージします。squash merge では `cms: ...` commit subject が失われ、翻訳 PR task の自動検出対象外になる場合があります。
 - CMS PR が `main` に merge されると、Cloudflare Pages が GitHub `main` push を受けて production deploy します。
@@ -153,7 +153,7 @@ author: 'author-id'
 Sveltia CMS は日本語ソース記事と日本語の固定ページ文言を編集できます。多言語記事本文とページ文言は GitHub Copilot coding agent が作成する Pull Request ベースで管理します。PR 量を抑えるため、push 連動の対象は Sveltia CMS の `cms: ...` commit だけに限定します。
 
 1. 日本語ソースを Sveltia CMS で更新する
-2. editorial workflow が短命な CMS branch と `main` 向け PR を作成する
+2. CMS proxy が `cms/acecore/*` の短命branchと `main` 向けPRを作成する
 3. CMS PR を `main` にマージすると、CMS commit の本文差分または日本語文言 key 差分だけを GitHub Actions が検出する
 4. Copilot coding agent が該当差分だけに沿って `src/content/blog/{locale}/` または `src/i18n/translations/{locale}.json` を更新する
 5. 完了時に `[translation]` PR が ready for review になったら、内容とビルドを確認してから必要に応じて手動マージする

--- a/docs/cms-write-workflow.md
+++ b/docs/cms-write-workflow.md
@@ -1,52 +1,61 @@
 # CMS 書き込み branch 運用
 
-最終確認日: 2026-06-19
+最終確認日: 2026-07-20
 
-## 現在の live 状態
+## 現在の構成
 
 - GitHub repository: `acecore-systems/acecore-net`
-- GitHub default branch: `main`
-- CMS backend: `public/admin/config.yml` の `backend.name: github`
-- CMS auth mode: GitHub 認証型
-- CMS OAuth backend: `https://sveltia-cms-auth.sparkling-tree-7cef.workers.dev`
-- CMS publication branch: `main`
-- CMS publish mode: `editorial_workflow`
-- `main`: GitHub branch API 上の `protected` は `true`
-- Branch protection: admin enforcement on、PR review on、required status check `Build and Format`
-- GitHub ruleset: なし
+- CMS: Sveltia CMS
+- 認証: GitHub OAuth Worker
+- publication branch: `main`
+- 保存API: 同一originの `/admin/api/github/*` と `/admin/api/graphql`
+- 保存branch: `cms/acecore/*` の短命branch
+- 本番deploy: Cloudflare PagesのGitHub連携 `main`
+- `main` protection: strictな `Build and Format`、admin enforcement、force push / deletion禁止
 
-## 方針
+`publish_mode: editorial_workflow` は設定しません。Sveltia CMSでは現時点でEditorial Workflowが未実装であり、設定だけを追加しても短命branchやPRは作られないためです。
 
-`main` は本番ソースの唯一の正にします。Cloudflare Pages の production deploy 元も GitHub 連携の `main` だけにします。
+## 保存経路
 
-Sveltia CMS は `backend.branch: main` と `publish_mode: editorial_workflow` で運用します。CMS 保存は恒久的な投稿受け皿 branch ではなく、短命な `cms/...` branch と PR として扱います。
+1. 編集者がGitHub OAuth Worker経由でSveltia CMSへログインする。
+2. Pages FunctionsがOAuth tokenでGitHub userと `acecore-net` へのpush権限を確認する。
+3. CMSのreadは、許可されたcontentとmediaのtree / blobだけを同一origin proxy経由で返す。
+4. 保存時はrepository、base branch `main`、最新HEAD、変更path、ファイル数、合計サイズを検証する。
+5. proxyが `cms/acecore/*` branchを `main` から作り、画像とコンテンツを同じcommitへ保存して `main` 向けPRを作る。
+6. `Build and Format` とCloudflare Pages previewを通過したPRだけをレビュー後にmergeする。
+7. `main` pushを受けてCloudflare Pagesがproduction deployする。
 
-Cloudflare Access を `/admin/` の前段に置く場合も、保存認証は GitHub OAuth Worker が担当します。Cherry のような Cloudflare Access 型 token proxy には寄せません。
+恒久的な `cms-content` branchは使いません。Sveltia CMSがEditorial Workflowを実装した後も、現行proxyと同等のpath制限、PR、CI、実保存テストを満たすまでは設定だけで置き換えません。
 
-`cms-content` は恒久運用しません。旧 remote branch は未反映差分や open PR がないことを確認して削除済みです。
+## CMS管理対象
 
-## 現行フロー
+- `src/content/blog/*.md` の日本語source記事（locale subdirectoryは対象外）
+- `src/content/authors/*.json`
+- `src/content/tags/*.json`
+- `src/i18n/source/ja/campaigns/*.json` と `public/admin/config.yml` の `files` に列挙した日本語source JSON
+- `public/uploads/**` の許可済み画像・PDF形式
 
-1. Sveltia CMS が `main` を publication branch として読み込む。
-2. CMS 保存時、editorial workflow が短命な CMS branch と PR を作る。
-3. PR CI が `npm run format:check`、`npm run validate:content`、`npm run build` を実行する。
-4. CMS PR を merge commit または rebase merge で `main` に入れる。
-5. `main` push を受けて Cloudflare Pages が production deploy する。
-6. `src/content/blog/*.md` または `src/i18n/source/ja/**/*.json` の CMS commit を検出した場合、翻訳 PR task が作成される。
+翻訳ファイル、workflow、設定、source codeなど上記以外はproxyが拒否します。1回の保存は最大100ファイル、追加データ合計25 MiBです。
 
-CMS PR は squash merge しません。squash merge では `cms: ...` commit subject が失われ、翻訳 PR task の自動検出対象外になる場合があります。
+## 認証方式の境界
 
-## 残る制約
+AcecoreとAceServerはGitHub認証型で、編集者のOAuth tokenを本人確認とGitHub上の保存actorに使います。CherryとHattはCloudflare Access認証型で、サイト専用GitHub Appを保存actorに使います。短命branch、content-only制約、PR、CIという書き込み方針は共通ですが、認証情報やAppは共用しません。
 
-現在の Sveltia CMS は GitHub OAuth 経由で保存します。editorial workflow により `main` 直 commit は避けられますが、PR branch 作成の actor は編集者個人の GitHub 権限です。
+GitHub認証型では、CMS proxy内の操作は制限されても、編集者個人のGitHub権限自体は変わりません。将来backend actorをGitHub Appへ分離する場合も、GitHubログインは維持し、Appとprivate keyはrepository単位で分離します。
 
-編集者個人ではなく専用 bot / GitHub App / backend actor に完全移行したい場合は、CMS 保存を受ける backend を別途実装し、その backend が content-only PR を作る形にします。
+## Mergeと翻訳
 
-## 検証方針
+CMS PRはmerge commitまたはrebase mergeで取り込みます。squash mergeでは `cms: ...` commit subjectが失われ、翻訳PR taskの自動検出対象外になる場合があります。
 
-`npm run validate:content` は CMS config が次の条件を満たすことも確認します。
+## 検証
 
-- `backend.branch` が `main`
-- `publish_mode` が `editorial_workflow`
-- CMS に `path` field を露出しない
-- CMS 管理対象が許可された content / i18n source path に収まっている
+`npm run validate:content` は、`main`、same-origin proxy、Pages Functions route、GitHub user権限検証、`cms/acecore/*` PR作成、CMS公開pathを確認します。proxy変更時は次も実行します。
+
+```powershell
+npm run test:cms
+npm run typecheck:functions
+npm run format:check
+npm run validate:content
+npm run build
+git diff --check
+```

--- a/functions/admin/api/_cms-policy.ts
+++ b/functions/admin/api/_cms-policy.ts
@@ -1,0 +1,142 @@
+export const CMS_REPOSITORY = {
+  owner: 'acecore-systems',
+  name: 'acecore-net',
+  branch: 'main',
+} as const
+
+const CONTENT_RULES = [
+  { prefix: 'src/content/blog/', extension: '.md', recursive: false },
+  { prefix: 'src/content/authors/', extension: '.json', recursive: false },
+  { prefix: 'src/content/tags/', extension: '.json', recursive: false },
+  {
+    prefix: 'src/i18n/source/ja/campaigns/',
+    extension: '.json',
+    recursive: false,
+  },
+] as const
+
+const CONTENT_FILES = new Set([
+  'src/i18n/source/ja/common.json',
+  'src/i18n/source/ja/blog.json',
+  'src/i18n/source/ja/pages/home.json',
+  'src/i18n/source/ja/pages/services.json',
+  'src/i18n/source/ja/pages/about.json',
+  'src/i18n/source/ja/pages/contact.json',
+  'src/i18n/source/ja/pages/acestudio.json',
+  'src/i18n/source/ja/pages/privacy.json',
+  'src/i18n/source/ja/pages/not-found.json',
+])
+
+const MEDIA_PREFIX = 'public/uploads/'
+const MAX_CMS_PATH_LENGTH = 240
+const MEDIA_EXTENSIONS = new Set([
+  '.avif',
+  '.gif',
+  '.jpeg',
+  '.jpg',
+  '.pdf',
+  '.png',
+  '.svg',
+  '.webp',
+])
+
+export function normalizeCmsPath(path: string | null) {
+  if (path === null || /[\u0000-\u001f\u007f]/.test(path)) return null
+
+  const normalized = path.replace(/\\/g, '/').replace(/^\/+/, '')
+
+  if (normalized === '') return ''
+  if (normalized.length > MAX_CMS_PATH_LENGTH) return null
+
+  const segments = normalized.split('/')
+
+  if (
+    segments.some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    return null
+  }
+
+  return segments.join('/')
+}
+
+export function isAllowedCmsWritePath(path: string) {
+  if (normalizeCmsPath(path) !== path) return false
+
+  if (CONTENT_FILES.has(path)) return true
+
+  if (
+    CONTENT_RULES.some(({ prefix, extension, recursive }) => {
+      if (!path.startsWith(prefix) || !path.endsWith(extension)) return false
+
+      const relativePath = path.slice(prefix.length)
+
+      return (
+        relativePath.length > 0 && (recursive || !relativePath.includes('/'))
+      )
+    })
+  ) {
+    return true
+  }
+
+  if (!path.startsWith(MEDIA_PREFIX)) return false
+
+  return MEDIA_EXTENSIONS.has(getExtension(path))
+}
+
+export function isAllowedCmsDirectoryPath(path: string) {
+  if (normalizeCmsPath(path) !== path) return false
+  if (path === '') return true
+
+  if (isDirectoryAllowedByRoot(path, MEDIA_PREFIX.slice(0, -1), true)) {
+    return true
+  }
+
+  if (
+    CONTENT_RULES.some(({ prefix, recursive }) => {
+      return isDirectoryAllowedByRoot(path, prefix.slice(0, -1), recursive)
+    })
+  ) {
+    return true
+  }
+
+  return Array.from(CONTENT_FILES, (filePath) =>
+    getDirectoryName(filePath),
+  ).some((root) => isDirectoryAllowedByRoot(path, root, false))
+}
+
+export function sanitizeCmsBranchPart(path: string) {
+  const base = path
+    .replace(/\.[^.]+$/, '')
+    .replace(/[^A-Za-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+
+  return base || 'content'
+}
+
+export function encodePathSegments(path: string) {
+  return path.split('/').map(encodeURIComponent).join('/')
+}
+
+function getDirectoryName(path: string) {
+  return path.split('/').slice(0, -1).join('/')
+}
+
+function isDirectoryAllowedByRoot(
+  path: string,
+  root: string,
+  recursive: boolean,
+) {
+  return (
+    path === root ||
+    root.startsWith(`${path}/`) ||
+    (recursive && path.startsWith(`${root}/`))
+  )
+}
+
+function getExtension(path: string) {
+  const fileName = path.split('/').pop() || ''
+  const dot = fileName.lastIndexOf('.')
+
+  return dot === -1 ? '' : fileName.slice(dot).toLowerCase()
+}

--- a/functions/admin/api/_github-api.ts
+++ b/functions/admin/api/_github-api.ts
@@ -1,0 +1,181 @@
+import {
+  CMS_REPOSITORY,
+  isAllowedCmsDirectoryPath,
+  isAllowedCmsWritePath,
+  normalizeCmsPath,
+} from './_cms-policy.ts'
+
+const GITHUB_API_VERSION = '2022-11-28'
+const USER_AGENT = 'acecore-net-sveltia-cms'
+
+export class GitHubApiError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.status = status
+  }
+}
+
+export type CmsGitTreeItem = {
+  path: string
+  mode: string
+  type: 'blob' | 'tree'
+  sha: string
+  size?: number
+  url?: string
+}
+
+export type CmsGitTree = {
+  sha: string
+  tree: CmsGitTreeItem[]
+  truncated: boolean
+  url?: string
+}
+
+export async function githubRequest({
+  accept = 'application/vnd.github+json',
+  body,
+  method = 'GET',
+  path,
+  token,
+}: {
+  accept?: string
+  body?: unknown
+  method?: string
+  path: string
+  token: string
+}) {
+  const headers = new Headers({
+    Accept: accept,
+    Authorization: `Bearer ${token}`,
+    'User-Agent': USER_AGENT,
+    'X-GitHub-Api-Version': GITHUB_API_VERSION,
+  })
+
+  if (body !== undefined) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  return fetch(`https://api.github.com${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+export async function githubJson<T>(
+  options: Parameters<typeof githubRequest>[0],
+) {
+  const response = await githubRequest(options)
+  const data: unknown = await response.json().catch(() => null)
+
+  if (!response.ok) {
+    const message =
+      isRecord(data) && typeof data.message === 'string'
+        ? data.message
+        : 'GitHub APIでエラーが発生しました。'
+
+    throw new GitHubApiError(message, response.status)
+  }
+
+  return data as T
+}
+
+export async function fetchCmsTree(
+  token: string,
+  ref: string = CMS_REPOSITORY.branch,
+) {
+  const data = await githubJson<unknown>({
+    path: `/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}/git/trees/${encodeURIComponent(ref)}?recursive=1`,
+    token,
+  })
+
+  if (
+    !isRecord(data) ||
+    typeof data.sha !== 'string' ||
+    !Array.isArray(data.tree) ||
+    typeof data.truncated !== 'boolean'
+  ) {
+    throw new GitHubApiError('GitHub tree response が不正です。', 502)
+  }
+
+  if (data.truncated) {
+    throw new GitHubApiError(
+      'GitHub tree が省略されたためCMS対象を安全に判定できません。',
+      502,
+    )
+  }
+
+  const tree = data.tree.flatMap((item): CmsGitTreeItem[] => {
+    if (!isRecord(item)) return []
+
+    const path =
+      typeof item.path === 'string' ? normalizeCmsPath(item.path) : null
+    const type = item.type
+    const sha = item.sha
+    const mode = item.mode
+
+    if (
+      !path ||
+      (type !== 'blob' && type !== 'tree') ||
+      typeof sha !== 'string' ||
+      typeof mode !== 'string'
+    ) {
+      return []
+    }
+
+    const allowed =
+      type === 'blob'
+        ? isAllowedCmsWritePath(path)
+        : isAllowedCmsDirectoryPath(path)
+
+    if (!allowed) return []
+
+    return [
+      {
+        path,
+        type,
+        sha,
+        mode,
+        ...(typeof item.size === 'number' ? { size: item.size } : {}),
+        ...(typeof item.url === 'string' ? { url: item.url } : {}),
+      },
+    ]
+  })
+
+  return {
+    sha: data.sha,
+    tree,
+    truncated: data.truncated,
+    ...(typeof data.url === 'string' ? { url: data.url } : {}),
+  } satisfies CmsGitTree
+}
+
+export function getAllowedCmsBlobShas(tree: CmsGitTree) {
+  return new Set(
+    tree.tree.filter((item) => item.type === 'blob').map((item) => item.sha),
+  )
+}
+
+export function copyGitHubResponse(response: Response) {
+  const headers = new Headers()
+
+  for (const name of ['Content-Type', 'ETag', 'Link']) {
+    const value = response.headers.get(name)
+
+    if (value) headers.set(name, value)
+  }
+
+  headers.set('Cache-Control', 'no-store')
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}

--- a/functions/admin/api/_github-oauth.ts
+++ b/functions/admin/api/_github-oauth.ts
@@ -1,0 +1,130 @@
+import { CMS_REPOSITORY } from './_cms-policy.ts'
+import { GitHubApiError, githubJson, isRecord } from './_github-api.ts'
+
+const AUTH_CACHE_TTL_MS = 5 * 60 * 1000
+const TOKEN_MAX_LENGTH = 512
+
+export type GitHubEditor = {
+  avatar_url: string
+  email: string | null
+  html_url: string
+  id: number
+  login: string
+  name: string | null
+  type: string
+}
+
+const authorizationCache = new Map<
+  string,
+  { expiresAt: number; user: GitHubEditor }
+>()
+
+export async function getGitHubEditor(request: Request) {
+  const token = readOAuthToken(request.headers.get('Authorization'))
+
+  if (!token) {
+    throw new GitHubApiError('GitHub OAuth認証が必要です。', 401)
+  }
+
+  const cacheKey = await sha256(token)
+  const cached = authorizationCache.get(cacheKey)
+
+  if (cached && cached.expiresAt > Date.now()) {
+    return { token, user: cached.user }
+  }
+
+  const user = await readCurrentUser(token)
+  let repository: unknown
+
+  try {
+    repository = await githubJson<unknown>({
+      path: `/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`,
+      token,
+    })
+  } catch (error) {
+    if (
+      error instanceof GitHubApiError &&
+      (error.status === 403 || error.status === 404)
+    ) {
+      throw new GitHubApiError(
+        'このGitHubアカウントにはCMS対象repositoryへのwrite権限がありません。',
+        403,
+      )
+    }
+
+    throw error
+  }
+
+  if (
+    !isRecord(repository) ||
+    !isRecord(repository.permissions) ||
+    repository.permissions.push !== true
+  ) {
+    throw new GitHubApiError(
+      'このGitHubアカウントにはCMS対象repositoryへのwrite権限がありません。',
+      403,
+    )
+  }
+
+  authorizationCache.set(cacheKey, {
+    expiresAt: Date.now() + AUTH_CACHE_TTL_MS,
+    user,
+  })
+
+  return { token, user }
+}
+
+export function clearGitHubEditorCacheForTests() {
+  authorizationCache.clear()
+}
+
+function readOAuthToken(authorization: string | null) {
+  const match = authorization?.match(/^(?:Bearer|token)\s+(\S+)$/i)
+  const token = match?.[1]
+
+  if (!token || token.length > TOKEN_MAX_LENGTH) return null
+
+  return token
+}
+
+async function readCurrentUser(token: string): Promise<GitHubEditor> {
+  let value: unknown
+
+  try {
+    value = await githubJson<unknown>({ path: '/user', token })
+  } catch (error) {
+    if (error instanceof GitHubApiError && error.status === 401) {
+      throw new GitHubApiError('GitHub OAuth tokenが無効です。', 401)
+    }
+
+    throw error
+  }
+
+  if (
+    !isRecord(value) ||
+    typeof value.id !== 'number' ||
+    typeof value.login !== 'string' ||
+    typeof value.html_url !== 'string'
+  ) {
+    throw new GitHubApiError('GitHub user responseが不正です。', 502)
+  }
+
+  return {
+    avatar_url: typeof value.avatar_url === 'string' ? value.avatar_url : '',
+    email: typeof value.email === 'string' ? value.email : null,
+    html_url: value.html_url,
+    id: value.id,
+    login: value.login,
+    name: typeof value.name === 'string' ? value.name : null,
+    type: typeof value.type === 'string' ? value.type : 'User',
+  }
+}
+
+async function sha256(value: string) {
+  const bytes = new TextEncoder().encode(value)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('')
+}

--- a/functions/admin/api/github/[[path]].ts
+++ b/functions/admin/api/github/[[path]].ts
@@ -1,0 +1,197 @@
+import { CMS_REPOSITORY } from '../_cms-policy.ts'
+import { getGitHubEditor, type GitHubEditor } from '../_github-oauth.ts'
+import {
+  GitHubApiError,
+  copyGitHubResponse,
+  fetchCmsTree,
+  getAllowedCmsBlobShas,
+  githubRequest,
+} from '../_github-api.ts'
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/i
+
+type ReadTarget = { kind: 'tree'; ref: string } | { kind: 'blob'; sha: string }
+
+export const onRequest: PagesFunction = async ({ request }) => {
+  const method = request.method.toUpperCase()
+
+  if (method !== 'GET' && method !== 'HEAD') {
+    return json({ message: 'Method not allowed' }, 405, {
+      Allow: 'GET, HEAD',
+    })
+  }
+
+  const proxyPath = getProxyPath(request)
+
+  try {
+    const auth = await getGitHubEditor(request)
+    const token = auth.token
+
+    if (proxyPath === 'user') {
+      return handleCurrentUser({ auth, method })
+    }
+
+    if (isCollaboratorCheckPath(proxyPath)) {
+      return noContent()
+    }
+
+    const target = getReadTarget(proxyPath, new URL(request.url))
+
+    if (!target) {
+      return json(
+        { message: 'CMS proxyで許可されていないGitHub APIです。' },
+        403,
+      )
+    }
+
+    if (target.kind === 'tree') {
+      return await handleTreeRead({ method, ref: target.ref, token })
+    }
+
+    return await handleBlobRead({ method, request, sha: target.sha, token })
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+async function handleCurrentUser({
+  auth,
+  method,
+}: {
+  auth: { user: GitHubEditor }
+  method: string
+}) {
+  if (method === 'HEAD') {
+    return noContent()
+  }
+
+  return json(auth.user)
+}
+
+async function handleTreeRead({
+  method,
+  ref,
+  token,
+}: {
+  method: string
+  ref: string
+  token: string
+}) {
+  if (method === 'HEAD') return noContent()
+
+  const tree = await fetchCmsTree(token, ref)
+
+  return json(tree)
+}
+
+async function handleBlobRead({
+  method,
+  request,
+  sha,
+  token,
+}: {
+  method: string
+  request: Request
+  sha: string
+  token: string
+}) {
+  const tree = await fetchCmsTree(token)
+
+  if (!getAllowedCmsBlobShas(tree).has(sha)) {
+    return json({ message: 'CMS管理対象外のGit blobです。' }, 403)
+  }
+
+  if (method === 'HEAD') return noContent()
+
+  const response = await githubRequest({
+    accept: request.headers.get('Accept') || 'application/vnd.github.raw',
+    path: `/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}/git/blobs/${sha}`,
+    token,
+  })
+
+  return copyGitHubResponse(response)
+}
+
+function getReadTarget(proxyPath: string, sourceUrl: URL): ReadTarget | null {
+  const repoRoot = `repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`
+  const treePrefix = `${repoRoot}/git/trees/`
+  const blobPrefix = `${repoRoot}/git/blobs/`
+
+  if (proxyPath.startsWith(treePrefix)) {
+    const ref = proxyPath.slice(treePrefix.length)
+    const queryNames = Array.from(sourceUrl.searchParams.keys())
+
+    if (
+      (!SHA_PATTERN.test(ref) && ref !== CMS_REPOSITORY.branch) ||
+      queryNames.some((name) => name !== 'recursive') ||
+      sourceUrl.searchParams.getAll('recursive').length !== 1 ||
+      sourceUrl.searchParams.get('recursive') !== '1'
+    ) {
+      return null
+    }
+
+    return { kind: 'tree', ref }
+  }
+
+  if (proxyPath.startsWith(blobPrefix) && sourceUrl.search === '') {
+    const sha = proxyPath.slice(blobPrefix.length)
+
+    return SHA_PATTERN.test(sha) ? { kind: 'blob', sha } : null
+  }
+
+  return null
+}
+
+function getProxyPath(request: Request) {
+  const pathname = new URL(request.url).pathname
+
+  return pathname
+    .replace(/^\/admin\/api\/github\/?/, '')
+    .replace(/^api\/v3\/?/, '')
+    .replace(/^\/+/, '')
+}
+
+function isCollaboratorCheckPath(proxyPath: string) {
+  const prefix = `repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}/collaborators/`
+
+  if (!proxyPath.startsWith(prefix)) return false
+
+  const login = proxyPath.slice(prefix.length)
+
+  return login.length > 0 && !login.includes('/')
+}
+
+function toErrorResponse(error: unknown) {
+  if (error instanceof GitHubApiError) {
+    return json({ message: error.message }, error.status)
+  }
+
+  console.error(
+    JSON.stringify({
+      message: 'CMS GitHub proxy failed',
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  )
+
+  return json({ message: 'CMS GitHub proxyでエラーが発生しました。' }, 500)
+}
+
+function json(data: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      ...headers,
+    },
+  })
+}
+
+function noContent() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/functions/admin/api/graphql.ts
+++ b/functions/admin/api/graphql.ts
@@ -1,0 +1,1034 @@
+import {
+  Kind,
+  parse,
+  type ArgumentNode,
+  type FieldNode,
+  type OperationDefinitionNode,
+  type SelectionSetNode,
+  type ValueNode,
+} from 'graphql'
+
+import {
+  CMS_REPOSITORY,
+  isAllowedCmsWritePath,
+  normalizeCmsPath,
+  sanitizeCmsBranchPart,
+} from './_cms-policy.ts'
+import { getGitHubEditor, type GitHubEditor } from './_github-oauth.ts'
+import {
+  GitHubApiError,
+  copyGitHubResponse,
+  fetchCmsTree,
+  getAllowedCmsBlobShas,
+  githubJson,
+  githubRequest,
+  isRecord,
+} from './_github-api.ts'
+
+type GraphqlPayload = {
+  query: string
+  variables: Record<string, unknown>
+}
+
+type CmsAddition = {
+  path: string
+  contents: string
+  byteSize: number
+}
+
+type CmsDeletion = {
+  path: string
+}
+
+type CmsCommitInput = {
+  expectedHeadOid: string
+  additions: CmsAddition[]
+  deletions: CmsDeletion[]
+}
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/i
+const BASE64_PATTERN =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+const MAX_GRAPHQL_QUERY_CHARS = 512 * 1024
+const MAX_REQUEST_BYTES = 36 * 1024 * 1024
+const MAX_CHANGE_COUNT = 100
+const MAX_TOTAL_CONTENT_BYTES = 25 * 1024 * 1024
+const MAX_GRAPHQL_BLOB_SIZE = 10 * 1024 * 1024
+
+export const onRequestPost: PagesFunction = async ({ request }) => {
+  try {
+    const auth = await getGitHubEditor(request)
+    const token = auth.token
+    const bodyText = await readRequestText(request)
+
+    if (bodyText === null) {
+      return json({ message: 'CMS保存データが大きすぎます。' }, 413)
+    }
+
+    const payload = parseGraphqlPayload(bodyText)
+
+    if (!payload || payload.query.length > MAX_GRAPHQL_QUERY_CHARS) {
+      return json({ message: 'CMS GraphQL request が不正です。' }, 400)
+    }
+
+    const operation = parseOperation(payload.query)
+
+    if (!operation) {
+      return json({ message: 'CMS GraphQL operation が不正です。' }, 400)
+    }
+
+    if (operation.operation === 'query') {
+      return await handleReadQuery({ operation, payload, token })
+    }
+
+    if (operation.operation === 'mutation') {
+      return await handleCommitMutation({ auth, operation, payload, token })
+    }
+
+    return json(
+      { message: 'CMS GraphQL operation は許可されていません。' },
+      403,
+    )
+  } catch (error) {
+    return toErrorResponse(error)
+  }
+}
+
+async function handleReadQuery({
+  operation,
+  payload,
+  token,
+}: {
+  operation: OperationDefinitionNode
+  payload: GraphqlPayload
+  token: string
+}) {
+  const authorization = validateReadOperation(operation, payload.variables)
+
+  if (!authorization) {
+    return json({ message: 'CMSで許可されていないGraphQL queryです。' }, 403)
+  }
+
+  if (authorization.blobShas.size > 0) {
+    const tree = await fetchCmsTree(token)
+    const allowedShas = getAllowedCmsBlobShas(tree)
+
+    if (
+      Array.from(authorization.blobShas).some((sha) => !allowedShas.has(sha))
+    ) {
+      return json({ message: 'CMS管理対象外のGit blobです。' }, 403)
+    }
+  }
+
+  const response = await githubRequest({
+    body: {
+      query: payload.query,
+      variables: payload.variables,
+    },
+    method: 'POST',
+    path: '/graphql',
+    token,
+  })
+
+  return copyGitHubResponse(response)
+}
+
+async function handleCommitMutation({
+  auth,
+  operation,
+  payload,
+  token,
+}: {
+  auth: { user: GitHubEditor }
+  operation: OperationDefinitionNode
+  payload: GraphqlPayload
+  token: string
+}) {
+  if (!isCmsCommitOperation(operation, payload.variables)) {
+    return json({ message: 'CMSで許可されていないGraphQL mutationです。' }, 403)
+  }
+
+  const commitInput = parseCmsCommitInput(payload.variables.input)
+
+  if (!commitInput) {
+    return json(
+      { message: 'CMS管理対象外のファイル、または不正な保存データです。' },
+      403,
+    )
+  }
+
+  const mainRef = await githubJson<unknown>({
+    path: `/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}/git/ref/heads/${CMS_REPOSITORY.branch}`,
+    token,
+  })
+  const mainSha = getGitRefSha(mainRef)
+
+  if (!mainSha) {
+    throw new GitHubApiError('GitHub branch response が不正です。', 502)
+  }
+
+  if (mainSha !== commitInput.expectedHeadOid) {
+    return json(
+      {
+        message:
+          'mainが更新されています。CMSを再読み込みしてから、もう一度保存してください。',
+      },
+      409,
+    )
+  }
+
+  const changedPaths = [
+    ...commitInput.additions.map(({ path }) => path),
+    ...commitInput.deletions.map(({ path }) => path),
+  ]
+  const branch = await createCmsBranch({
+    baseSha: mainSha,
+    primaryPath: changedPaths[0],
+    token,
+  })
+  const mutation = buildCmsCommitMutation(commitInput.additions)
+  let githubResult: Record<string, unknown>
+
+  try {
+    githubResult = await githubJson<Record<string, unknown>>({
+      body: {
+        query: mutation,
+        variables: {
+          input: {
+            branch: {
+              repositoryNameWithOwner: `${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`,
+              branchName: branch,
+            },
+            expectedHeadOid: mainSha,
+            fileChanges: {
+              additions: commitInput.additions.map(({ path, contents }) => ({
+                path,
+                contents,
+              })),
+              deletions: commitInput.deletions,
+            },
+            message: {
+              headline: buildCommitHeadline(changedPaths),
+            },
+          },
+        },
+      },
+      method: 'POST',
+      path: '/graphql',
+      token,
+    })
+
+    ensureCommitSucceeded(githubResult)
+  } catch (error) {
+    if (error instanceof GitHubApiError) {
+      await deleteUncommittedCmsBranch(branch, token)
+    }
+
+    throw error
+  }
+
+  const pullRequest = await openPullRequest({
+    branch,
+    changedPaths,
+    login: auth.user.login,
+    token,
+  })
+  const extensions = isRecord(githubResult.extensions)
+    ? githubResult.extensions
+    : {}
+
+  return json({
+    ...githubResult,
+    extensions: {
+      ...extensions,
+      cms: {
+        branch,
+        pull_request: {
+          number: pullRequest.number,
+          html_url: pullRequest.html_url,
+        },
+      },
+    },
+  })
+}
+
+function validateReadOperation(
+  operation: OperationDefinitionNode,
+  variables: Record<string, unknown>,
+) {
+  if (
+    operation.operation !== 'query' ||
+    operation.directives?.length ||
+    !variablesMatchDefinitions(operation, variables) ||
+    operation.selectionSet.selections.length !== 1
+  ) {
+    return null
+  }
+
+  const root = operation.selectionSet.selections[0]
+
+  if (
+    root.kind !== Kind.FIELD ||
+    root.name.value !== 'repository' ||
+    root.alias ||
+    !root.selectionSet ||
+    !hasExactArguments(root, ['owner', 'name']) ||
+    !argumentMatches(root, 'owner', CMS_REPOSITORY.owner, variables) ||
+    !argumentMatches(root, 'name', CMS_REPOSITORY.name, variables)
+  ) {
+    return null
+  }
+
+  const authorization = { blobShas: new Set<string>() }
+
+  return validateRepositorySelection(
+    root.selectionSet,
+    variables,
+    authorization,
+  )
+    ? authorization
+    : null
+}
+
+function validateRepositorySelection(
+  selectionSet: SelectionSetNode,
+  variables: Record<string, unknown>,
+  authorization: { blobShas: Set<string> },
+) {
+  if (
+    selectionSet.selections.length === 0 ||
+    selectionSet.selections.length > 600
+  ) {
+    return false
+  }
+
+  return selectionSet.selections.every((selection) => {
+    if (selection.kind !== Kind.FIELD || selection.directives?.length)
+      return false
+
+    if (selection.name.value === 'defaultBranchRef') {
+      return (
+        !selection.arguments?.length &&
+        !!selection.selectionSet &&
+        validateLeafSelection(selection.selectionSet, ['name'])
+      )
+    }
+
+    if (selection.name.value === 'ref') {
+      return (
+        !!selection.selectionSet &&
+        hasExactArguments(selection, ['qualifiedName']) &&
+        argumentMatches(
+          selection,
+          'qualifiedName',
+          CMS_REPOSITORY.branch,
+          variables,
+        ) &&
+        validateRefSelection(selection.selectionSet)
+      )
+    }
+
+    if (selection.name.value === 'object') {
+      const oid = getArgumentString(selection, 'oid', variables)
+
+      if (
+        !oid ||
+        !SHA_PATTERN.test(oid) ||
+        !selection.selectionSet ||
+        !hasExactArguments(selection, ['oid']) ||
+        !validateBlobObjectSelection(selection.selectionSet)
+      ) {
+        return false
+      }
+
+      authorization.blobShas.add(oid)
+      return true
+    }
+
+    return false
+  })
+}
+
+function validateRefSelection(selectionSet: SelectionSetNode) {
+  if (selectionSet.selections.length !== 1) return false
+
+  const target = selectionSet.selections[0]
+
+  return (
+    target.kind === Kind.FIELD &&
+    target.name.value === 'target' &&
+    !target.alias &&
+    !target.arguments?.length &&
+    !target.directives?.length &&
+    !!target.selectionSet &&
+    validateTypedSelection(
+      target.selectionSet,
+      'Commit',
+      validateCommitSelection,
+    )
+  )
+}
+
+function validateBlobObjectSelection(selectionSet: SelectionSetNode) {
+  return validateTypedSelection(selectionSet, 'Blob', (blobSelection) => {
+    return validateLeafSelection(blobSelection, ['text'])
+  })
+}
+
+function validateTypedSelection(
+  selectionSet: SelectionSetNode,
+  typeName: string,
+  validator: (selectionSet: SelectionSetNode) => boolean,
+) {
+  if (selectionSet.selections.length !== 1) return false
+
+  const fragment = selectionSet.selections[0]
+
+  return (
+    fragment.kind === Kind.INLINE_FRAGMENT &&
+    fragment.typeCondition?.name.value === typeName &&
+    !fragment.directives?.length &&
+    validator(fragment.selectionSet)
+  )
+}
+
+function validateCommitSelection(selectionSet: SelectionSetNode) {
+  if (
+    selectionSet.selections.length === 0 ||
+    selectionSet.selections.length > 300
+  ) {
+    return false
+  }
+
+  return selectionSet.selections.every((selection) => {
+    if (
+      selection.kind !== Kind.FIELD ||
+      selection.name.value !== 'history' ||
+      selection.directives?.length ||
+      !selection.selectionSet
+    ) {
+      return false
+    }
+
+    const argumentNames = (selection.arguments || []).map(
+      ({ name }) => name.value,
+    )
+
+    if (
+      !argumentNames.includes('first') ||
+      argumentNames.some((name) => name !== 'first' && name !== 'path') ||
+      new Set(argumentNames).size !== argumentNames.length
+    ) {
+      return false
+    }
+
+    const first = getArgument(selection, 'first')?.value
+
+    if (first?.kind !== Kind.INT) return false
+
+    const firstValue = Number(first.value)
+
+    if (!Number.isInteger(firstValue) || firstValue < 1 || firstValue > 100) {
+      return false
+    }
+
+    const pathArgument = getArgument(selection, 'path')
+
+    if (pathArgument) {
+      if (pathArgument.value.kind !== Kind.STRING) return false
+
+      const path = normalizeCmsPath(pathArgument.value.value)
+
+      if (
+        !path ||
+        path !== pathArgument.value.value ||
+        !isAllowedCmsWritePath(path)
+      ) {
+        return false
+      }
+    }
+
+    return validateHistorySelection(selection.selectionSet)
+  })
+}
+
+function validateHistorySelection(selectionSet: SelectionSetNode) {
+  if (selectionSet.selections.length !== 1) return false
+
+  const nodes = selectionSet.selections[0]
+
+  return (
+    nodes.kind === Kind.FIELD &&
+    nodes.name.value === 'nodes' &&
+    !nodes.alias &&
+    !nodes.arguments?.length &&
+    !nodes.directives?.length &&
+    !!nodes.selectionSet &&
+    validateCommitNodeSelection(nodes.selectionSet)
+  )
+}
+
+function validateCommitNodeSelection(selectionSet: SelectionSetNode) {
+  const leafFields = new Set(['oid', 'message', 'committedDate'])
+
+  if (selectionSet.selections.length === 0) return false
+
+  return selectionSet.selections.every((selection) => {
+    if (selection.kind !== Kind.FIELD || selection.directives?.length)
+      return false
+
+    if (leafFields.has(selection.name.value)) {
+      return !selection.arguments?.length && !selection.selectionSet
+    }
+
+    if (selection.name.value !== 'author') return false
+
+    return (
+      !selection.arguments?.length &&
+      !!selection.selectionSet &&
+      validateAuthorSelection(selection.selectionSet)
+    )
+  })
+}
+
+function validateAuthorSelection(selectionSet: SelectionSetNode) {
+  const leafFields = new Set(['name', 'email', 'avatarUrl'])
+
+  if (selectionSet.selections.length === 0) return false
+
+  return selectionSet.selections.every((selection) => {
+    if (selection.kind !== Kind.FIELD || selection.directives?.length)
+      return false
+
+    if (leafFields.has(selection.name.value)) {
+      return !selection.arguments?.length && !selection.selectionSet
+    }
+
+    if (selection.name.value !== 'user') return false
+
+    return (
+      !selection.arguments?.length &&
+      !!selection.selectionSet &&
+      validateLeafSelection(selection.selectionSet, ['databaseId', 'login'])
+    )
+  })
+}
+
+function validateLeafSelection(
+  selectionSet: SelectionSetNode,
+  allowedNames: string[],
+) {
+  const allowed = new Set(allowedNames)
+
+  return (
+    selectionSet.selections.length > 0 &&
+    selectionSet.selections.every((selection) => {
+      return (
+        selection.kind === Kind.FIELD &&
+        allowed.has(selection.name.value) &&
+        !selection.arguments?.length &&
+        !selection.directives?.length &&
+        !selection.selectionSet
+      )
+    })
+  )
+}
+
+function isCmsCommitOperation(
+  operation: OperationDefinitionNode,
+  variables: Record<string, unknown>,
+) {
+  if (
+    operation.operation !== 'mutation' ||
+    operation.directives?.length ||
+    operation.selectionSet.selections.length !== 1 ||
+    Object.keys(variables).length !== 1 ||
+    !Object.hasOwn(variables, 'input')
+  ) {
+    return false
+  }
+
+  const root = operation.selectionSet.selections[0]
+
+  if (
+    root.kind !== Kind.FIELD ||
+    root.name.value !== 'createCommitOnBranch' ||
+    root.alias ||
+    root.directives?.length ||
+    !root.selectionSet ||
+    !hasExactArguments(root, ['input'])
+  ) {
+    return false
+  }
+
+  const input = getArgument(root, 'input')?.value
+
+  return input?.kind === Kind.VARIABLE && input.name.value === 'input'
+}
+
+function parseCmsCommitInput(value: unknown): CmsCommitInput | null {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      'branch',
+      'expectedHeadOid',
+      'fileChanges',
+      'message',
+    ]) ||
+    !isRecord(value.branch) ||
+    !hasOnlyKeys(value.branch, ['repositoryNameWithOwner', 'branchName']) ||
+    value.branch.repositoryNameWithOwner !==
+      `${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}` ||
+    value.branch.branchName !== CMS_REPOSITORY.branch ||
+    typeof value.expectedHeadOid !== 'string' ||
+    !SHA_PATTERN.test(value.expectedHeadOid) ||
+    !isRecord(value.fileChanges) ||
+    !hasOnlyKeys(value.fileChanges, ['additions', 'deletions']) ||
+    !isRecord(value.message) ||
+    !hasOnlyKeys(value.message, ['headline']) ||
+    typeof value.message.headline !== 'string'
+  ) {
+    return null
+  }
+
+  const additionsValue = value.fileChanges.additions ?? []
+  const deletionsValue = value.fileChanges.deletions ?? []
+
+  if (!Array.isArray(additionsValue) || !Array.isArray(deletionsValue)) {
+    return null
+  }
+
+  if (
+    additionsValue.length + deletionsValue.length === 0 ||
+    additionsValue.length + deletionsValue.length > MAX_CHANGE_COUNT
+  ) {
+    return null
+  }
+
+  const additions: CmsAddition[] = []
+  const deletions: CmsDeletion[] = []
+  const paths = new Set<string>()
+  let totalContentBytes = 0
+
+  for (const addition of additionsValue) {
+    if (
+      !isRecord(addition) ||
+      !hasOnlyKeys(addition, ['path', 'contents']) ||
+      typeof addition.path !== 'string' ||
+      typeof addition.contents !== 'string' ||
+      !BASE64_PATTERN.test(addition.contents)
+    ) {
+      return null
+    }
+
+    const path = normalizeCmsPath(addition.path)
+
+    if (
+      !path ||
+      path !== addition.path ||
+      !isAllowedCmsWritePath(path) ||
+      paths.has(path)
+    ) {
+      return null
+    }
+
+    const byteSize = getBase64ByteSize(addition.contents)
+
+    totalContentBytes += byteSize
+
+    if (totalContentBytes > MAX_TOTAL_CONTENT_BYTES) return null
+
+    paths.add(path)
+    additions.push({ path, contents: addition.contents, byteSize })
+  }
+
+  for (const deletion of deletionsValue) {
+    if (
+      !isRecord(deletion) ||
+      !hasOnlyKeys(deletion, ['path']) ||
+      typeof deletion.path !== 'string'
+    ) {
+      return null
+    }
+
+    const path = normalizeCmsPath(deletion.path)
+
+    if (
+      !path ||
+      path !== deletion.path ||
+      !isAllowedCmsWritePath(path) ||
+      paths.has(path)
+    ) {
+      return null
+    }
+
+    paths.add(path)
+    deletions.push({ path })
+  }
+
+  return {
+    expectedHeadOid: value.expectedHeadOid,
+    additions,
+    deletions,
+  }
+}
+
+async function createCmsBranch({
+  baseSha,
+  primaryPath,
+  token,
+}: {
+  baseSha: string
+  primaryPath: string
+  token: string
+}) {
+  const base = sanitizeCmsBranchPart(primaryPath)
+
+  for (let index = 0; index < 3; index += 1) {
+    const id = crypto.randomUUID().slice(0, 8)
+    const branch = `cms/acecore/${timestamp()}-${base}-${id}`
+
+    try {
+      await githubJson({
+        body: {
+          ref: `refs/heads/${branch}`,
+          sha: baseSha,
+        },
+        method: 'POST',
+        path: `/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}/git/refs`,
+        token,
+      })
+
+      return branch
+    } catch (error) {
+      if (!(error instanceof GitHubApiError) || error.status !== 422) {
+        throw error
+      }
+    }
+  }
+
+  throw new GitHubApiError('CMS保存用branchを作成できませんでした。', 409)
+}
+
+async function deleteUncommittedCmsBranch(branch: string, token: string) {
+  try {
+    const encodedBranch = branch.split('/').map(encodeURIComponent).join('/')
+    const response = await githubRequest({
+      method: 'DELETE',
+      path: `/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}/git/refs/heads/${encodedBranch}`,
+      token,
+    })
+
+    if (!response.ok && response.status !== 404) {
+      console.error(
+        JSON.stringify({
+          message: 'Failed to remove unused CMS branch',
+          branch,
+          status: response.status,
+        }),
+      )
+    }
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        message: 'Failed to remove unused CMS branch',
+        branch,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    )
+  }
+}
+
+async function openPullRequest({
+  branch,
+  changedPaths,
+  login,
+  token,
+}: {
+  branch: string
+  changedPaths: string[]
+  login: string
+  token: string
+}) {
+  const primaryPath = summarizePath(changedPaths[0])
+  const extraCount = changedPaths.length - 1
+  const title = `cms: update ${primaryPath}${extraCount > 0 ? ` (+${extraCount})` : ''}`
+
+  const result = await githubJson<unknown>({
+    body: {
+      base: CMS_REPOSITORY.branch,
+      body: [
+        'Sveltia CMS の保存をGitHub認証済みユーザーから受け付けました。',
+        '',
+        `- GitHub user: @${login}`,
+        '- Files:',
+        ...changedPaths.map((path) => `  - \`${path}\``),
+        '',
+        '画像とコンテンツは同じ commit に含まれています。',
+        'CIで content/schema/build を確認してから main に取り込んでください。',
+      ].join('\n'),
+      head: branch,
+      title,
+    },
+    method: 'POST',
+    path: `/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}/pulls`,
+    token,
+  })
+
+  if (
+    !isRecord(result) ||
+    typeof result.number !== 'number' ||
+    typeof result.html_url !== 'string'
+  ) {
+    throw new GitHubApiError('GitHub pull request response が不正です。', 502)
+  }
+
+  return { number: result.number, html_url: result.html_url }
+}
+
+function buildCmsCommitMutation(additions: CmsAddition[]) {
+  const fileShaQuery = additions
+    .map(({ path, byteSize }, index) => {
+      return byteSize <= MAX_GRAPHQL_BLOB_SIZE
+        ? `file_${index}: file(path: ${JSON.stringify(path)}) { oid }`
+        : ''
+    })
+    .filter(Boolean)
+    .join('\n')
+
+  return `
+    mutation CmsCommit($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit {
+          oid
+          committedDate
+          ${fileShaQuery}
+        }
+      }
+    }
+  `
+}
+
+function ensureCommitSucceeded(result: Record<string, unknown>) {
+  if (Array.isArray(result.errors) && result.errors.length > 0) {
+    const firstError = result.errors[0]
+    const message =
+      isRecord(firstError) && typeof firstError.message === 'string'
+        ? firstError.message
+        : 'GitHub GraphQL mutation が失敗しました。'
+
+    throw new GitHubApiError(message, 502)
+  }
+
+  if (
+    !isRecord(result.data) ||
+    !isRecord(result.data.createCommitOnBranch) ||
+    !isRecord(result.data.createCommitOnBranch.commit) ||
+    typeof result.data.createCommitOnBranch.commit.oid !== 'string'
+  ) {
+    throw new GitHubApiError(
+      'GitHub GraphQL mutation response が不正です。',
+      502,
+    )
+  }
+}
+
+function parseGraphqlPayload(text: string): GraphqlPayload | null {
+  try {
+    const value: unknown = JSON.parse(text)
+
+    if (
+      !isRecord(value) ||
+      typeof value.query !== 'string' ||
+      (value.variables !== undefined && !isRecord(value.variables))
+    ) {
+      return null
+    }
+
+    return {
+      query: value.query,
+      variables: value.variables || {},
+    }
+  } catch {
+    return null
+  }
+}
+
+function parseOperation(query: string) {
+  try {
+    const document = parse(query)
+
+    if (document.definitions.length !== 1) return null
+
+    const definition = document.definitions[0]
+
+    return definition.kind === Kind.OPERATION_DEFINITION ? definition : null
+  } catch {
+    return null
+  }
+}
+
+function variablesMatchDefinitions(
+  operation: OperationDefinitionNode,
+  variables: Record<string, unknown>,
+) {
+  const defined = new Set(
+    (operation.variableDefinitions || []).map(
+      ({ variable }) => variable.name.value,
+    ),
+  )
+
+  return Object.keys(variables).every((name) => defined.has(name))
+}
+
+function hasExactArguments(field: FieldNode, names: string[]) {
+  const argumentsList = field.arguments || []
+
+  return (
+    argumentsList.length === names.length &&
+    new Set(argumentsList.map(({ name }) => name.value)).size ===
+      names.length &&
+    names.every((name) => argumentsList.some((arg) => arg.name.value === name))
+  )
+}
+
+function argumentMatches(
+  field: FieldNode,
+  name: string,
+  expected: string,
+  variables: Record<string, unknown>,
+) {
+  return getArgumentString(field, name, variables) === expected
+}
+
+function getArgument(field: FieldNode, name: string): ArgumentNode | undefined {
+  return field.arguments?.find((argument) => argument.name.value === name)
+}
+
+function getArgumentString(
+  field: FieldNode,
+  name: string,
+  variables: Record<string, unknown>,
+) {
+  const value = getArgument(field, name)?.value
+
+  return value ? resolveStringValue(value, variables) : null
+}
+
+function resolveStringValue(
+  value: ValueNode,
+  variables: Record<string, unknown>,
+) {
+  if (value.kind === Kind.STRING) return value.value
+
+  if (value.kind === Kind.VARIABLE) {
+    const variable = variables[value.name.value]
+
+    return typeof variable === 'string' ? variable : null
+  }
+
+  return null
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowedKeys: string[]) {
+  const allowed = new Set(allowedKeys)
+
+  return Object.keys(value).every((key) => allowed.has(key))
+}
+
+function getBase64ByteSize(value: string) {
+  if (!value) return 0
+
+  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0
+
+  return (value.length * 3) / 4 - padding
+}
+
+function buildCommitHeadline(changedPaths: string[]) {
+  const extraCount = changedPaths.length - 1
+
+  return `cms: update ${summarizePath(changedPaths[0])}${extraCount > 0 ? ` (+${extraCount})` : ''}`
+}
+
+function summarizePath(path: string) {
+  return path.length > 200 ? `${path.slice(0, 197)}...` : path
+}
+
+function getGitRefSha(value: unknown) {
+  if (!isRecord(value) || !isRecord(value.object)) return null
+
+  return typeof value.object.sha === 'string' &&
+    SHA_PATTERN.test(value.object.sha)
+    ? value.object.sha
+    : null
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/\D/g, '').slice(0, 14)
+}
+
+async function readRequestText(request: Request) {
+  const contentLength = Number(request.headers.get('Content-Length') || 0)
+
+  if (Number.isFinite(contentLength) && contentLength > MAX_REQUEST_BYTES) {
+    return null
+  }
+
+  if (!request.body) return ''
+
+  const reader = request.body.getReader()
+  const decoder = new TextDecoder('utf-8', {
+    fatal: true,
+    ignoreBOM: false,
+  })
+  const chunks: string[] = []
+  let totalBytes = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+
+      if (done) break
+
+      totalBytes += value.byteLength
+
+      if (totalBytes > MAX_REQUEST_BYTES) {
+        await reader.cancel().catch(() => undefined)
+        return null
+      }
+
+      chunks.push(decoder.decode(value, { stream: true }))
+    }
+
+    chunks.push(decoder.decode())
+    return chunks.join('')
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function toErrorResponse(error: unknown) {
+  if (error instanceof GitHubApiError) {
+    return json({ message: error.message }, error.status)
+  }
+
+  console.error(
+    JSON.stringify({
+      message: 'CMS GraphQL proxy failed',
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  )
+
+  return json({ message: 'CMS GraphQL proxyでエラーが発生しました。' }, 500)
+}
+
+function json(data: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      ...headers,
+    },
+  })
+}

--- a/functions/admin/config.yml.ts
+++ b/functions/admin/config.yml.ts
@@ -1,0 +1,27 @@
+type PagesContext = {
+  request: Request
+  next: () => Promise<Response>
+}
+
+export const onRequestGet = async ({
+  request,
+  next,
+}: PagesContext): Promise<Response> => {
+  const response = await next()
+
+  if (!response.ok) return response
+
+  const origin = new URL(request.url).origin
+  const source = await response.text()
+  const config = source
+    .replace(/^(\s*api_root:\s*).+$/m, `$1${origin}/admin/api/github`)
+    .replace(/^(\s*graphql_api_root:\s*).+$/m, `$1${origin}/admin/api/graphql`)
+
+  return new Response(config, {
+    status: response.status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'application/yaml; charset=utf-8',
+    },
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,17 +12,20 @@
         "@astrojs/sitemap": "^3.7.2",
         "@fontsource/noto-sans-jp": "^5.2.9",
         "astro": "^6.1.1",
+        "graphql": "^16.14.2",
         "rehype-external-links": "^3.0.0",
         "satori": "^0.26.0",
         "sharp": "^0.34.5"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260702.1",
         "@iconify-json/lucide": "^1.2.100",
         "@unocss/astro": "^66.6.7",
         "@unocss/preset-typography": "^66.6.7",
         "pagefind": "^1.4.0",
         "prettier": "^3.8.1",
         "prettier-plugin-astro": "^0.14.1",
+        "typescript": "^5.9.3",
         "unocss": "^66.6.7"
       }
     },
@@ -212,6 +215,13 @@
         "@clack/core": "1.1.0",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
@@ -3181,6 +3191,15 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -5859,6 +5878,20 @@
       "integrity": "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "preview": "astro preview",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
+    "test:cms": "node --test tests/cms-proxy.test.mjs",
+    "typecheck:functions": "tsc --project tsconfig.functions.json",
     "validate:content": "node scripts/validate-content.mjs",
     "validate:seo": "node scripts/validate-seo.mjs",
     "validate:tag-redirects": "node --experimental-strip-types scripts/validate-tag-redirects.mjs",
@@ -21,17 +23,20 @@
     "@astrojs/sitemap": "^3.7.2",
     "@fontsource/noto-sans-jp": "^5.2.9",
     "astro": "^6.1.1",
+    "graphql": "^16.14.2",
     "rehype-external-links": "^3.0.0",
     "satori": "^0.26.0",
     "sharp": "^0.34.5"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260702.1",
     "@iconify-json/lucide": "^1.2.100",
     "@unocss/astro": "^66.6.7",
     "@unocss/preset-typography": "^66.6.7",
     "pagefind": "^1.4.0",
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
+    "typescript": "^5.9.3",
     "unocss": "^66.6.7"
   },
   "overrides": {

--- a/public/_headers
+++ b/public/_headers
@@ -17,7 +17,7 @@
   Cache-Control: public, max-age=0, must-revalidate
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   X-Robots-Tag: noindex, nofollow
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' blob: data: https://*; media-src blob:; connect-src 'self' blob: data: https://unpkg.com https://api.github.com https://www.githubstatus.com https://sveltia-cms-auth.sparkling-tree-7cef.workers.dev; frame-src blob:; worker-src blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://github.com https://sveltia-cms-auth.sparkling-tree-7cef.workers.dev; frame-ancestors 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' blob: data: https://*; media-src blob:; connect-src 'self' blob: data: https://unpkg.com https://sveltia-cms-auth.sparkling-tree-7cef.workers.dev; frame-src blob:; worker-src blob:; object-src 'none'; base-uri 'self'; form-action 'self' https://github.com https://sveltia-cms-auth.sparkling-tree-7cef.workers.dev; frame-ancestors 'self'
 
 /admin/config.yml
   Content-Type: application/yaml; charset=utf-8

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -5,6 +5,8 @@ backend:
   repo: acecore-systems/acecore-net
   branch: main
   base_url: https://sveltia-cms-auth.sparkling-tree-7cef.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -12,8 +14,6 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 
 media_folder: /public/uploads
 public_folder: /uploads

--- a/public/admin/init.js
+++ b/public/admin/init.js
@@ -1,7 +1,7 @@
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -58,6 +58,18 @@ function extractCmsFileDefinition(config, contentPath) {
 async function validateCmsConfig() {
   const scope = 'public/admin/config.yml'
   const config = await readFile(path.join(root, scope), 'utf8')
+  const graphql = await readFile(
+    path.join(root, 'functions/admin/api/graphql.ts'),
+    'utf8',
+  )
+  const oauth = await readFile(
+    path.join(root, 'functions/admin/api/_github-oauth.ts'),
+    'utf8',
+  )
+  const configFunction = await readFile(
+    path.join(root, 'functions/admin/config.yml.ts'),
+    'utf8',
+  )
 
   if (/^\s*-?\s*name:\s*path\b/m.test(config)) {
     fail(scope, 'path field must not be exposed in CMS')
@@ -68,11 +80,42 @@ async function validateCmsConfig() {
       'CMS backend branch must be main; do not use a permanent cms-content branch',
     )
   }
-  if (!/^publish_mode:\s*editorial_workflow\b/m.test(config)) {
+  if (/^publish_mode:\s*editorial_workflow\b/m.test(config)) {
     fail(
       scope,
-      'CMS must use editorial_workflow so saves create short-lived branches and PRs',
+      'Sveltia CMS does not implement editorial_workflow; use the validated PR proxy',
     )
+  }
+  if (
+    !config.includes('api_root: /admin/api/github') ||
+    !config.includes('graphql_api_root: /admin/api/graphql')
+  ) {
+    fail(scope, 'CMS must use the same-origin GitHub REST and GraphQL proxy')
+  }
+  if (
+    !graphql.includes('createCmsBranch') ||
+    !graphql.includes('cms/acecore/') ||
+    !graphql.includes('/pulls')
+  ) {
+    fail(
+      scope,
+      'CMS writes must create a short-lived cms/acecore branch and PR',
+    )
+  }
+  if (
+    !oauth.includes('repository.permissions.push !== true') ||
+    !oauth.includes("path: '/user'")
+  ) {
+    fail(
+      scope,
+      'CMS proxy must validate the GitHub user and repository write access',
+    )
+  }
+  if (
+    !configFunction.includes('$1${origin}/admin/api/github') ||
+    !configFunction.includes('$1${origin}/admin/api/graphql')
+  ) {
+    fail(scope, 'CMS runtime config must use the deployment origin proxy')
   }
 
   for (const contentPath of extractCmsContentPaths(config)) {

--- a/scripts/write-cms-runtime-config.mjs
+++ b/scripts/write-cms-runtime-config.mjs
@@ -1,25 +1,9 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
-const defaultCmsBranch = 'main'
-const deploymentBranch =
-  process.env.CF_PAGES_BRANCH ||
-  process.env.GITHUB_HEAD_REF ||
-  process.env.GITHUB_REF_NAME ||
-  process.env.BRANCH
-const cmsBranch =
-  process.env.CMS_BACKEND_BRANCH ||
-  (deploymentBranch && deploymentBranch !== 'main'
-    ? deploymentBranch
-    : defaultCmsBranch)
-
 const outputPath = resolve('public/admin/runtime-config.js')
 
 await mkdir(dirname(outputPath), { recursive: true })
-await writeFile(
-  outputPath,
-  `window.CMS_MANUAL_INIT = true;\nwindow.ACECORE_CMS_BRANCH = ${JSON.stringify(cmsBranch)};\n`,
-  'utf8',
-)
+await writeFile(outputPath, 'window.CMS_MANUAL_INIT = true;\n', 'utf8')
 
-console.log(`CMS runtime config branch: ${cmsBranch}`)
+console.log('CMS runtime config branch: main')

--- a/src/content/blog/cms-selection-and-turnstile.md
+++ b/src/content/blog/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: 運用を自動化する
-      description: mainをpublication branchにし、editorial workflowの短命branch、CMS編集PR、翻訳PR taskをつなぎます。
+      description: mainをpublication branchにし、検証付き保存proxyの短命branch、CMS編集PR、翻訳PR taskをつなぎます。
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - GitHubやエディタを使える人しか更新しにくい
       - 画像パス、著者ID、タグ名を手入力しがち
       - 日本語sourceと翻訳ファイルの更新範囲が混ざる
-      - 公開前のpreview branchでCMSがmainを見にいくことがある
+      - CMSの保存先や書き込み可能pathが曖昧になりやすい
   after:
     label: Sveltia CMSで編集
     items:
       - ブラウザからMarkdownやJSONをフォーム編集できる
       - relation、image、selectで入力ミスを減らせる
       - CMS commitだけを翻訳PR taskの対象にできる
-      - runtime configでpreview branchと本番branchを切り替えられる
+      - 同一origin proxyが許可pathだけを短命branchとPRへ保存する
 callout:
   type: note
   title: この記事の前提
@@ -104,8 +104,8 @@ workers/sveltia-cms-auth
 main branch
   -> 公開ソースの唯一の正
 
-Sveltia CMS editorial workflow
-  -> 保存ごとに短命branchとmain向けPRを作成
+CMS save proxy
+  -> 保存ごとに許可pathを検証し、短命branchとmain向けPRを作成
 
 .github/workflows/create-translation-prs.yml
   -> cms: commitだけを翻訳PR taskの対象にする
@@ -136,7 +136,7 @@ Astroでは `public` 配下が静的ファイルとしてそのまま配信さ�
 
 ここで余計なCSSや `type="module"` を足さないのがポイントです。Sveltia CMSは必要なスタイルをJavaScript bundleに含めており、現在の配布形態では通常のscriptとして読み込むのが素直です。
 
-Acecoreではpreview branchを扱うため、実際には `window.CMS_MANUAL_INIT = true` と `CMS.init()` を使って、あとからbranchだけ差し替えています。
+Acecoreでは設定を明示的に上書きできるよう、`window.CMS_MANUAL_INIT = true` と `CMS.init()` を使っています。publication branchは環境にかかわらず `main` に固定します。
 
 ```html
 <script src="/admin/runtime-config.js"></script>
@@ -148,7 +148,7 @@ Acecoreではpreview branchを扱うため、実際には `window.CMS_MANUAL_INI
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -164,6 +164,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -171,11 +173,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-publication branchは `main` に固定し、`publish_mode: editorial_workflow` で保存ごとの短命branchとPRを作るのが現在の構成です。`main` を本番ソースの唯一の正にしながら、CMS変更を直接commitせずレビューできます。
+publication branchは `main` に固定し、readとsaveを同一originのAPI proxyへ向けます。proxyがrepository、GitHub userのwrite権限、変更path、最新のmain HEADを検証してから、保存ごとの短命branchとPRを作ります。
+
+2026年7月20日時点で、Sveltia CMSのEditorial Workflowは未実装です。Decap CMS向けの `publish_mode: editorial_workflow` を設定しても、Sveltia CMSが短命branchやPRを作る保証にはなりません。
 
 `cms-content` のような恒久branchを別本流にすると、`main` との同期、競合、deploy元の誤設定を継続的に管理する必要があります。受け皿branchを常設せず、短命branchをPRごとに閉じるほうが運用を単純にできます。
 
@@ -191,9 +193,9 @@ backend:
   repo: acecore-systems/acecore-net
   branch: main
   base_url: https://sveltia-cms-auth.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
-
-publish_mode: editorial_workflow
 ```
 
 GitHub OAuth App側では、callback URLをWorkerの `/callback` に向けます。Worker側には `GITHUB_CLIENT_ID`、`GITHUB_CLIENT_SECRET`、必要なら `ALLOWED_DOMAINS` を環境変数として設定します。
@@ -286,23 +288,16 @@ Markdownをフォーム化するときは、自由入力を減らすほど運用
 
 固定ページ文言をCMS化するときは、日本語sourceを勝手に翻訳ファイルへ直書きしない運用も決めておきます。翻訳側はPRで更新するほうが、レビューと差分追跡が楽です。
 
-## 8. preview branchでmainを読まないようにする
+## 8. previewでもpublication branchをmainに固定する
 
-Cloudflare Pagesのpreview環境でCMSを開くとき、CMSが常に `main` を読みにいくと確認がずれます。previewで見ているPR branchの内容をCMSでも見たい場合は、branchを実行時に差し替える必要があります。
+CMS保存proxyは最新の `main` から短命branchを作るため、Cloudflare Pagesのpreviewでもbackend branchをPR branchへ差し替えません。previewは生成されたCMS PRの表示確認に使い、編集開始点は常に本番ソースの正である `main` にします。
 
-Acecoreでは、ビルド前に `public/admin/runtime-config.js` を生成しています。
+Acecoreでは、ビルド前に `public/admin/runtime-config.js` を生成し、手動初期化だけを有効にしています。
 
 ```javascript
-const cmsBranch =
-  process.env.CF_PAGES_BRANCH ||
-  process.env.GITHUB_HEAD_REF ||
-  process.env.GITHUB_REF_NAME ||
-  process.env.BRANCH ||
-  'main'
-
 await writeFile(
   'public/admin/runtime-config.js',
-  `window.CMS_MANUAL_INIT = true;\nwindow.ACECORE_CMS_BRANCH = ${JSON.stringify(cmsBranch)};\n`,
+  'window.CMS_MANUAL_INIT = true;\n',
   'utf8',
 )
 ```
@@ -313,28 +308,30 @@ await writeFile(
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-この形にしておくと、設定ファイル本体は共有したまま、previewだけ対象ブランチを切り替えられます。
+この形ならproductionとpreviewで保存起点が分岐せず、proxyも `main` 以外をbaseにするrequestを拒否できます。
 
-## 9. Editorial workflowで短命branchとPRを作る
+## 9. 保存proxyで短命branchとPRを作る
 
-CMSで保存した内容をそのまま本番反映せず、Sveltia CMSのeditorial workflowで保存ごとの短命branchとmain向けPRを作ります。
+CMSで保存した内容をそのまま本番反映せず、同一originの保存proxyで保存ごとの短命branchとmain向けPRを作ります。
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-publication branchは `main` ですが、editorial workflowの保存は `main` への直接commitではありません。CMSが短命branchとPRを管理し、レビュー後にmergeします。merge後のbranch自動削除も有効にして、恒久的な別本流を残しません。
+proxyはGraphQLの `createCommitOnBranch` を受けても `main` へ直接commitしません。許可されたcontentとmediaだけを同じcommitへまとめ、最新の `main` から `cms/acecore/*` branchを作ってPRを開きます。merge後のbranch自動削除も有効にして、恒久的な別本流を残しません。
+
+GitHub OAuth型では編集者のtokenを本人確認と保存actorに使います。Cloudflare Access型にする場合は、Access identityを確認したうえでサイト専用GitHub Appを保存actorにできます。認証方式は異なっても、path制限、短命branch、PR、CIという書き込み方針は共通です。
 
 ここで重要なのがmerge方法です。Acecoreの翻訳PR taskは `cms: create ...` や `cms: update ...` というcommit subjectを見て、CMS由来の日本語source更新だけを対象にしています。
 
@@ -404,9 +401,9 @@ CMSを差し替えたら、設定ファイルだけでなく、関連記事と�
 
 `cms:` は見た目のprefixではなく、翻訳PR taskを起動するための契約です。CMS以外のPRで使うと不要なワークフローが動きますし、CMS PRをsquashして消すと必要なワークフローが動かないことがあります。
 
-### 6. previewでどのbranchを見ているかを明示する
+### 6. publication branchを環境で切り替えない
 
-CMSはGitHub上のファイルを読むため、preview環境で表示しているbranchとCMSが編集しているbranchがずれることがあります。runtime configでbranchを注入する設計は、preview確認が多いサイトでは早めに入れておくべきです。
+previewのdeploy branchをそのままCMSのpublication branchにすると、別本流が増えて保存proxyの検証も複雑になります。CMSは常に `main` から編集を始め、PRのCloudflare Pages previewで保存結果を確認するほうが役割を分けやすくなります。
 
 ## 導入時の最小構成
 
@@ -425,13 +422,13 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
     update: 'cms: update {{collection}} "{{slug}}"'
     delete: 'cms: delete {{collection}} "{{slug}}"'
-
-publish_mode: editorial_workflow
 
 media_folder: public/uploads
 public_folder: /uploads
@@ -449,12 +446,13 @@ collections:
       - { name: body, label: 本文, widget: markdown }
 ```
 
-ここから、著者relation、タグrelation、画像フィールド、固定ページJSON、editorial workflow、翻訳PR taskの順で広げれば、導入直後から運用破綻しにくくなります。
+ここから、著者relation、タグrelation、画像フィールド、固定ページJSON、検証付き保存proxy、翻訳PR taskの順で広げれば、導入直後から運用破綻しにくくなります。
 
 ## 参考リンク
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow（未実装）](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/src/content/blog/de/cms-selection-and-turnstile.md
+++ b/src/content/blog/de/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Betrieb automatisieren
-      description: main als Veröffentlichungsbranch nutzen und kurzlebige Editorial-Workflow-Branches, CMS-PRs und Übersetzungs-Tasks verbinden.
+      description: main als Veröffentlichungsbranch nutzen und validierte Save-Proxy-Branches, CMS-PRs und Übersetzungs-Tasks verbinden.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - Aktualisierungen sind vor allem für GitHub- oder Editor-Nutzer einfach
       - Bildpfade, Autoren-IDs und Tags werden leicht falsch getippt
       - Japanische Source und Übersetzungen können vermischt werden
-      - Preview-Umgebungen können versehentlich main lesen
+      - Speicherziel und beschreibbare Pfade können unklar sein
   after:
     label: Bearbeitung mit Sveltia CMS
     items:
       - Markdown und JSON lassen sich im Browserformular bearbeiten
       - relation, image und select reduzieren ungültige Werte
       - Nur CMS-Commits lösen Übersetzungs-Tasks aus
-      - Runtime Config wechselt den CMS-Branch zwischen Preview und Produktion
+      - Ein Same-Origin-Proxy schreibt nur erlaubte Pfade in einen kurzlebigen Branch und PR
 callout:
   type: note
   title: Annahme dieses Leitfadens
@@ -102,8 +102,8 @@ workers/sveltia-cms-auth
 main branch
   -> einzige Quelle für die Produktion
 
-Sveltia CMS editorial workflow
-  -> erstellt pro Änderung einen kurzlebigen Branch und PR
+CMS save proxy
+  -> validiert erlaubte Pfade und erstellt pro Änderung einen kurzlebigen Branch und PR
 
 .github/workflows/create-translation-prs.yml
   -> erzeugt Übersetzungs-Tasks nur für cms:-Commits
@@ -132,13 +132,13 @@ In Astro wird `public` unverändert statisch ausgeliefert. Auch die Sveltia-CMS-
 
 Zusätzliche CSS-Dateien oder `type="module"` sind nicht nötig. Die UI-Styles stecken im JavaScript-Bundle.
 
-Acecore nutzt manuelle Initialisierung, damit Preview-Branches zur Laufzeit gewechselt werden können.
+Acecore nutzt manuelle Initialisierung für explizite Backend-Konfiguration. Der Veröffentlichungsbranch bleibt in jeder Umgebung `main`.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -154,6 +154,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -161,11 +163,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-`main` bleibt der Veröffentlichungsbranch. Mit `publish_mode: editorial_workflow` speichert jede Änderung in einem kurzlebigen Branch und PR statt direkt in der Produktion.
+`main` bleibt der Veröffentlichungsbranch. Reads und Saves laufen über einen Same-Origin-Proxy, der Repository, Schreibberechtigung des GitHub-Users, Änderungspfade und den aktuellen `main`-HEAD prüft und danach einen kurzlebigen Branch mit PR erstellt.
+
+Mit Stand vom 20. Juli 2026 ist Editorial Workflow in Sveltia CMS nicht implementiert. Die Decap-CMS-Einstellung `publish_mode: editorial_workflow` lässt Sveltia CMS nicht automatisch kurzlebige Branches oder PRs erstellen.
 
 Ein dauerhafter Branch wie `cms-content` erfordert laufende Synchronisierung und erhöht das Risiko für Konflikte oder eine falsche Deployment-Quelle. Kurzlebige Branches halten `main` als einzige Quelle der Wahrheit.
 
@@ -223,34 +225,36 @@ Feste Seitentexte lassen sich ebenfalls im CMS pflegen. Acecore bündelt sie unt
 
 Die Lehre: Nicht alle Felder auf einmal hinzufügen. `config.yml` wächst schnell. Besser mit Blog, Autoren, Tags, Hinweisen und häufig geänderten Seiten starten.
 
-## 8. Preview muss den richtigen Branch lesen
+## 8. Auch in Preview `main` als Veröffentlichungsbranch behalten
 
-Wenn ein CMS in einer Cloudflare-Pages-Preview weiterhin `main` liest, passt der Editor nicht zur Preview. Acecore erzeugt vor dem Build `public/admin/runtime-config.js` und injiziert den aktuellen Branch.
+Der Save-Proxy erstellt jeden kurzlebigen Branch vom aktuellen `main`. Deshalb darf eine Cloudflare-Pages-Preview den Backend-Branch nicht durch ihren PR-Branch ersetzen. Das Ergebnis wird in der Pages-Preview des erzeugten CMS-PRs geprüft.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-## 9. Kurzlebige Branches mit Editorial Workflow verwenden
+## 9. Kurzlebige Branches mit einem Save-Proxy erstellen
 
-Sveltia CMS erstellt mit Editorial Workflow für jede Änderung einen kurzlebigen Branch und einen PR nach `main`.
+Ein Same-Origin-Save-Proxy erstellt für jede Änderung einen kurzlebigen Branch und einen PR nach `main`.
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-Der Veröffentlichungsbranch ist `main`, aber CMS-Änderungen werden nicht direkt dorthin committed. Nach Review und Merge wird der kurzlebige Branch automatisch gelöscht.
+Der Proxy schreibt nicht direkt nach `main`. Er bündelt erlaubte Inhalte und Medien in einem Commit, erstellt `cms/acecore/*` vom aktuellen `main` und öffnet einen PR. Nach Review und Merge wird der kurzlebige Branch automatisch gelöscht.
+
+Bei GitHub OAuth dient das Token des Editors als Identität und Schreib-Akteur. Bei Cloudflare Access kann ein sitespezifischer GitHub App-Akteur verwendet werden. Pfadbegrenzung, kurzlebige Branches, PRs und CI bleiben in beiden Varianten gleich.
 
 Die Merge-Methode ist wichtig. Übersetzungs-Tasks hängen an Commit-Subjects wie `cms: create ...`. Wenn Squash-Merge diese entfernt, kann Automatisierung den Source-Change übersehen. Für CMS-PRs sind Merge-Commit oder Rebase-Merge geeigneter.
 
@@ -283,7 +287,7 @@ Sveltia CMS betrifft GitHub Backend, OAuth, Collections, Medien und PRs. Turnsti
 - Medienpfade sollten vor den Uploads feststehen.
 - `config.yml` sollte schrittweise wachsen.
 - `cms:` ist ein Automatisierungsvertrag.
-- In Preview muss klar sein, welchen Branch das CMS liest.
+- Der Veröffentlichungsbranch darf nicht je Umgebung wechseln; Preview prüft das Ergebnis des CMS-PRs.
 
 ## Minimaler Startpunkt
 
@@ -300,6 +304,7 @@ Danach folgen Autoren-Relationen, Tag-Relationen, Bilder, Source-JSONs, CMS-PR-A
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow (nicht implementiert)](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/src/content/blog/en/cms-selection-and-turnstile.md
+++ b/src/content/blog/en/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Automate operations
-      description: Use main as the publication branch and connect editorial workflow branches, CMS edit PRs, and translation PR tasks.
+      description: Use main as the publication branch and connect validated save-proxy branches, CMS edit PRs, and translation PR tasks.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - Only people comfortable with GitHub or an editor can update content
       - Image paths, author IDs, and tag names are typed manually
       - Japanese source changes and translated files are easy to mix
-      - Preview environments can accidentally read content from main
+      - The save target and writable paths can be unclear
   after:
     label: Editing with Sveltia CMS
     items:
       - Markdown and JSON can be edited from a browser form
       - relation, image, and select widgets reduce broken values
       - Only CMS commits can trigger translation PR tasks
-      - Runtime config can switch the CMS branch between preview and production
+      - A same-origin proxy writes only allowed paths to a short-lived branch and PR
 callout:
   type: note
   title: Assumption for this guide
@@ -104,8 +104,8 @@ workers/sveltia-cms-auth
 main branch
   -> the single source of truth for production
 
-Sveltia CMS editorial workflow
-  -> creates a short-lived branch and pull request for each edit
+CMS save proxy
+  -> validates allowed paths and creates a short-lived branch and pull request for each edit
 
 .github/workflows/create-translation-prs.yml
   -> creates translation PR tasks only for cms: commits
@@ -136,7 +136,7 @@ A minimal page looks like this:
 
 Do not add an extra stylesheet or `type="module"` unless you have a specific reason. Sveltia CMS bundles its UI styles in the JavaScript file, and the current CDN build is loaded as a normal script.
 
-Acecore uses manual initialization so preview builds can override the branch at runtime.
+Acecore uses manual initialization so the backend can be overridden explicitly. The publication branch remains `main` in every environment.
 
 ```html
 <script src="/admin/runtime-config.js"></script>
@@ -148,7 +148,7 @@ Acecore uses manual initialization so preview builds can override the branch at 
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -164,6 +164,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -171,11 +173,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-Keep `main` as the publication branch and enable `publish_mode: editorial_workflow`. Each save then goes to a short-lived branch and pull request instead of committing directly to production.
+Keep `main` as the publication branch and route reads and saves through a same-origin API proxy. Before opening a short-lived branch and pull request, the proxy validates the repository, the GitHub user's write permission, changed paths, and the latest `main` HEAD.
+
+As of July 20, 2026, Editorial Workflow is not implemented in Sveltia CMS. Adding Decap CMS's `publish_mode: editorial_workflow` setting does not make Sveltia CMS create short-lived branches or pull requests.
 
 A permanent branch such as `cms-content` creates ongoing synchronization, conflict, and deployment-source risks. Closing a short-lived branch with each pull request keeps `main` as the only source of truth.
 
@@ -191,9 +193,9 @@ backend:
   repo: acecore-systems/acecore-net
   branch: main
   base_url: https://sveltia-cms-auth.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
-
-publish_mode: editorial_workflow
 ```
 
 The GitHub OAuth App callback points to the Worker's `/callback` URL. The Worker receives `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and optionally `ALLOWED_DOMAINS` as environment variables.
@@ -272,23 +274,16 @@ The lesson from implementation was to avoid adding every field at once. After ma
 
 For multilingual sites, do not let CMS edits directly rewrite translation files. Keeping Japanese source edits and translation pull requests separate makes review much easier.
 
-## 8. Keep Preview Branches Honest
+## 8. Keep `main` as the Publication Branch in Preview
 
-When the CMS is opened in a Cloudflare Pages preview build, it should not necessarily read `main`. If the preview is for a pull request, the CMS should know which branch it is looking at.
+The save proxy creates every short-lived branch from the latest `main`, so a Cloudflare Pages preview must not replace the backend branch with its PR branch. Use the generated CMS pull request's Pages preview to inspect the result, while every edit starts from the production source of truth.
 
-Acecore generates `public/admin/runtime-config.js` before builds:
+Acecore generates `public/admin/runtime-config.js` before builds to enable manual initialization only:
 
 ```javascript
-const cmsBranch =
-  process.env.CF_PAGES_BRANCH ||
-  process.env.GITHUB_HEAD_REF ||
-  process.env.GITHUB_REF_NAME ||
-  process.env.BRANCH ||
-  'main'
-
 await writeFile(
   'public/admin/runtime-config.js',
-  `window.CMS_MANUAL_INIT = true;\nwindow.ACECORE_CMS_BRANCH = ${JSON.stringify(cmsBranch)};\n`,
+  'window.CMS_MANUAL_INIT = true;\n',
   'utf8',
 )
 ```
@@ -299,28 +294,30 @@ Then `init.js` overrides only the backend branch.
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-This keeps the shared YAML config stable while still making preview environments point at the right branch.
+This prevents production and preview from using different save bases, and lets the proxy reject any request whose base is not `main`.
 
-## 9. Use Editorial Workflow for Short-Lived Branches
+## 9. Create Short-Lived Branches with a Save Proxy
 
-Do not publish CMS saves directly. Sveltia CMS editorial workflow creates a short-lived branch and pull request for each edit.
+Do not publish CMS saves directly. A same-origin save proxy creates a short-lived branch and pull request for each edit.
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-Although the publication branch is `main`, editorial workflow does not commit saves directly to it. Review and merge the generated pull request, then delete the merged branch automatically.
+When it receives GraphQL `createCommitOnBranch`, the proxy does not commit to `main`. It combines allowed content and media in one commit, creates a `cms/acecore/*` branch from the latest `main`, and opens a pull request. Delete the branch automatically after merge so no permanent secondary source remains.
+
+In a GitHub OAuth setup, the editor's token provides identity and acts as the GitHub writer. In a Cloudflare Access setup, Access can provide identity while a site-specific GitHub App acts as the writer. The authentication mode can differ while path restrictions, short-lived branches, pull requests, and CI remain common policy.
 
 The merge method matters. Acecore's translation task detection relies on commit subjects such as `cms: create ...` and `cms: update ...`. If a CMS PR is squash merged and those subjects disappear, the translation workflow may not detect the source change. For CMS PRs, keep the `cms:` commits through merge commit or rebase merge.
 
@@ -380,9 +377,9 @@ Putting every page text field into `config.yml` at once makes the config hard to
 
 `cms:` is not cosmetic. It is an input to automation. Using it outside the CMS flow can trigger unnecessary workflows; removing it from CMS merges can stop required workflows.
 
-### 6. Make the Active Branch Visible
+### 6. Do Not Switch the Publication Branch by Environment
 
-The CMS reads files from GitHub, so preview builds need a clear branch story. Runtime branch injection prevents preview and CMS state from drifting apart.
+Using a preview deployment branch as the CMS publication branch creates another source line and complicates proxy validation. Start every edit from `main`, then inspect the saved result in the pull request's Cloudflare Pages preview.
 
 ## Minimal Starting Point
 
@@ -401,13 +398,13 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
     update: 'cms: update {{collection}} "{{slug}}"'
     delete: 'cms: delete {{collection}} "{{slug}}"'
-
-publish_mode: editorial_workflow
 
 media_folder: public/uploads
 public_folder: /uploads
@@ -431,6 +428,7 @@ From there, add author relations, tag relations, uploaded images, source JSON ed
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow (not implemented)](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/src/content/blog/es/cms-selection-and-turnstile.md
+++ b/src/content/blog/es/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Automatizar la operación
-      description: Usa main como rama de publicación y conecta ramas temporales del flujo editorial, PRs de CMS y tareas de traducción.
+      description: Usa main como rama de publicación y conecta ramas temporales del proxy de guardado validado, PRs de CMS y tareas de traducción.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - Solo quienes usan GitHub o un editor pueden actualizar fácilmente
       - Rutas de imagen, IDs de autor y etiquetas se escriben a mano
       - Cambios de fuente japonesa y traducciones se mezclan con facilidad
-      - El preview puede leer contenido de main por error
+      - El destino de guardado y las rutas editables pueden quedar ambiguos
   after:
     label: Edición con Sveltia CMS
     items:
       - Markdown y JSON se editan desde formularios del navegador
       - relation, image y select reducen valores inválidos
       - Solo commits de CMS disparan tareas de traducción
-      - runtime config cambia la rama del CMS entre preview y producción
+      - Un proxy same-origin escribe solo rutas permitidas en una rama temporal y un PR
 callout:
   type: note
   title: Supuesto de esta guía
@@ -104,8 +104,8 @@ workers/sveltia-cms-auth
 main branch
   -> única fuente de verdad para producción
 
-Sveltia CMS editorial workflow
-  -> crea una rama temporal y un PR por cada cambio
+CMS save proxy
+  -> valida las rutas permitidas y crea una rama temporal y un PR por cada cambio
 
 .github/workflows/create-translation-prs.yml
   -> crea tareas de traducción solo para commits cms:
@@ -134,13 +134,13 @@ En Astro, `public` se sirve como archivos estáticos. La documentación de Svelt
 
 No añadas una hoja CSS extra ni `type="module"` sin necesidad. La UI ya viene empaquetada en el JavaScript de Sveltia CMS.
 
-Acecore usa inicialización manual para poder cambiar la rama en preview.
+Acecore usa inicialización manual para configurar el backend de forma explícita. La rama de publicación sigue siendo `main` en todos los entornos.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -156,6 +156,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -163,11 +165,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-Mantén `main` como rama de publicación y activa `publish_mode: editorial_workflow`. Cada guardado usa una rama temporal y un PR en vez de escribir directamente en producción.
+Mantén `main` como rama de publicación y dirige lecturas y guardados por un proxy same-origin. Antes de crear una rama temporal y un PR, el proxy valida el repositorio, el permiso de escritura del usuario de GitHub, las rutas modificadas y el HEAD más reciente de `main`.
+
+A 20 de julio de 2026, Editorial Workflow no está implementado en Sveltia CMS. Añadir la opción de Decap CMS `publish_mode: editorial_workflow` no hace que Sveltia CMS cree ramas temporales o PRs automáticamente.
 
 Una rama permanente como `cms-content` exige sincronización continua y aumenta el riesgo de conflictos o de configurar mal el origen del despliegue. Las ramas temporales mantienen `main` como única fuente de verdad.
 
@@ -225,34 +227,36 @@ Los textos fijos de páginas pueden gestionarse igual. Acecore reúne la fuente 
 
 La advertencia es no añadir todos los campos de golpe. `config.yml` crece rápido y se vuelve difícil de revisar. Empieza por blog, autores, etiquetas, avisos y páginas que cambian a menudo.
 
-## 8. Mantener coherentes las ramas de preview
+## 8. Mantener `main` como rama de publicación en preview
 
-Si el CMS abierto en una preview de Cloudflare Pages sigue leyendo `main`, el editor verá contenido distinto al preview. Acecore genera `public/admin/runtime-config.js` antes del build e inyecta la rama actual.
+El proxy crea cada rama temporal desde el último `main`. Por eso una preview de Cloudflare Pages no debe sustituir la rama backend por su rama de PR. El resultado se revisa en la preview Pages del PR de CMS generado.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-## 9. Usar ramas temporales con editorial workflow
+## 9. Crear ramas temporales con un proxy de guardado
 
-Sveltia CMS crea una rama temporal y un PR hacia `main` para cada cambio mediante editorial workflow.
+Un proxy de guardado same-origin crea una rama temporal y un PR hacia `main` para cada cambio.
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-Aunque la rama de publicación es `main`, el CMS no escribe directamente en ella. Tras revisar y fusionar el PR, la rama temporal se elimina automáticamente.
+El proxy no escribe directamente en `main`. Reúne contenido y medios permitidos en un commit, crea `cms/acecore/*` desde el último `main` y abre un PR. Tras revisarlo y fusionarlo, la rama temporal se elimina automáticamente.
+
+Con GitHub OAuth, el token del editor aporta identidad y actúa como escritor. Con Cloudflare Access, una GitHub App específica del sitio puede ser el actor. Las restricciones de rutas, ramas temporales, PRs y CI son comunes a ambas variantes.
 
 La forma de merge importa. Las tareas de traducción dependen de subjects como `cms: create ...` o `cms: update ...`. Si se hace squash y se pierden, la automatización puede no detectar el cambio. Para PRs CMS, conviene merge commit o rebase merge.
 
@@ -285,7 +289,7 @@ Sveltia CMS trata de GitHub backend, OAuth, collections, medios y PRs. Turnstile
 - Las rutas de medios deben fijarse antes de subir imágenes.
 - `config.yml` debe crecer por etapas.
 - `cms:` es un contrato para automatización.
-- En preview debe estar claro qué branch lee el CMS.
+- La rama de publicación no cambia por entorno; la preview comprueba el resultado del PR de CMS.
 
 ## Punto de partida mínimo
 
@@ -302,6 +306,7 @@ Desde ahí, añade relations de autores y etiquetas, imágenes, JSON fuente, PRs
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow (no implementado)](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/src/content/blog/fr/cms-selection-and-turnstile.md
+++ b/src/content/blog/fr/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Automatiser l'exploitation
-      description: Utiliser main comme branche de publication et relier les branches temporaires du workflow éditorial, les PRs CMS et les tâches de traduction.
+      description: Utiliser main comme branche de publication et relier les branches temporaires du proxy de sauvegarde validé, les PRs CMS et les tâches de traduction.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - Seules les personnes à l'aise avec GitHub ou un éditeur peuvent mettre à jour
       - Les chemins d'image, IDs d'auteur et tags sont saisis à la main
       - Source japonaise et traductions peuvent être mélangées
-      - Une preview peut lire main par erreur
+      - La cible de sauvegarde et les chemins modifiables peuvent être ambigus
   after:
     label: Édition avec Sveltia CMS
     items:
       - Markdown et JSON se modifient dans le navigateur
       - relation, image et select réduisent les valeurs invalides
       - Seuls les commits CMS déclenchent les tâches de traduction
-      - runtime config change la branche CMS entre preview et production
+      - Un proxy same-origin écrit uniquement les chemins autorisés dans une branche temporaire et une PR
 callout:
   type: note
   title: Hypothèse de ce guide
@@ -102,8 +102,8 @@ workers/sveltia-cms-auth
 main branch
   -> source unique pour la production
 
-Sveltia CMS editorial workflow
-  -> crée une branche temporaire et une PR par modification
+CMS save proxy
+  -> valide les chemins autorisés et crée une branche temporaire et une PR par modification
 
 .github/workflows/create-translation-prs.yml
   -> crée des tâches de traduction seulement pour les commits cms:
@@ -132,13 +132,13 @@ Dans Astro, `public` est servi comme dossier statique. La documentation Sveltia 
 
 N'ajoutez pas de CSS externe ni `type="module"` sans besoin. Le bundle JavaScript contient déjà les styles nécessaires.
 
-Acecore utilise l'initialisation manuelle pour changer la branche en preview.
+Acecore utilise l'initialisation manuelle pour configurer explicitement le backend. La branche de publication reste `main` dans tous les environnements.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -154,6 +154,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -161,11 +163,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-Conservez `main` comme branche de publication et activez `publish_mode: editorial_workflow`. Chaque sauvegarde passe alors par une branche temporaire et une PR, sans écrire directement en production.
+Conservez `main` comme branche de publication et faites passer les lectures et sauvegardes par un proxy same-origin. Avant de créer une branche temporaire et une PR, le proxy vérifie le dépôt, le droit d'écriture de l'utilisateur GitHub, les chemins modifiés et le dernier HEAD de `main`.
+
+Au 20 juillet 2026, Editorial Workflow n'est pas implémenté dans Sveltia CMS. Ajouter le paramètre Decap CMS `publish_mode: editorial_workflow` ne fait pas créer automatiquement des branches temporaires ou des PRs par Sveltia CMS.
 
 Une branche permanente comme `cms-content` impose une synchronisation continue et augmente le risque de conflits ou d'une mauvaise source de déploiement. Les branches temporaires gardent `main` comme source unique.
 
@@ -223,34 +225,36 @@ Les textes de pages fixes peuvent aussi être exposés. Acecore les centralise d
 
 La leçon : ne pas tout ajouter d'un coup. `config.yml` grossit vite. Commencez par blog, auteurs, tags, annonces et pages qui changent souvent.
 
-## 8. Les previews doivent lire la bonne branche
+## 8. Garder `main` comme branche de publication en preview
 
-Si le CMS ouvert dans une preview Cloudflare Pages lit encore `main`, l'éditeur ne voit pas le même contenu que la preview. Acecore génère `public/admin/runtime-config.js` avant le build et injecte la branche courante.
+Le proxy crée chaque branche temporaire depuis le dernier `main`. Une preview Cloudflare Pages ne doit donc pas remplacer la branche backend par sa branche de PR. Le résultat est vérifié dans la preview Pages de la PR CMS générée.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-## 9. Utiliser des branches temporaires avec editorial workflow
+## 9. Créer des branches temporaires avec un proxy de sauvegarde
 
-Sveltia CMS crée une branche temporaire et une PR vers `main` pour chaque modification avec editorial workflow.
+Un proxy de sauvegarde same-origin crée une branche temporaire et une PR vers `main` pour chaque modification.
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-Même si la branche de publication est `main`, le CMS n'y écrit pas directement. Après revue et fusion de la PR, la branche temporaire est supprimée automatiquement.
+Le proxy n'écrit pas directement dans `main`. Il regroupe les contenus et médias autorisés dans un commit, crée `cms/acecore/*` depuis le dernier `main` et ouvre une PR. Après revue et fusion, la branche temporaire est supprimée automatiquement.
+
+Avec GitHub OAuth, le token de l'éditeur sert d'identité et d'acteur d'écriture. Avec Cloudflare Access, une GitHub App propre au site peut être l'acteur. Les restrictions de chemins, branches temporaires, PRs et CI restent communes aux deux variantes.
 
 La méthode de merge compte. Les tâches de traduction dépendent de subjects comme `cms: create ...`. Si un squash les supprime, l'automatisation peut rater le changement. Pour les PRs CMS, préférez merge commit ou rebase merge.
 
@@ -283,7 +287,7 @@ Sveltia CMS concerne le backend GitHub, OAuth, les collections, médias et PRs. 
 - Les chemins médias doivent être fixés avant les uploads.
 - `config.yml` doit grandir par étapes.
 - `cms:` est un contrat pour les workflows.
-- En preview, la branche lue par le CMS doit être claire.
+- La branche de publication ne change pas selon l'environnement ; la preview vérifie le résultat de la PR CMS.
 
 ## Point de départ minimal
 
@@ -300,6 +304,7 @@ Ajoutez ensuite relations auteurs et tags, images, JSON source, PRs automatiques
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow (non implémenté)](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/src/content/blog/ko/cms-selection-and-turnstile.md
+++ b/src/content/blog/ko/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: 운영 자동화
-      description: main을 publication branch로 사용하고 editorial workflow의 단기 branch, CMS 편집 PR, 번역 PR task를 연결합니다.
+      description: main을 publication branch로 사용하고 검증된 저장 proxy의 단기 branch, CMS 편집 PR, 번역 PR task를 연결합니다.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - GitHub나 에디터에 익숙한 사람만 쉽게 수정할 수 있음
       - 이미지 경로, 작성자 ID, 태그명을 수동 입력하기 쉬움
       - 일본어 source와 번역 파일 수정 범위가 섞이기 쉬움
-      - preview 환경이 main 내용을 읽을 수 있음
+      - 저장 대상과 쓰기 가능한 경로가 불명확해질 수 있음
   after:
     label: Sveltia CMS 편집
     items:
       - 브라우저 폼에서 Markdown과 JSON을 편집할 수 있음
       - relation, image, select로 잘못된 값을 줄임
       - CMS commit만 번역 PR task를 트리거함
-      - runtime config로 preview와 production의 CMS branch를 전환함
+      - same-origin proxy가 허용 경로만 단기 branch와 PR에 저장함
 callout:
   type: note
   title: 이 글의 전제
@@ -102,8 +102,8 @@ workers/sveltia-cms-auth
 main branch
   -> 운영 환경의 유일한 기준
 
-Sveltia CMS editorial workflow
-  -> 변경마다 단기 branch와 main 대상 PR 생성
+CMS save proxy
+  -> 허용 경로를 검증하고 변경마다 단기 branch와 main 대상 PR 생성
 
 .github/workflows/create-translation-prs.yml
   -> cms: commit에만 번역 PR task 생성
@@ -132,13 +132,13 @@ Astro에서는 `public` 아래 파일이 정적 파일로 배포됩니다. Svelt
 
 불필요한 CSS나 `type="module"`을 추가하지 않습니다. 현재 CDN bundle은 일반 script로 읽는 구성이 자연스럽습니다.
 
-Acecore에서는 preview branch를 바꾸기 위해 수동 초기화를 사용합니다.
+Acecore에서는 backend를 명시적으로 설정하기 위해 수동 초기화를 사용합니다. publication branch는 모든 환경에서 `main`으로 유지합니다.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -154,6 +154,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -161,11 +163,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-`main`을 publication branch로 유지하고 `publish_mode: editorial_workflow`를 사용합니다. 각 저장은 운영 환경에 직접 기록되지 않고 단기 branch와 PR을 거칩니다.
+`main`을 publication branch로 유지하고 읽기와 저장을 same-origin proxy로 보냅니다. proxy는 단기 branch와 PR을 만들기 전에 repository, GitHub 사용자의 쓰기 권한, 변경 경로, 최신 `main` HEAD를 검증합니다.
+
+2026년 7월 20일 기준으로 Sveltia CMS에는 Editorial Workflow가 구현되어 있지 않습니다. Decap CMS의 `publish_mode: editorial_workflow` 설정을 추가해도 Sveltia CMS가 단기 branch나 PR을 자동 생성하지는 않습니다.
 
 `cms-content` 같은 영구 branch는 지속적인 동기화가 필요하며 충돌이나 잘못된 배포 source 설정 위험을 높입니다. PR마다 단기 branch를 닫으면 `main`을 유일한 기준으로 유지할 수 있습니다.
 
@@ -223,34 +225,36 @@ Acecore는 나중에 [PR #116](https://github.com/acecore-systems/acecore-net/pu
 
 반성점은 한 번에 모든 필드를 넣지 않는 것입니다. `config.yml`이 급격히 커지면 리뷰와 유지보수가 어려워집니다. 블로그, 작성자, 태그, 공지, 자주 바뀌는 페이지부터 시작하는 편이 좋습니다.
 
-## 8. preview branch를 맞춘다
+## 8. preview에서도 publication branch를 `main`으로 유지한다
 
-Cloudflare Pages preview에서 CMS가 여전히 `main`을 읽으면, preview 화면과 CMS 내용이 어긋납니다. Acecore는 build 전에 `public/admin/runtime-config.js`를 만들고 현재 branch를 주입합니다.
+저장 proxy는 최신 `main`에서 모든 단기 branch를 만듭니다. 따라서 Cloudflare Pages preview가 backend branch를 해당 PR branch로 바꾸면 안 됩니다. 저장 결과는 생성된 CMS PR의 Pages preview에서 확인합니다.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-## 9. Editorial workflow로 단기 branch와 PR 만들기
+## 9. 저장 proxy로 단기 branch와 PR 만들기
 
-Sveltia CMS editorial workflow는 변경마다 단기 branch와 `main` 대상 PR을 만듭니다.
+same-origin 저장 proxy가 변경마다 단기 branch와 `main` 대상 PR을 만듭니다.
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-publication branch는 `main`이지만 CMS가 여기에 직접 commit하지는 않습니다. PR을 검토하고 merge한 뒤 단기 branch를 자동으로 삭제합니다.
+proxy는 `main`에 직접 commit하지 않습니다. 허용된 content와 media를 한 commit으로 묶고 최신 `main`에서 `cms/acecore/*`를 만든 뒤 PR을 엽니다. 검토와 merge 후 단기 branch를 자동 삭제합니다.
+
+GitHub OAuth 방식에서는 편집자의 token이 identity와 쓰기 actor 역할을 합니다. Cloudflare Access 방식에서는 사이트 전용 GitHub App이 actor가 될 수 있습니다. 경로 제한, 단기 branch, PR, CI 정책은 두 방식 모두 같습니다.
 
 merge 방식도 중요합니다. 번역 workflow는 `cms: create ...`, `cms: update ...` 같은 commit subject를 봅니다. squash merge로 subject가 사라지면 자동화가 감지하지 못할 수 있으므로 CMS PR은 merge commit 또는 rebase merge가 적합합니다.
 
@@ -283,7 +287,7 @@ Sveltia CMS는 GitHub backend, OAuth, collections, media, PR 운영의 문제입
 - 이미지 경로는 업로드 전에 고정해야 합니다.
 - `config.yml`은 단계적으로 확장해야 합니다.
 - `cms:`는 자동화 계약입니다.
-- preview에서 CMS가 읽는 branch를 명확히 해야 합니다.
+- publication branch는 환경별로 바꾸지 않고, preview에서는 CMS PR 결과를 확인합니다.
 
 ## 최소 시작점
 
@@ -300,6 +304,7 @@ public/admin/runtime-config.js
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow (미구현)](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/src/content/blog/pt/cms-selection-and-turnstile.md
+++ b/src/content/blog/pt/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Automatizar a operação
-      description: Use main como branch de publicação e conecte branches temporárias do editorial workflow, PRs de CMS e tarefas de tradução.
+      description: Use main como branch de publicação e conecte branches temporárias do proxy de salvamento validado, PRs de CMS e tarefas de tradução.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - Só quem usa GitHub ou editor atualiza com facilidade
       - Caminhos de imagem, IDs de autor e tags são digitados à mão
       - Fonte japonesa e traduções podem ser misturadas
-      - Preview pode ler conteúdo da main por engano
+      - O destino de salvamento e os caminhos graváveis podem ficar ambíguos
   after:
     label: Edição com Sveltia CMS
     items:
       - Markdown e JSON são editados em formulários no navegador
       - relation, image e select reduzem valores inválidos
       - Apenas commits de CMS disparam tarefas de tradução
-      - runtime config troca a branch do CMS entre preview e produção
+      - Um proxy same-origin grava apenas caminhos permitidos em uma branch temporária e um PR
 callout:
   type: note
   title: Premissa deste guia
@@ -102,8 +102,8 @@ workers/sveltia-cms-auth
 main branch
   -> única fonte de verdade para produção
 
-Sveltia CMS editorial workflow
-  -> cria uma branch temporária e um PR para cada alteração
+CMS save proxy
+  -> valida caminhos permitidos e cria uma branch temporária e um PR para cada alteração
 
 .github/workflows/create-translation-prs.yml
   -> cria tarefas de tradução apenas para commits cms:
@@ -132,13 +132,13 @@ No Astro, arquivos em `public` são servidos como estáticos. A documentação d
 
 Não adicione CSS extra ou `type="module"` sem motivo. O bundle do Sveltia CMS já inclui os estilos da UI.
 
-Na Acecore usamos inicialização manual para trocar a branch em previews.
+Na Acecore usamos inicialização manual para configurar o backend explicitamente. A branch de publicação permanece `main` em todos os ambientes.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -154,6 +154,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -161,11 +163,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-Mantenha `main` como branch de publicação e ative `publish_mode: editorial_workflow`. Cada salvamento passa por uma branch temporária e um PR, sem gravar diretamente em produção.
+Mantenha `main` como branch de publicação e encaminhe leituras e salvamentos por um proxy same-origin. Antes de criar uma branch temporária e um PR, o proxy valida o repositório, a permissão de escrita do usuário GitHub, os caminhos alterados e o HEAD mais recente de `main`.
+
+Em 20 de julho de 2026, o Editorial Workflow ainda não está implementado no Sveltia CMS. Adicionar a opção do Decap CMS `publish_mode: editorial_workflow` não faz o Sveltia CMS criar branches temporárias ou PRs automaticamente.
 
 Uma branch permanente como `cms-content` exige sincronização contínua e aumenta o risco de conflitos ou de configurar a origem de deploy incorretamente. Branches temporárias mantêm `main` como única fonte de verdade.
 
@@ -223,34 +225,36 @@ Textos fixos também podem entrar no CMS. A Acecore centraliza a fonte japonesa 
 
 O cuidado é não adicionar todos os campos de uma vez. `config.yml` cresce rapidamente. Comece por blog, autores, tags, avisos e páginas que mudam com frequência.
 
-## 8. Preview deve ler a branch certa
+## 8. Manter `main` como branch de publicação no preview
 
-Se o CMS em um preview do Cloudflare Pages ainda lê `main`, ele mostra conteúdo diferente do preview. A Acecore gera `public/admin/runtime-config.js` antes do build e injeta a branch atual.
+O proxy cria cada branch temporária a partir do `main` mais recente. Portanto, um preview do Cloudflare Pages não deve substituir a branch backend pela branch do PR. O resultado é revisado no Pages preview do PR de CMS gerado.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-## 9. Usar branches temporárias com editorial workflow
+## 9. Criar branches temporárias com um proxy de salvamento
 
-O Sveltia CMS cria uma branch temporária e um PR para `main` a cada alteração usando editorial workflow.
+Um proxy de salvamento same-origin cria uma branch temporária e um PR para `main` a cada alteração.
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-Embora a branch de publicação seja `main`, o CMS não grava diretamente nela. Após revisar e fazer merge do PR, a branch temporária é removida automaticamente.
+O proxy não grava diretamente em `main`. Ele reúne conteúdo e mídia permitidos em um commit, cria `cms/acecore/*` a partir do `main` mais recente e abre um PR. Após revisão e merge, a branch temporária é removida automaticamente.
+
+Com GitHub OAuth, o token do editor fornece identidade e atua como gravador. Com Cloudflare Access, uma GitHub App específica do site pode ser o ator. Restrições de caminho, branches temporárias, PRs e CI continuam comuns às duas variantes.
 
 O modo de merge importa. As traduções dependem de subjects como `cms: create ...` e `cms: update ...`. Se um squash merge apaga esses subjects, a automação pode não detectar a mudança. Para PRs de CMS, preserve os commits `cms:` com merge commit ou rebase merge.
 
@@ -283,7 +287,7 @@ Sveltia CMS trata de backend GitHub, OAuth, collections, mídia e PRs. Turnstile
 - Caminhos de mídia devem ser definidos antes de uploads.
 - `config.yml` deve crescer por etapas.
 - `cms:` é contrato de automação.
-- Preview precisa deixar clara a branch lida pelo CMS.
+- A branch de publicação não muda por ambiente; o preview verifica o resultado do PR de CMS.
 
 ## Ponto inicial mínimo
 
@@ -300,6 +304,7 @@ Depois adicione relations de autores e tags, imagens, JSON fonte, PRs automátic
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow (não implementado)](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/src/content/blog/ru/cms-selection-and-turnstile.md
+++ b/src/content/blog/ru/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: Автоматизировать эксплуатацию
-      description: Использовать main как ветку публикации и связать временные ветки editorial workflow, CMS PR и задачи перевода.
+      description: Использовать main как ветку публикации и связать временные ветки проверяющего save proxy, CMS PR и задачи перевода.
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - Обновлять удобно только тем, кто уверенно пользуется GitHub или редактором
       - Пути изображений, ID авторов и теги вводятся вручную
       - Изменения японского source и переводов легко смешать
-      - Preview может случайно читать main
+      - Цель сохранения и доступные для записи пути могут быть неясны
   after:
     label: Редактирование в Sveltia CMS
     items:
       - Markdown и JSON редактируются через формы в браузере
       - relation, image и select уменьшают число некорректных значений
       - Только CMS commits запускают задачи перевода
-      - runtime config переключает CMS branch между preview и production
+      - Same-origin proxy пишет только разрешённые пути во временную ветку и PR
 callout:
   type: note
   title: Предпосылка статьи
@@ -102,8 +102,8 @@ workers/sveltia-cms-auth
 main branch
   -> единственный источник для production
 
-Sveltia CMS editorial workflow
-  -> создаёт временную ветку и PR для каждого изменения
+CMS save proxy
+  -> проверяет разрешённые пути и создаёт временную ветку и PR для каждого изменения
 
 .github/workflows/create-translation-prs.yml
   -> создаёт задачи перевода только для cms: commits
@@ -132,13 +132,13 @@ Sveltia CMS editorial workflow
 
 Не стоит добавлять лишний CSS или `type="module"` без причины. Стили интерфейса уже включены в JavaScript bundle.
 
-Acecore использует ручную инициализацию, чтобы preview мог подставлять нужную ветку.
+Acecore использует ручную инициализацию для явной настройки backend. Ветка публикации остаётся `main` во всех окружениях.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -154,6 +154,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -161,11 +163,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-Оставьте `main` веткой публикации и включите `publish_mode: editorial_workflow`. Каждое сохранение проходит через временную ветку и PR, а не записывается напрямую в production.
+Оставьте `main` веткой публикации и направляйте чтение и сохранение через same-origin proxy. Перед созданием временной ветки и PR proxy проверяет репозиторий, право GitHub-пользователя на запись, изменённые пути и последний HEAD `main`.
+
+По состоянию на 20 июля 2026 года Editorial Workflow не реализован в Sveltia CMS. Настройка Decap CMS `publish_mode: editorial_workflow` не заставляет Sveltia CMS автоматически создавать временные ветки или PR.
 
 Постоянная ветка вроде `cms-content` требует непрерывной синхронизации и повышает риск конфликтов или неверной настройки источника deploy. Временные ветки сохраняют `main` единственным источником истины.
 
@@ -223,34 +225,36 @@ Acecore позже исправила этот момент в [PR #116](https:/
 
 Урок простой: не добавлять все поля сразу. `config.yml` быстро растёт. Начните с блога, авторов, тегов, объявлений и часто меняющихся страниц.
 
-## 8. Preview должен читать правильную ветку
+## 8. Сохранять `main` веткой публикации и в preview
 
-Если CMS в preview Cloudflare Pages всё ещё читает `main`, редактор видит не тот контент, что preview. Acecore перед build создаёт `public/admin/runtime-config.js` и передаёт текущий branch.
+Proxy создаёт каждую временную ветку от последнего `main`. Поэтому preview Cloudflare Pages не должен подменять backend branch своей PR-веткой. Результат проверяется в Pages preview созданного CMS PR.
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-## 9. Использовать временные ветки editorial workflow
+## 9. Создавать временные ветки через save proxy
 
-Sveltia CMS создаёт временную ветку и PR в `main` для каждого изменения через editorial workflow.
+Same-origin save proxy создаёт временную ветку и PR в `main` для каждого изменения.
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-Хотя ветка публикации — `main`, CMS не записывает изменения прямо в неё. После ревью и merge временная ветка удаляется автоматически.
+Proxy не пишет напрямую в `main`. Он объединяет разрешённый контент и медиа в один commit, создаёт `cms/acecore/*` от последнего `main` и открывает PR. После ревью и merge временная ветка удаляется автоматически.
+
+При GitHub OAuth token редактора задаёт личность и выступает актором записи. При Cloudflare Access актором может быть отдельная GitHub App сайта. Ограничения путей, временные ветки, PR и CI одинаковы в обеих схемах.
 
 Способ merge важен. Задачи перевода зависят от commit subjects вроде `cms: create ...`. Если squash merge их удалит, автоматизация может не увидеть изменение source. Для CMS PR лучше merge commit или rebase merge.
 
@@ -283,7 +287,7 @@ Sveltia CMS — про GitHub backend, OAuth, collections, медиа и PR. Tur
 - Пути медиа нужно зафиксировать до загрузок.
 - `config.yml` лучше расширять постепенно.
 - `cms:` — контракт автоматизации.
-- В preview должно быть ясно, какой branch читает CMS.
+- Ветка публикации не меняется между окружениями; preview проверяет результат CMS PR.
 
 ## Минимальная отправная точка
 
@@ -300,6 +304,7 @@ public/admin/runtime-config.js
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow (не реализован)](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/src/content/blog/zh-cn/cms-selection-and-turnstile.md
+++ b/src/content/blog/zh-cn/cms-selection-and-turnstile.md
@@ -22,7 +22,7 @@ processFigure:
       icon: i-lucide-file-text
       accent: amber
     - title: 自动化运维
-      description: 将 main 作为发布分支，并连接 editorial workflow 的短期分支、CMS 编辑 PR 与翻译 PR task。
+      description: 将 main 作为发布分支，并连接经过验证的保存 proxy 短期分支、CMS 编辑 PR 与翻译 PR task。
       icon: i-lucide-git-pull-request
       accent: slate
 compareTable:
@@ -33,14 +33,14 @@ compareTable:
       - 只有熟悉 GitHub 或编辑器的人容易更新
       - 图片路径、作者 ID、标签名容易手写出错
       - 日语 source 与翻译文件的修改范围容易混在一起
-      - preview 环境可能仍然读取 main 的内容
+      - 保存目标和可写路径可能不够明确
   after:
     label: 使用 Sveltia CMS 编辑
     items:
       - 可以在浏览器表单中编辑 Markdown 与 JSON
       - relation、image、select 减少无效值
       - 只有 CMS commit 会触发翻译 PR task
-      - runtime config 可以在 preview 与 production 间切换 CMS branch
+      - same-origin proxy 只把允许的路径写入短期 branch 和 PR
 callout:
   type: note
   title: 本文前提
@@ -104,8 +104,8 @@ workers/sveltia-cms-auth
 main branch
   -> 生产环境唯一的真实来源
 
-Sveltia CMS editorial workflow
-  -> 每次修改创建短期分支和 main 向 PR
+CMS save proxy
+  -> 验证允许的路径，并为每次修改创建短期分支和 main 向 PR
 
 .github/workflows/create-translation-prs.yml
   -> 只为 cms: commit 创建翻译 PR task
@@ -136,13 +136,13 @@ Astro 会原样发布 `public` 目录下的文件。Sveltia CMS 官方文档也�
 
 不要额外加入不存在的 CSS，也不要随手加 `type="module"`。当前的 Sveltia CMS CDN 版本按普通 script 加载即可。
 
-Acecore 为了让 preview 环境切换 branch，使用了手动初始化。
+Acecore 使用手动初始化来明确配置 backend。所有环境的发布分支都固定为 `main`。
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
@@ -158,6 +158,8 @@ backend:
   repo: owner/repository
   branch: main
   base_url: https://your-sveltia-cms-auth-worker.example.workers.dev
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
   auth_methods: [oauth]
   commit_messages:
     create: 'cms: create {{collection}} "{{slug}}"'
@@ -165,11 +167,11 @@ backend:
     delete: 'cms: delete {{collection}} "{{slug}}"'
     uploadMedia: 'cms: upload "{{path}}"'
     deleteMedia: 'cms: delete media "{{path}}"'
-
-publish_mode: editorial_workflow
 ```
 
-将 `main` 保持为发布分支，并启用 `publish_mode: editorial_workflow`。每次保存都会进入短期分支和 PR，而不是直接写入生产环境。
+将 `main` 保持为发布分支，并让读取和保存都经过 same-origin proxy。proxy 在创建短期分支和 PR 之前，会验证 repository、GitHub 用户的写权限、修改路径以及最新的 `main` HEAD。
+
+截至 2026 年 7 月 20 日，Sveltia CMS 尚未实现 Editorial Workflow。添加 Decap CMS 的 `publish_mode: editorial_workflow` 配置，并不会让 Sveltia CMS 自动创建短期分支或 PR。
 
 像 `cms-content` 这样的常设分支需要持续同步，并会增加冲突或错误配置部署来源的风险。按 PR 关闭短期分支，可以让 `main` 始终是唯一的真实来源。
 
@@ -243,36 +245,38 @@ Acecore 把 CMS 编辑范围分成四类。
 
 反省点是，一开始不要把所有字段一次性放进 `config.yml`。配置会迅速变大，既存值读取、标签命名和审核都会变困难。建议从博客、作者、标签、告知、常改页面开始，逐步扩展。
 
-## 8. preview 环境要读取正确 branch
+## 8. preview 环境也将发布分支固定为 `main`
 
-Cloudflare Pages preview 中打开 CMS 时，如果 CMS 仍然读取 `main`，看到的内容就会和 preview 页面不一致。Acecore 在构建前生成 `public/admin/runtime-config.js`，把当前 branch 注入到 `window.ACECORE_CMS_BRANCH`。
+保存 proxy 始终从最新的 `main` 创建短期 branch，因此 Cloudflare Pages preview 不应把 backend branch 替换为当前 PR branch。保存结果应在生成的 CMS PR 对应 Pages preview 中确认。
 
 ```javascript
 CMS.init({
   config: {
     backend: {
-      branch: window.ACECORE_CMS_BRANCH || 'main',
+      branch: 'main',
     },
   },
 })
 ```
 
-这样可以保持 YAML 配置共通，同时让 preview 指向正确分支。
+这样 production 与 preview 就不会使用不同的保存起点，proxy 也可以拒绝以 `main` 之外的 branch 为 base 的请求。
 
-## 9. 使用 editorial workflow 的短期分支
+## 9. 使用保存 proxy 创建短期分支
 
-Sveltia CMS 通过 editorial workflow 为每次修改创建短期分支和 main 向 PR。
+same-origin 保存 proxy 为每次修改创建短期分支和 main 向 PR。
 
 ```yaml
 backend:
   name: github
   repo: owner/repository
   branch: main
-
-publish_mode: editorial_workflow
+  api_root: /admin/api/github
+  graphql_api_root: /admin/api/graphql
 ```
 
-虽然发布分支是 `main`，CMS 并不会直接提交到它。审核并合并 PR 后，短期分支会自动删除。
+proxy 不会直接提交到 `main`。它把允许的 content 与 media 合并到一个 commit，从最新 `main` 创建 `cms/acecore/*` 并打开 PR。审核并合并后，短期 branch 会自动删除。
+
+在 GitHub OAuth 模式中，编辑者 token 用于身份确认并作为写入 actor；在 Cloudflare Access 模式中，可以使用站点专属 GitHub App 作为 actor。路径限制、短期 branch、PR 与 CI 策略保持一致。
 
 这里的 merge 方法很重要。Acecore 的翻译任务依赖 `cms: create ...`、`cms: update ...` 等 commit subject。如果 squash merge 抹掉这些 subject，翻译 workflow 可能无法检测到 source 更新。CMS PR 应使用保留 `cms:` commit 的 merge commit 或 rebase merge。
 
@@ -305,7 +309,7 @@ Sveltia CMS 关注 GitHub backend、OAuth、collection、图片路径和 PR 运�
 - 图片路径要在编辑者上传前固定。
 - `config.yml` 的字段要逐步增加，不要一次性暴露全部页面文案。
 - `cms:` commit subject 是自动化契约，不是普通前缀。
-- preview 环境必须清楚显示 CMS 正在读哪个 branch。
+- 发布分支不随环境切换；preview 用于检查 CMS PR 的结果。
 
 ## 最小起点
 
@@ -324,6 +328,7 @@ public/admin/runtime-config.js
 
 - [Sveltia CMS Getting Started](https://sveltiacms.app/en/docs/start)
 - [Sveltia CMS GitHub Backend](https://sveltiacms.app/en/docs/backends/github)
+- [Sveltia CMS Editorial Workflow（尚未实现）](https://sveltiacms.app/en/docs/workflows/editorial)
 - [Sveltia CMS Internal Media Storage](https://sveltiacms.app/en/docs/media/internal)
 - [Sveltia CMS Manual Initialization](https://sveltiacms.app/en/docs/api/initialization)
 - [Sveltia CMS Authenticator](https://github.com/sveltia/sveltia-cms-auth)

--- a/tests/cms-proxy.test.mjs
+++ b/tests/cms-proxy.test.mjs
@@ -1,0 +1,546 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { afterEach, test } from 'node:test'
+
+import {
+  CMS_REPOSITORY,
+  isAllowedCmsDirectoryPath,
+  isAllowedCmsWritePath,
+} from '../functions/admin/api/_cms-policy.ts'
+import { clearGitHubEditorCacheForTests } from '../functions/admin/api/_github-oauth.ts'
+import { onRequestPost as handleGraphql } from '../functions/admin/api/graphql.ts'
+import { onRequest as handleGithubRest } from '../functions/admin/api/github/[[path]].ts'
+
+const originalFetch = globalThis.fetch
+const mainSha = 'a'.repeat(40)
+const oauthToken = 'test-oauth-token'
+const repositoryApi = `https://api.github.com/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`
+const branchPrefix =
+  CMS_REPOSITORY.name === 'acecore-net' ? 'cms/acecore/' : 'cms/aceserver/'
+const contentPath =
+  CMS_REPOSITORY.name === 'acecore-net'
+    ? 'src/content/blog/example.md'
+    : 'src/content/pages/top.json'
+const rejectedPath =
+  CMS_REPOSITORY.name === 'acecore-net'
+    ? 'src/i18n/translations/en.json'
+    : 'src/content.config.ts'
+const collectionWritePaths =
+  CMS_REPOSITORY.name === 'acecore-net'
+    ? [
+        'src/content/blog/example.md',
+        'src/content/authors/example.json',
+        'src/content/tags/example.json',
+        'src/i18n/source/ja/campaigns/example.json',
+      ]
+    : []
+const unlistedContentPath =
+  CMS_REPOSITORY.name === 'acecore-net'
+    ? 'src/content/blog/en/example.md'
+    : 'src/content/pages/unlisted.json'
+
+const editor = {
+  avatar_url: 'https://avatars.githubusercontent.com/u/1',
+  email: null,
+  html_url: 'https://github.com/editor',
+  id: 1,
+  login: 'editor',
+  name: 'Editor',
+  type: 'User',
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  clearGitHubEditorCacheForTests()
+})
+
+test('CMS対象pathだけを許可する', () => {
+  assert.equal(isAllowedCmsWritePath(contentPath), true)
+  for (const path of collectionWritePaths) {
+    assert.equal(isAllowedCmsWritePath(path), true)
+  }
+  assert.equal(isAllowedCmsWritePath('public/uploads/example.png'), true)
+  assert.equal(isAllowedCmsWritePath(rejectedPath), false)
+  assert.equal(isAllowedCmsWritePath(unlistedContentPath), false)
+  assert.equal(isAllowedCmsWritePath('README.md'), false)
+  assert.equal(isAllowedCmsWritePath('../README.md'), false)
+  assert.equal(isAllowedCmsWritePath(`${contentPath}\nREADME.md`), false)
+})
+
+test('CMS設定で公開したfolderとfileがproxyの許可範囲に収まる', async () => {
+  const config = await readFile(
+    new URL('../public/admin/config.yml', import.meta.url),
+    'utf8',
+  )
+  const folders = Array.from(
+    config.matchAll(/^\s*folder:\s*([^,\s]+),?\s*$/gm),
+    (match) => match[1],
+  )
+  const files = Array.from(
+    config.matchAll(/^\s*file:\s*([^,\s]+),?\s*$/gm),
+    (match) => match[1],
+  )
+
+  if (CMS_REPOSITORY.name === 'acecore-net') {
+    assert.ok(folders.length > 0)
+  }
+  assert.ok(files.length > 0)
+
+  for (const path of folders) {
+    assert.equal(isAllowedCmsDirectoryPath(path), true, path)
+  }
+
+  for (const path of files) {
+    assert.equal(isAllowedCmsWritePath(path), true, path)
+  }
+})
+
+test('GitHub OAuth認証がないrequestを拒否する', async () => {
+  let called = false
+  globalThis.fetch = async () => {
+    called = true
+    throw new Error('GitHub must not be called')
+  }
+
+  const response = await handleGraphql({
+    request: graphqlRequest({ authorization: null }),
+  })
+
+  assert.equal(response.status, 401)
+  assert.equal(called, false)
+})
+
+test('repositoryへのpush権限がないGitHub userを拒否する', async () => {
+  mockGitHub(async () => {
+    throw new Error('CMS operation must not continue')
+  }, false)
+
+  const response = await handleGraphql({
+    request: graphqlRequest(),
+  })
+
+  assert.equal(response.status, 403)
+  assert.match((await response.json()).message, /write権限/)
+})
+
+test('Sveltia CMS 0.166のlast-commit queryを許可する', async () => {
+  mockGitHub(async (url, _init, body) => {
+    assert.match(url, /\/graphql$/)
+    assert.match(body.query, /ref\(qualifiedName: \$branch\)/)
+
+    return jsonResponse({
+      data: {
+        repository: {
+          ref: {
+            target: {
+              history: { nodes: [{ oid: mainSha, message: 'latest' }] },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  const response = await handleGraphql({
+    request: graphqlReadRequest(
+      `
+        query($owner: String!, $repo: String!, $branch: String!) {
+          repository(owner: $owner, name: $repo) {
+            ref(qualifiedName: $branch) {
+              target {
+                ... on Commit {
+                  history(first: 1) { nodes { oid message } }
+                }
+              }
+            }
+          }
+        }
+      `,
+      {
+        owner: CMS_REPOSITORY.owner,
+        repo: CMS_REPOSITORY.name,
+        branch: 'main',
+      },
+    ),
+  })
+
+  assert.equal(response.status, 200)
+})
+
+test('Sveltia CMS 0.166のcontent queryをCMS対象blobだけ許可する', async () => {
+  const blobSha = 'b'.repeat(40)
+
+  mockGitHub(async (url, _init, body) => {
+    if (url.includes('/git/trees/main?recursive=1')) {
+      return jsonResponse({
+        sha: mainSha,
+        truncated: false,
+        tree: [
+          {
+            mode: '100644',
+            path: contentPath,
+            sha: blobSha,
+            size: 12,
+            type: 'blob',
+          },
+        ],
+      })
+    }
+
+    assert.match(url, /\/graphql$/)
+    assert.match(body.query, /content_0:\s*object/)
+    assert.match(body.query, /commit_0:\s*ref/)
+
+    return jsonResponse({ data: { repository: {} } })
+  })
+
+  const response = await handleGraphql({
+    request: graphqlReadRequest(
+      `
+        query($owner: String!, $repo: String!, $branch: String!) {
+          repository(owner: $owner, name: $repo) {
+            content_0: object(oid: "${blobSha}") {
+              ... on Blob { text }
+            }
+            commit_0: ref(qualifiedName: $branch) {
+              target {
+                ... on Commit {
+                  history(first: 1, path: "${contentPath}") {
+                    nodes {
+                      author {
+                        name
+                        email
+                        user { id: databaseId login }
+                      }
+                      committedDate
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      {
+        owner: CMS_REPOSITORY.owner,
+        repo: CMS_REPOSITORY.name,
+        branch: 'main',
+      },
+    ),
+  })
+
+  assert.equal(response.status, 200)
+})
+
+test('画像と本文を同じ短期branchの1 commit・1 PRに保存する', async () => {
+  const calls = []
+  let cmsBranch = ''
+
+  mockGitHub(async (url, init, body) => {
+    calls.push({ url, init, body })
+
+    if (url.endsWith('/git/ref/heads/main')) {
+      return jsonResponse({ object: { sha: mainSha } })
+    }
+
+    if (url.endsWith('/git/refs')) {
+      cmsBranch = body.ref.replace('refs/heads/', '')
+      assert.match(cmsBranch, new RegExp(`^${branchPrefix}`))
+      assert.equal(body.sha, mainSha)
+
+      return jsonResponse({ ref: body.ref, object: { sha: mainSha } }, 201)
+    }
+
+    if (url.endsWith('/graphql')) {
+      assert.match(body.query, /mutation CmsCommit/)
+      assert.equal(
+        body.variables.input.branch.repositoryNameWithOwner,
+        `${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`,
+      )
+      assert.equal(body.variables.input.branch.branchName, cmsBranch)
+      assert.equal(body.variables.input.expectedHeadOid, mainSha)
+      assert.deepEqual(
+        body.variables.input.fileChanges.additions.map(({ path }) => path),
+        ['public/uploads/example.png', contentPath],
+      )
+
+      return jsonResponse({
+        data: {
+          createCommitOnBranch: {
+            commit: {
+              oid: 'b'.repeat(40),
+              committedDate: '2026-07-20T00:00:00Z',
+              file_0: { oid: 'c'.repeat(40) },
+              file_1: { oid: 'd'.repeat(40) },
+            },
+          },
+        },
+      })
+    }
+
+    if (url.endsWith('/pulls')) {
+      assert.equal(body.head, cmsBranch)
+      assert.equal(body.base, 'main')
+      assert.match(body.body, /GitHub user: @editor/)
+      assert.match(body.body, new RegExp(contentPath.replaceAll('/', '\\/')))
+
+      return jsonResponse(
+        { number: 91, html_url: 'https://github.com/example/pull/91' },
+        201,
+      )
+    }
+
+    throw new Error(`Unexpected GitHub request: ${url}`)
+  })
+
+  const response = await handleGraphql({
+    request: graphqlRequest({
+      variables: {
+        input: {
+          branch: {
+            repositoryNameWithOwner: `${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`,
+            branchName: 'main',
+          },
+          expectedHeadOid: mainSha,
+          fileChanges: {
+            additions: [
+              {
+                path: 'public/uploads/example.png',
+                contents: Buffer.from('image').toString('base64'),
+              },
+              {
+                path: contentPath,
+                contents: Buffer.from('content').toString('base64'),
+              },
+            ],
+            deletions: [],
+          },
+          message: { headline: 'cms: update example' },
+        },
+      },
+    }),
+  })
+  const result = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(result.extensions.cms.branch, cmsBranch)
+  assert.equal(result.extensions.cms.pull_request.number, 91)
+  assert.equal(calls.length, 4)
+})
+
+test('CMS管理対象外の保存をGitHubへ送らない', async () => {
+  let cmsOperationCalled = false
+
+  mockGitHub(async () => {
+    cmsOperationCalled = true
+    throw new Error('CMS operation must not continue')
+  })
+
+  const response = await handleGraphql({
+    request: graphqlRequest({
+      variables: {
+        input: {
+          branch: {
+            repositoryNameWithOwner: `${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`,
+            branchName: 'main',
+          },
+          expectedHeadOid: mainSha,
+          fileChanges: {
+            additions: [
+              {
+                path: 'README.md',
+                contents: Buffer.from('blocked').toString('base64'),
+              },
+            ],
+            deletions: [],
+          },
+          message: { headline: 'cms: update blocked' },
+        },
+      },
+    }),
+  })
+
+  assert.equal(response.status, 403)
+  assert.equal(cmsOperationCalled, false)
+})
+
+test('main以外を指定した保存を拒否する', async () => {
+  let cmsOperationCalled = false
+
+  mockGitHub(async () => {
+    cmsOperationCalled = true
+    throw new Error('CMS operation must not continue')
+  })
+
+  const response = await handleGraphql({
+    request: graphqlRequest({
+      variables: {
+        input: {
+          branch: {
+            repositoryNameWithOwner: `${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`,
+            branchName: 'preview',
+          },
+          expectedHeadOid: mainSha,
+          fileChanges: {
+            additions: [
+              {
+                path: contentPath,
+                contents: Buffer.from('blocked').toString('base64'),
+              },
+            ],
+            deletions: [],
+          },
+          message: { headline: 'cms: update blocked' },
+        },
+      },
+    }),
+  })
+
+  assert.equal(response.status, 403)
+  assert.equal(cmsOperationCalled, false)
+})
+
+test('Git tree responseからCMS対象外pathを除外する', async () => {
+  mockGitHub(async (url) => {
+    assert.match(url, /\/git\/trees\/main\?recursive=1$/)
+
+    return jsonResponse({
+      sha: mainSha,
+      truncated: false,
+      tree: [
+        { mode: '040000', path: 'src', sha: '1'.repeat(40), type: 'tree' },
+        {
+          mode: '100644',
+          path: contentPath,
+          sha: '2'.repeat(40),
+          size: 12,
+          type: 'blob',
+        },
+        {
+          mode: '100644',
+          path: 'README.md',
+          sha: '3'.repeat(40),
+          size: 12,
+          type: 'blob',
+        },
+      ],
+    })
+  })
+
+  const response = await handleGithubRest({
+    request: new Request(
+      `https://example.com/admin/api/github/api/v3/repos/${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}/git/trees/main?recursive=1`,
+      { headers: authorizationHeaders() },
+    ),
+  })
+  const result = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(
+    result.tree.filter(({ type }) => type === 'blob').map(({ path }) => path),
+    [contentPath],
+  )
+})
+
+test('REST writeを認証前に拒否する', async () => {
+  let called = false
+  globalThis.fetch = async () => {
+    called = true
+    throw new Error('GitHub must not be called')
+  }
+
+  const response = await handleGithubRest({
+    request: new Request('https://example.com/admin/api/github/user', {
+      method: 'POST',
+      headers: authorizationHeaders(),
+    }),
+  })
+
+  assert.equal(response.status, 405)
+  assert.equal(called, false)
+})
+
+function mockGitHub(handler, push = true) {
+  globalThis.fetch = async (input, init = {}) => {
+    const url = String(input)
+    const body = typeof init.body === 'string' ? JSON.parse(init.body) : null
+
+    if (url === 'https://api.github.com/user') {
+      assert.equal(
+        new Headers(init.headers).get('Authorization'),
+        `Bearer ${oauthToken}`,
+      )
+      return jsonResponse(editor)
+    }
+
+    if (url === repositoryApi) {
+      return jsonResponse({ permissions: { push } })
+    }
+
+    return handler(url, init, body)
+  }
+}
+
+function graphqlRequest({
+  authorization = `Bearer ${oauthToken}`,
+  variables = {
+    input: {
+      branch: {
+        repositoryNameWithOwner: `${CMS_REPOSITORY.owner}/${CMS_REPOSITORY.name}`,
+        branchName: 'main',
+      },
+      expectedHeadOid: mainSha,
+      fileChanges: {
+        additions: [
+          {
+            path: contentPath,
+            contents: Buffer.from('content').toString('base64'),
+          },
+        ],
+        deletions: [],
+      },
+      message: { headline: 'cms: update example' },
+    },
+  },
+} = {}) {
+  const headers = new Headers({ 'Content-Type': 'application/json' })
+
+  if (authorization) headers.set('Authorization', authorization)
+
+  return new Request('https://example.com/admin/api/graphql', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      query: `
+        mutation($input: CreateCommitOnBranchInput!) {
+          createCommitOnBranch(input: $input) {
+            commit { oid committedDate }
+          }
+        }
+      `,
+      variables,
+    }),
+  })
+}
+
+function authorizationHeaders() {
+  return { Authorization: `Bearer ${oauthToken}` }
+}
+
+function graphqlReadRequest(query, variables) {
+  return new Request('https://example.com/admin/api/graphql', {
+    method: 'POST',
+    headers: {
+      ...authorizationHeaders(),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  })
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/tsconfig.functions.json
+++ b/tsconfig.functions.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "lib": ["ES2023"],
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "exclude": [],
+  "include": ["functions/**/*.ts"]
+}


### PR DESCRIPTION
関連 Issue: なし

## 概要

- Sveltia CMS 0.166.0 で未実装の editorial workflow 設定依存を廃止
- GitHub OAuth は維持し、同一 origin proxy が repository 権限・main HEAD・content/media path を検証
- 保存を `cms/acecore/*` の短命 branch、1 commit、main 向け PR へ変換
- CMS 運用資料と多言語 CMS 解説記事を実装仕様に合わせて訂正
- CI に CMS proxy test と Pages Functions typecheck を追加

## 確認

- `npm run format:check`
- `npm run validate:content`
- `npm run test:cms`（11件成功）
- `npm run typecheck:functions`
- `npm run build`（651ページ、Pagefind成功）
- `npm run validate:seo`
- `npm run validate:tag-redirects`
- `npm run validate:legacy-redirects`
- `git diff --check origin/main...HEAD`
- Sveltia CMS v0.166.0公式sourceのREST / GraphQL呼び出し形と照合

## 補足

- CMS変更可能範囲は日本語source contentと許可済みmediaだけです。翻訳、workflow、source codeへの保存はproxyが拒否します。
- 実アカウントでの保存往復は本番反映後の手動受入確認として残します。