### PR TITLE
削除済みVectorize index名を再作成可能にする

### DIFF
--- a/scripts/sync-vectorize.mjs
+++ b/scripts/sync-vectorize.mjs
@@ -765,7 +765,11 @@ async function ensureIndex(client, indexName, { createIfMissing = true } = {}) {
     const payload = await client.request(`/vectorize/v2/indexes/${encodedName}`)
     return payload.result
   } catch (error) {
-    if (!(error instanceof CloudflareApiError) || error.status !== 404) {
+    // Cloudflare returns 410 for a deleted Vectorize name that can be reused.
+    if (
+      !(error instanceof CloudflareApiError) ||
+      (error.status !== 404 && error.status !== 410)
+    ) {
       throw error
     }
   }

--- a/tests/vectorize-sync.test.mjs
+++ b/tests/vectorize-sync.test.mjs
@@ -310,6 +310,54 @@ test('planは不存在indexを作成せずfail closedする', async () => {
   assert.equal(createRequests, 0)
 })
 
+test('削除済みの正規名indexは再作成して同期対象にできる', async () => {
+  const corpus = createCorpus()
+  const corpusFile = await writeCorpus(corpus)
+  let createRequests = 0
+
+  const fetchImpl = async (input, init = {}) => {
+    const url = String(input)
+    if (url.endsWith(`/vectorize/v2/indexes/${CANONICAL_PRODUCTION_INDEX}`)) {
+      return cloudflareResponse(null, 410)
+    }
+    if (
+      url.endsWith('/vectorize/v2/indexes') &&
+      (init.method || 'GET') === 'POST'
+    ) {
+      createRequests += 1
+      assert.deepEqual(JSON.parse(init.body), {
+        name: CANONICAL_PRODUCTION_INDEX,
+        description:
+          'Acecore site semantic search (OpenAI text-embedding-3-large, 1536 dimensions)',
+        config: { dimensions: 1536, metric: 'cosine' },
+      })
+      return indexResponse()
+    }
+    if (url.includes('/list?')) {
+      return cloudflareResponse({
+        vectors: corpus.chunks.map(({ id }) => ({ id })),
+        isTruncated: false,
+      })
+    }
+    throw new Error(`Unexpected request: ${url}`)
+  }
+
+  const result = await syncVectorize({
+    accountId: 'account',
+    apiToken: 'token',
+    indexName: CANONICAL_PRODUCTION_INDEX,
+    corpusFile,
+    fetchImpl,
+    logger: silentLogger,
+  })
+
+  assert.equal(createRequests, 1)
+  assert.equal(result.indexName, CANONICAL_PRODUCTION_INDEX)
+  assert.equal(result.upserted, 0)
+  assert.equal(result.deleted, 0)
+  assert.equal(result.verified, true)
+})
+
 test('同期先indexをproductionだけに制限する', async () => {
   const corpusFile = await writeCorpus(createCorpus())
 


### PR DESCRIPTION
関連 Issue: なし

## 概要

- Cloudflareが削除済みVectorize index名を返す `410 vectorize.index.deleted` を、再利用可能な名前として新規作成へ進めます。
- 404と410以外のCloudflare APIエラーは従来どおりfail closedで停止します。
- 正規名 `acecore-net-search-openai-1536-production` の再作成を回帰テストで固定します。

## 確認

- `volta run --node 24.18.0 npm run test:search`
- `volta run --node 24.18.0 npm run check:pages-config`
- `volta run --node 24.18.0 npm exec prettier -- --check scripts/sync-vectorize.mjs tests/vectorize-sync.test.mjs`
- `git diff --check`

## 補足

- 現行のv2 bindingは変更しません。PR #199の手動Production同期を安全に再実行するための最小修正です。