### PR TITLE
fix: お問い合わせフォームのTurnstile期限切れを回復

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:blog-freshness": "node --test --test-isolation=none tests/blog-freshness.test.mjs",
     "test:cms": "node --import ./tests/register-json-module-hooks.mjs tests/cms-proxy.test.mjs && node --import ./tests/register-json-module-hooks.mjs tests/cms-blog-freshness-validator.test.mjs && node tests/render-safety.test.mjs && node tests/translation-trigger.test.mjs",
     "test:ai-chat": "node --experimental-strip-types --test tests/ai-contact.test.mjs",
-    "test:contact": "node --experimental-strip-types --test tests/contact-api.test.mjs tests/specialist-url.test.mjs",
+    "test:contact": "node --experimental-strip-types --test tests/contact-api.test.mjs tests/contact-page-turnstile.test.mjs tests/specialist-url.test.mjs",
     "test:site-config": "node --experimental-strip-types --test --test-isolation=none tests/monetized-blog-path.test.mjs && node --experimental-strip-types --test --test-isolation=none tests/search-modal-spa-style.test.mjs && node --test --test-isolation=none tests/pagefind-headers.test.mjs",
     "test:search": "node --experimental-strip-types --test tests/deployment-marker.test.mjs tests/search-api.test.mjs tests/network-search-api.test.mjs tests/search-corpus.test.mjs tests/vectorize-sync.test.mjs tests/vectorize-workflow.test.mjs",
     "sync:vectorize": "node scripts/sync-vectorize.mjs",

--- a/src/views/ContactPage.astro
+++ b/src/views/ContactPage.astro
@@ -331,6 +331,9 @@ const contactPageLd = {
           sitekey,
           language,
           theme,
+          'expired-callback': function () {
+            window.turnstile.reset(widgetId)
+          },
         })
         turnstileEl.dataset.widgetId = String(widgetId)
       }
@@ -534,8 +537,8 @@ const contactPageLd = {
         function resetTurnstile() {
           const turnstileEl = document.getElementById('turnstile-widget')
           const widgetId = turnstileEl?.dataset.widgetId
-          if (typeof turnstile !== 'undefined' && widgetId) {
-            turnstile.reset(widgetId)
+          if (typeof window.turnstile !== 'undefined' && widgetId) {
+            window.turnstile.reset(widgetId)
           }
         }
 
@@ -568,7 +571,14 @@ const contactPageLd = {
           })
             .then(async function (res) {
               if (!res.ok) {
-                throw new Error('Failed')
+                const payload = await res.json().catch(function () {
+                  return null
+                })
+                const message =
+                  typeof payload?.message === 'string' && payload.message.trim()
+                    ? payload.message.trim()
+                    : errorText
+                throw new Error(message)
               }
               if (window.aceTrackEvent) {
                 window.aceTrackEvent('generate_lead', {
@@ -588,8 +598,12 @@ const contactPageLd = {
                 resetTurnstile()
               }
             })
-            .catch(function () {
-              showFeedback('error', errorText)
+            .catch(function (error) {
+              const message =
+                error instanceof Error && error.message
+                  ? error.message
+                  : errorText
+              showFeedback('error', message)
               resetTurnstile()
             })
             .finally(function () {

--- a/tests/contact-page-turnstile.test.mjs
+++ b/tests/contact-page-turnstile.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const contactPageUrl = new URL(
+  '../src/views/ContactPage.astro',
+  import.meta.url,
+)
+
+test('期限切れの Turnstile トークンを自動的に再取得する', async () => {
+  const page = await readFile(contactPageUrl, 'utf8')
+
+  assert.match(
+    page,
+    /'expired-callback': function \(\) \{\s*window\.turnstile\.reset\(widgetId\)/,
+  )
+  assert.match(page, /typeof window\.turnstile !== 'undefined' && widgetId/)
+})
+
+test('API の安全なエラーメッセージをフォームへ表示する', async () => {
+  const page = await readFile(contactPageUrl, 'utf8')
+
+  assert.match(page, /const payload = await res\.json\(\)\.catch/)
+  assert.match(page, /showFeedback\('error', message\)/)
+})


### PR DESCRIPTION
関連 Issue: Closes #8

## 概要

- Turnstile トークンが期限切れになった際、ウィジェットを自動リセットして新しいトークンを取得するようにしました。
- API が返す安全なエラーメッセージをフォームに表示し、再送時には Turnstile を再取得します。
- フォーム側の回帰テストを追加しました。

## 確認

- `volta run --node 24.18.0 npm run test:contact`
- `node_modules\\.bin\\prettier.cmd --check src\\views\\ContactPage.astro package.json tests\\contact-page-turnstile.test.mjs`
- `volta run --node 24.18.0 npm run build`
- 本番フォームを新しい Turnstile トークンで送信し、`/contact/thanks/` への遷移を確認しました。

## 補足

初回失敗時のレスポンスログは Cloudflare API の 525 により取得できませんでした。Turnstile トークンは 5 分で期限切れになり、単回使用のため、送信前の待機で失効した可能性が最も高いと判断しています。