### PR TITLE
法人名を共通表記へ反映

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -134,7 +134,7 @@ const businessLinks = [
     </div>
 
     <div class="mt-10 border-t border-slate-700 pt-8 text-center text-sm">
-      <p>&copy;{currentYear} Acecore</p>
+      <p>&copy;{currentYear} {SITE.legalName}</p>
     </div>
   </div>
 </footer>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -7,6 +7,8 @@
 export const SITE = {
   /** サイト名 */
   name: 'Acecore',
+  /** 法人名 */
+  legalName: '株式会社Acecore',
   /** サイトの公開 URL（Cloudflare Pages） */
   url: 'https://acecore.net',
   /** 電話番号（国内表記） */

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -348,6 +348,7 @@ import { SITE } from '../data/site'
         '@type': 'Organization',
         '@id': organizationId,
         name: 'Acecore',
+        legalName: SITE.legalName,
         url: SITE.url,
         description: t(locale, 'meta.defaultDescription'),
         logo: 'https://acecore.net/favicon.svg',

--- a/src/views/AboutPage.astro
+++ b/src/views/AboutPage.astro
@@ -68,6 +68,7 @@ const organizationLd = {
   '@type': 'Organization',
   '@id': organizationId,
   name: 'Acecore',
+  legalName: SITE.legalName,
   url: SITE.url,
   logo: 'https://acecore.net/favicon.svg',
   description: t(locale, 'meta.defaultDescription'),


### PR DESCRIPTION
関連 Issue: なし

## 概要

- 共通サイト設定に法人名 `株式会社Acecore` を追加しました。
- 全ページの Organization 構造化データと会社概要の構造化データに `legalName` を設定しました。
- 共通 footer の著作権表記を法人名へ更新しました。

## 確認

- `volta run --node 24.18.0 -- npm exec --no -- prettier --check src/data/site.ts src/components/Footer.astro src/layouts/BaseLayout.astro src/views/AboutPage.astro`
- `volta run --node 24.18.0 -- npm run validate:content`
- `git diff --check`
- `volta run --node 24.18.0 -- npm ci --ignore-scripts`
- `volta run --node 24.18.0 -- npm run build`（既存の Windows/Vite 環境で `source-map-js` の CJS 読み込み時に停止。クリーン依存でも再現）

## 補足

直近の main 向け PR #195 でも同じローカルビルド制約と、GitHub CI・Cloudflare Pages Preview の成功が記録されています。本PRも CI と Preview の成功をマージ条件とします。