### PR TITLE
READMEの開発環境をAstro 7・Node 24へ同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Acecore（エースコア）公式Webサイト。
 
 | 技術                                                                                            | 用途                                      |
 | ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| [Astro](https://astro.build/) v6                                                                | 静的サイトジェネレーター                  |
+| [Astro](https://astro.build/) v7                                                                | 静的サイトジェネレーター                  |
 | [UnoCSS](https://unocss.dev/)                                                                   | ユーティリティファースト CSS              |
 | [Cloudflare Pages](https://pages.cloudflare.com/)                                               | ホスティング・CDN                         |
 | [Cloudflare Images Transformations](https://developers.cloudflare.com/images/transform-images/) | 外部画像の自動最適化（`/cdn-cgi/image/`） |
@@ -31,6 +31,8 @@ Acecore（エースコア）公式Webサイト。
 - UI・固定ページ文字列は日本語ソースを `src/i18n/source/ja/`、翻訳先を `src/i18n/translations/` で管理し、Sveltia CMS の「ページ・サイト文言」からページ/用途別に編集
 
 ## 開発
+
+Node.js 24.18.0 以上が必要です。使用バージョンは `.node-version`、必要条件は `package.json` の `engines.node` を正とします。
 
 ```bash
 npm install


### PR DESCRIPTION
関連 Issue: なし

## 概要

- PR #165 で依存関係が Astro 7.1.3、Node.js 24.18.0 へ更新された後も残っていた README の Astro v6 表記を v7 に修正
- 開発に必要な Node.js 24.18.0 以上と、`.node-version`／`package.json` の `engines.node` を正とする方針を追記

## 確認

- `npx --no-install prettier --config .prettierrc --ignore-path C:\Users\gnish\.codex\worktrees\readme-environment\acecore-net\.prettierignore --check C:\Users\gnish\.codex\worktrees\readme-environment\acecore-net\README.md`: 成功
- `git diff --cached --check`: 成功
- `git diff --check origin/main...HEAD`: 成功
- `npm run build`: 未実施（README のみの変更のため）

## 補足

履歴記事内の Astro 6 表記は執筆時点の記録であり、今回の対象外です。