### PR TITLE
Vectorize正規名indexへの同期を準備する

### DIFF
--- a/.github/workflows/sync-vectorize.yml
+++ b/.github/workflows/sync-vectorize.yml
@@ -7,6 +7,15 @@ on:
   schedule:
     - cron: '*/15 * * * *'
   workflow_dispatch:
+    inputs:
+      index_name:
+        description: 正規名indexへの移行時だけ選択する同期先
+        required: false
+        type: choice
+        default: acecore-net-search-openai-1536-production-v2
+        options:
+          - acecore-net-search-openai-1536-production-v2
+          - acecore-net-search-openai-1536-production
 
 permissions:
   contents: read
@@ -131,7 +140,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: db9b62f409f463da7acbcc374b8385d0
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          VECTORIZE_INDEX_NAME: acecore-net-search-openai-1536-production-v2
+          VECTORIZE_INDEX_NAME: ${{ inputs.index_name || 'acecore-net-search-openai-1536-production-v2' }}
         run: |
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
             echo "::error::CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN is not configured."

--- a/scripts/sync-vectorize.mjs
+++ b/scripts/sync-vectorize.mjs
@@ -42,8 +42,14 @@ const MIN_LOCALE_VECTOR_COUNTS = Object.freeze({
   ru: 18,
 })
 const MANAGED_VECTOR_ID_PATTERN = /^v1-[0-9a-f]{48}$/
-const PRODUCTION_INDEX_NAME = 'acecore-net-search-openai-1536-production-v2'
-const ALLOWED_INDEX_NAMES = new Set([PRODUCTION_INDEX_NAME])
+const CURRENT_PRODUCTION_INDEX_NAME =
+  'acecore-net-search-openai-1536-production-v2'
+const CANONICAL_PRODUCTION_INDEX_NAME =
+  'acecore-net-search-openai-1536-production'
+const ALLOWED_INDEX_NAMES = new Set([
+  CURRENT_PRODUCTION_INDEX_NAME,
+  CANONICAL_PRODUCTION_INDEX_NAME,
+])
 const SUPPORTED_LOCALES = [
   'ja',
   'en',
@@ -1053,10 +1059,10 @@ export function parseArguments(argv, environment = process.env) {
   if (
     !options.dryRun &&
     !options.planOnly &&
-    options.confirmProduction !== PRODUCTION_INDEX_NAME
+    options.confirmProduction !== options.indexName
   ) {
     throw new Error(
-      `Production sync requires --confirm-production ${PRODUCTION_INDEX_NAME}.`,
+      `Production sync requires --confirm-production ${options.indexName}.`,
     )
   }
   delete options.confirmProduction

--- a/tests/vectorize-sync.test.mjs
+++ b/tests/vectorize-sync.test.mjs
@@ -11,7 +11,9 @@ import {
   validateCorpus,
 } from '../scripts/sync-vectorize.mjs'
 
-const PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production-v2'
+const CURRENT_PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production-v2'
+const CANONICAL_PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production'
+const PRODUCTION_INDEX = CURRENT_PRODUCTION_INDEX
 const LOCALES = ['ja', 'en', 'zh-cn', 'es', 'pt', 'fr', 'ko', 'de', 'ru']
 const temporaryRoots = []
 const embedding = Array.from({ length: 1536 }, () => 0.01)
@@ -49,17 +51,29 @@ test('embeddingのindex・件数・1536次元を検証する', () => {
 })
 
 test('live Production同期は正確なindex名の明示確認を要求する', () => {
-  const environment = { VECTORIZE_INDEX_NAME: PRODUCTION_INDEX }
+  for (const indexName of [
+    CURRENT_PRODUCTION_INDEX,
+    CANONICAL_PRODUCTION_INDEX,
+  ]) {
+    const environment = { VECTORIZE_INDEX_NAME: indexName }
 
-  assert.throws(
-    () => parseArguments([], environment),
-    /--confirm-production acecore-net-search-openai-1536-production-v2/u,
-  )
-  assert.doesNotThrow(() =>
-    parseArguments(['--confirm-production', PRODUCTION_INDEX], environment),
-  )
-  assert.doesNotThrow(() => parseArguments(['--dry-run'], environment))
-  assert.doesNotThrow(() => parseArguments(['--plan'], environment))
+    assert.throws(
+      () => parseArguments([], environment),
+      new RegExp(`--confirm-production ${indexName}`, 'u'),
+    )
+    assert.doesNotThrow(() =>
+      parseArguments(['--confirm-production', indexName], environment),
+    )
+    assert.throws(
+      () =>
+        parseArguments(['--confirm-production', CURRENT_PRODUCTION_INDEX], {
+          VECTORIZE_INDEX_NAME: CANONICAL_PRODUCTION_INDEX,
+        }),
+      new RegExp(`--confirm-production ${CANONICAL_PRODUCTION_INDEX}`, 'u'),
+    )
+    assert.doesNotThrow(() => parseArguments(['--dry-run'], environment))
+    assert.doesNotThrow(() => parseArguments(['--plan'], environment))
+  }
 })
 
 test('corpusと既存indexの差分だけをupsert・deleteする', async () => {
@@ -313,7 +327,15 @@ test('同期先indexをproductionだけに制限する', async () => {
     syncVectorize({
       corpusFile,
       dryRun: true,
-      indexName: 'acecore-net-search-openai-1536-production-v2',
+      indexName: CURRENT_PRODUCTION_INDEX,
+      logger: silentLogger,
+    }),
+  )
+  await assert.doesNotReject(
+    syncVectorize({
+      corpusFile,
+      dryRun: true,
+      indexName: CANONICAL_PRODUCTION_INDEX,
       logger: silentLogger,
     }),
   )

--- a/tests/vectorize-workflow.test.mjs
+++ b/tests/vectorize-workflow.test.mjs
@@ -18,7 +18,20 @@ test('Production同期workflowから20%超削除を解除できない', async ()
     ({ name }) => name === 'Sync production Vectorize index',
   )
 
-  assert.equal(workflow.on.workflow_dispatch, null)
+  assert.deepEqual(workflow.on.workflow_dispatch, {
+    inputs: {
+      index_name: {
+        description: '正規名indexへの移行時だけ選択する同期先',
+        required: false,
+        type: 'choice',
+        default: 'acecore-net-search-openai-1536-production-v2',
+        options: [
+          'acecore-net-search-openai-1536-production-v2',
+          'acecore-net-search-openai-1536-production',
+        ],
+      },
+    },
+  })
   assert.equal(
     productionSteps.find(
       ({ name }) => name === 'Validate manual large-delete approval',
@@ -37,7 +50,7 @@ test('Production同期workflowから20%超削除を解除できない', async ()
   assert.match(syncStep.run, /--confirm-production "\$VECTORIZE_INDEX_NAME"/u)
   assert.equal(
     syncStep.env.VECTORIZE_INDEX_NAME,
-    'acecore-net-search-openai-1536-production-v2',
+    "${{ inputs.index_name || 'acecore-net-search-openai-1536-production-v2' }}",
   )
   assert.equal(syncStep.env.OPENAI_API_KEY, '${{ secrets.OPENAI_API_KEY }}')
   assert.match(syncStep.run, /OPENAI_API_KEY is not configured/)
@@ -48,7 +61,10 @@ test('Vectorize同期workflowはProduction専用でPreview credentialを参照�
   const workflow = yaml.load(source)
 
   assert.deepEqual(Object.keys(workflow.jobs), ['sync-production'])
-  assert.equal(workflow.on.workflow_dispatch, null)
+  assert.deepEqual(workflow.on.workflow_dispatch.inputs.index_name.options, [
+    'acecore-net-search-openai-1536-production-v2',
+    'acecore-net-search-openai-1536-production',
+  ])
   assert.match(
     workflow.jobs['sync-production'].if,
     /github\.event_name == 'workflow_dispatch'/,


### PR DESCRIPTION
関連 Issue: なし

## 概要

- 正規名 `acecore-net-search-openai-1536-production` への移行前に、Production専用の手動同期先としてだけ選択可能にします。
- 通常のpush・schedule同期とPagesの `SEARCH_INDEX` bindingは引き続きv2のままとし、空indexへ切り替えません。
- 同期先はv2または正規名の完全一致に限定し、確認引数も選択したindex名との完全一致を要求します。

## 確認

- `volta run --node 24.18.0 npm run test:search`
- `volta run --node 24.18.0 npm run check:pages-config`
- `volta run --node 24.18.0 npm exec prettier -- --check scripts/sync-vectorize.mjs .github/workflows/sync-vectorize.yml tests/vectorize-sync.test.mjs tests/vectorize-workflow.test.mjs`
- `git diff --check`

## 補足

- 本PRでは本番bindingを変更しません。mainで正規名indexを全量同期・ID集合照合・query canaryした後、別PRでNet/Portalのbindingを切り替えます。