### PR TITLE
Vectorize反映遅延を待って収束確認

### DIFF
--- a/scripts/sync-vectorize.mjs
+++ b/scripts/sync-vectorize.mjs
@@ -19,6 +19,8 @@ const DELETE_BATCH_SIZE = 100
 const LIST_BATCH_SIZE = 1000
 const MUTATION_WAIT_TIMEOUT_MS = 180_000
 const MUTATION_POLL_INTERVAL_MS = 5_000
+const RECONCILIATION_MAX_ATTEMPTS = 13
+const RECONCILIATION_POLL_INTERVAL_MS = 5_000
 const REQUEST_TIMEOUT_MS = 30_000
 const MAX_API_RESPONSE_BYTES = 8 * 1024 * 1024
 const MAX_REQUEST_RETRIES = 5
@@ -234,13 +236,12 @@ export async function syncVectorize({
     await waitForMutation(client, indexName, lastMutationId)
   }
   if (waitForMutations && verifyAfterMutation) {
-    const reconciledIds = await listVectorIds(client, indexName, {
+    await waitForReconciliation(client, indexName, expectedIds, {
       logger,
       sleepImpl,
       retryBaseDelayMs,
+      maxAttempts: lastMutationId ? RECONCILIATION_MAX_ATTEMPTS : 1,
     })
-    validateExistingVectorIds(reconciledIds, indexName)
-    validateReconciliation(reconciledIds, expectedIds, indexName)
     verified = true
   }
 
@@ -450,6 +451,38 @@ function validateReconciliation(actualIds, expectedIds, indexName) {
   throw new Error(
     `Vectorize index ${indexName} did not converge: ${missingIds.length} missing and ${unexpectedIds.length} unexpected vector(s).`,
   )
+}
+
+async function waitForReconciliation(
+  client,
+  indexName,
+  expectedIds,
+  { logger, sleepImpl, retryBaseDelayMs, maxAttempts },
+) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const reconciledIds = await listVectorIds(client, indexName, {
+      logger,
+      sleepImpl,
+      retryBaseDelayMs,
+    })
+    validateExistingVectorIds(reconciledIds, indexName)
+
+    try {
+      validateReconciliation(reconciledIds, expectedIds, indexName)
+      return
+    } catch (error) {
+      if (attempt >= maxAttempts) throw error
+
+      logger.log(
+        JSON.stringify({
+          event: 'vectorize_reconciliation_retry',
+          indexName,
+          attempt,
+        }),
+      )
+      await sleepImpl(RECONCILIATION_POLL_INTERVAL_MS)
+    }
+  }
 }
 
 export function extractEmbeddingData(payload, expectedCount) {

--- a/tests/vectorize-sync.test.mjs
+++ b/tests/vectorize-sync.test.mjs
@@ -594,11 +594,63 @@ test('mutation完了後のID集合がcorpusへ収束しなければ失敗する'
       indexName: PREVIEW_INDEX,
       corpusFile,
       fetchImpl,
+      sleepImpl: async () => {},
       logger: silentLogger,
     }),
     /did not converge: 1 missing/,
   )
   assert.equal(remoteIds.has(missingChunk.id), false)
+})
+
+test('mutation完了直後にlistが古くてもbounded retryで収束を確認する', async () => {
+  const corpus = createCorpus()
+  const corpusFile = await writeCorpus(corpus)
+  const missingChunk = corpus.chunks.at(-1)
+  const remoteIds = new Set(corpus.chunks.slice(0, -1).map(({ id }) => id))
+  const sleepDelays = []
+  let listRequests = 0
+
+  const fetchImpl = async (input) => {
+    const url = String(input)
+    if (url.endsWith(`/vectorize/v2/indexes/${PREVIEW_INDEX}`)) {
+      return indexResponse()
+    }
+    if (url.includes('/list?')) {
+      listRequests += 1
+      if (listRequests >= 3) remoteIds.add(missingChunk.id)
+      return cloudflareResponse({
+        vectors: [...remoteIds].map((id) => ({ id })),
+        isTruncated: false,
+      })
+    }
+    if (url.endsWith('/v1/embeddings')) {
+      return openAiEmbeddingResponse([embedding])
+    }
+    if (url.endsWith('/upsert')) {
+      return cloudflareResponse({ mutationId: 'mutation-upsert' })
+    }
+    if (url.endsWith('/info')) {
+      return cloudflareResponse({
+        processedUpToMutation: 'mutation-upsert',
+      })
+    }
+    throw new Error(`Unexpected request: ${url}`)
+  }
+
+  const result = await syncVectorize({
+    accountId: 'account',
+    apiToken: 'token',
+    openAiApiKey: 'openai-key',
+    indexName: PREVIEW_INDEX,
+    corpusFile,
+    fetchImpl,
+    sleepImpl: async (delay) => sleepDelays.push(delay),
+    logger: silentLogger,
+  })
+
+  assert.equal(result.verified, true)
+  assert.equal(listRequests, 3)
+  assert.deepEqual(sleepDelays, [5000])
 })
 
 test('network・429・5xxをRetry-Afterと指数backoff付きで再試行する', async () => {


### PR DESCRIPTION
## 概要

- Vectorize mutation完了直後に`list` APIが古いID集合を返す場合、最大60秒のbounded retryで収束を再確認
- retryはこの実行でmutationが発生した場合だけ。no-op同期で不一致が出た場合は従来どおり即時fail closed
- retry中は追加mutationを行わず、全ID集合・管理対象IDの検証を毎回維持

## 背景

本番初回同期 run 30601162778 は164 vectorsのupsert自体には成功しましたが、直後の`list`が0件を返し`164 missing`で誤失敗しました。その後Cloudflare `/info` と手動再同期 run 30601623256 で164件への収束を確認しています。

## 検証

- `npm run format:check`
- `npm run test:search`（35件成功）
- 反映遅延後に収束する回帰テストを追加
- 恒久的に不一致なら上限到達後に失敗する既存テストを維持