### PR TITLE
chore(search): 本番Vectorize index名を正規名へ統一

### DIFF
--- a/.github/workflows/sync-vectorize.yml
+++ b/.github/workflows/sync-vectorize.yml
@@ -7,15 +7,6 @@ on:
   schedule:
     - cron: '*/15 * * * *'
   workflow_dispatch:
-    inputs:
-      index_name:
-        description: 正規名indexへの移行時だけ選択する同期先
-        required: false
-        type: choice
-        default: acecore-net-search-openai-1536-production-v2
-        options:
-          - acecore-net-search-openai-1536-production-v2
-          - acecore-net-search-openai-1536-production
 
 permissions:
   contents: read
@@ -140,7 +131,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: db9b62f409f463da7acbcc374b8385d0
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          VECTORIZE_INDEX_NAME: ${{ inputs.index_name || 'acecore-net-search-openai-1536-production-v2' }}
+          VECTORIZE_INDEX_NAME: acecore-net-search-openai-1536-production
         run: |
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
             echo "::error::CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN is not configured."

--- a/docs/search-vectorize.md
+++ b/docs/search-vectorize.md
@@ -31,7 +31,7 @@ Acecore公式サイトの検索モーダルは、Acecoreが管理する同じVec
 
 | 質問の担当       | Production Pages binding        | Production index名                               | namespace  | 情報の責任範囲                                   |
 | ---------------- | ------------------------------- | ------------------------------------------------ | ---------- | ------------------------------------------------ |
-| Acecore          | `SEARCH_INDEX`                  | `acecore-net-search-openai-1536-production-v2`   | 表示locale | 会社情報、事業の案内、共通窓口                   |
+| Acecore          | `SEARCH_INDEX`                  | `acecore-net-search-openai-1536-production`      | 表示locale | 会社情報、事業の案内、共通窓口                   |
 | Systems          | `SYSTEMS_SEARCH_INDEX`          | `acecore-systems-search-openai-1536-production`  | `ja`       | 技術サービス                                     |
 | Schools          | `SCHOOLS_SEARCH_INDEX`          | `acecore-schools-search-openai-1536-production`  | `ja`       | 学習サービス                                     |
 | Aceserver WIKI   | `ACESERVER_WIKI_SEARCH_INDEX`   | `aceserver-wiki-search-openai-1536-production`   | `ja`       | ルール、コマンド、参加条件、運用情報             |
@@ -57,14 +57,14 @@ World Foundation owner repositoryでは、公開corpusの生成、Production同�
 
 ## Acecoreが管理するCloudflareリソース
 
-| 環境       | Vectorize index                                | namespace                                               |
-| ---------- | ---------------------------------------------- | ------------------------------------------------------- |
-| Preview    | 未接続                                         | 未適用                                                  |
-| Production | `acecore-net-search-openai-1536-production-v2` | `ja`, `en`, `zh-cn`, `es`, `pt`, `fr`, `ko`, `de`, `ru` |
+| 環境       | Vectorize index                             | namespace                                               |
+| ---------- | ------------------------------------------- | ------------------------------------------------------- |
+| Preview    | 未接続                                      | 未適用                                                  |
+| Production | `acecore-net-search-openai-1536-production` | `ja`, `en`, `zh-cn`, `es`, `pt`, `fr`, `ko`, `de`, `ru` |
 
-Production indexは `text-embedding-3-large` の短縮embeddingに合わせて `dimensions: 1536`、`metric: cosine` で作成します。横断検索先も同じmodelと次元を契約とします。旧BGE-M3用1024次元indexへ混在させず、新indexの全corpus同期と代表的な日本語queryの確認が終わってからbindingを切り替えます。2026-07-31にv2の本番検証を完了した後、旧 `acecore-net-search-openai-1536-production` は削除しました。現在、即時に戻せる旧indexはありません。
+Production indexは `text-embedding-3-large` の短縮embeddingに合わせて `dimensions: 1536`、`metric: cosine` で作成します。横断検索先も同じmodelと次元を契約とします。旧BGE-M3用1024次元indexへ混在させず、新indexの全corpus同期と代表的な日本語queryの確認が終わってからbindingを切り替えます。2026-08-01に正規名 `acecore-net-search-openai-1536-production` へ305 vectorsを全量同期し、ID集合一致とquery canaryを確認しました。Productionの通常同期とbindingはこの正規名だけを使います。
 
-2026-07-31の監査では、旧 `acecore-net-search-openai-1536-production` は164 vectors、公開corpusとの差分は42 upsert・35 delete（21.3%）でした。大量削除の安全gateに従い、旧indexに対する35件の直接deleteは実行せず、同じ1536次元・cosine設定の `acecore-net-search-openai-1536-production-v2` をreplacementとして作成しました。v2の全量同期、ID集合の完全一致、query canaryがProduction workflowで成功したことを確認して `wrangler.jsonc` の `SEARCH_INDEX` bindingをv2へ切り替え、本番検索の継続応答を確認した後、明示承認のもと旧indexを削除しました。以後の復旧は、別のreplacement indexを新規作成して公開corpusを全量同期する手順とします。top-level／Previewはbindingを持たず `SEARCH_ENABLED=false`、Productionだけを `true` とします。Preview用indexは運用せず、接続・利用しません。
+2026-07-31の監査では、旧 `acecore-net-search-openai-1536-production` は164 vectors、公開corpusとの差分は42 upsert・35 delete（21.3%）でした。大量削除の安全gateに従い、旧indexに対する35件の直接deleteは実行せず、同じ1536次元・cosine設定の `acecore-net-search-openai-1536-production-v2` をreplacementとして作成しました。v2の全量同期、ID集合の完全一致、query canaryがProduction workflowで成功したことを確認して一時的にbindingを切り替え、旧indexを削除しました。2026-08-01に正規名indexを再作成・全量同期して通常同期とbindingを戻したため、v2はcutover検証後に削除する一時rollback用です。以後の復旧は、別のreplacement indexを新規作成して公開corpusを全量同期する手順とします。top-level／Previewはbindingを持たず `SEARCH_ENABLED=false`、Productionだけを `true` とします。Preview用indexは運用せず、接続・利用しません。
 
 検索API、横断検索、AIチャットのrate limitは、Pagesで正式対応されているD1 bindingを使い、PreviewとProductionで本番D1を共有します。Previewは検索を無効のまま維持し、同じtable内では自サイト検索を `client:` / `global`、横断検索を `network-search:{caller}:client:` / `network-search:global`、AIチャットを `ai-chat:client:` / `ai-chat:global` prefixで分離します。
 
@@ -90,7 +90,7 @@ npm run typecheck:functions
 - 15分ごとのreconciler: 現在公開中のbuild markerを読み、40文字のGit SHAであり、`origin/main` のancestorであることを検証してproduction indexを再同期する。concurrencyで待機中のrunが置換された場合も、次回のreconcilerが公開状態へ収束させる。
 - 手動production: 現在公開中のmain由来corpusをproduction indexへ再同期する。
 
-このworkflowの同期先はreplacementの `acecore-net-search-openai-1536-production-v2` です。初回は空のv2へ公開corpusを全量upsertし、既存indexの大量削除は行いません。upsertが発生したrunは、mutation完了とID集合の完全一致に加え、今回upsertしたvectorをREST queryして結果にそのIDが含まれることを確認します。初回の全量同期とquery canaryを含む成功runを確認してから、別のレビュー済み変更でPages bindingをv2へ切り替えます。
+このworkflowの同期先は正規名の `acecore-net-search-openai-1536-production` です。2026-08-01に空の正規名indexへ公開corpusを305 vectors全量upsertし、ID集合の完全一致とquery canaryを確認しました。以後のupsertが発生したrunは、mutation完了とID集合の完全一致に加え、今回upsertしたvectorをREST queryして結果にそのIDが含まれることを確認します。
 
 push、schedule、手動実行のいずれも `refs/heads/main` 以外ではjobを実行しません。workflow用のcheckoutは常にprotected `main` を `tooling/` へ固定し、同期scriptもこのcheckoutから実行します。公開対象のsite commitは別の `site/` へcheckoutしてbuildするため、build markerが指す過去のmain commitを復旧同期する場合も、secretを扱う同期ロジックはprotected `main` のものです。
 
@@ -99,9 +99,9 @@ Productionのlive同期は、index名と同じ値を`--confirm-production`へ明
 
 GitHub Actionsには次のGitHub Environmentとenvironment secretが必要です。
 
-| GitHub Environment             | environment secrets                                        | Cloudflare account token                | 同期先                                         |
-| ------------------------------ | ---------------------------------------------------------- | --------------------------------------- | ---------------------------------------------- |
-| `cloudflare-search-production` | `CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN`, `OPENAI_API_KEY` | `acecore-net-vectorize-production-sync` | `acecore-net-search-openai-1536-production-v2` |
+| GitHub Environment             | environment secrets                                        | Cloudflare account token                | 同期先                                      |
+| ------------------------------ | ---------------------------------------------------------- | --------------------------------------- | ------------------------------------------- |
+| `cloudflare-search-production` | `CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN`, `OPENAI_API_KEY` | `acecore-net-vectorize-production-sync` | `acecore-net-search-openai-1536-production` |
 
 EnvironmentのDeployment branches and tagsは `Selected branches and tags` を選び、branch ruleには `main` だけを登録します。workflow側にもmain判定がありますが、Environment側のmain-only protectionをsecret払い出しの独立した必須条件として設定してください。任意refから起動されたworkflowは、そのref上のworkflow定義自体が変更されている可能性があるため、このEnvironment設定なしでは運用を開始しません。
 
@@ -124,7 +124,7 @@ npm run sync:vectorize:dry-run
 credentialを使って現行indexとの差分だけを確認し、mutationしない場合:
 
 ```powershell
-$env:VECTORIZE_INDEX_NAME = 'acecore-net-search-openai-1536-production-v2'
+$env:VECTORIZE_INDEX_NAME = 'acecore-net-search-openai-1536-production'
 $env:CLOUDFLARE_ACCOUNT_ID = '<account-id>'
 $env:CLOUDFLARE_API_TOKEN = '<scoped-token>'
 node scripts/sync-vectorize.mjs --plan
@@ -135,7 +135,7 @@ node scripts/sync-vectorize.mjs --plan
 Productionへ同期する場合:
 
 ```powershell
-$env:VECTORIZE_INDEX_NAME = 'acecore-net-search-openai-1536-production-v2'
+$env:VECTORIZE_INDEX_NAME = 'acecore-net-search-openai-1536-production'
 $env:CLOUDFLARE_ACCOUNT_ID = '<account-id>'
 $env:CLOUDFLARE_API_TOKEN = '<scoped-token>'
 $env:OPENAI_API_KEY = '<project-api-key>'

--- a/scripts/sync-vectorize.mjs
+++ b/scripts/sync-vectorize.mjs
@@ -42,14 +42,8 @@ const MIN_LOCALE_VECTOR_COUNTS = Object.freeze({
   ru: 18,
 })
 const MANAGED_VECTOR_ID_PATTERN = /^v1-[0-9a-f]{48}$/
-const CURRENT_PRODUCTION_INDEX_NAME =
-  'acecore-net-search-openai-1536-production-v2'
-const CANONICAL_PRODUCTION_INDEX_NAME =
-  'acecore-net-search-openai-1536-production'
-const ALLOWED_INDEX_NAMES = new Set([
-  CURRENT_PRODUCTION_INDEX_NAME,
-  CANONICAL_PRODUCTION_INDEX_NAME,
-])
+const PRODUCTION_INDEX_NAME = 'acecore-net-search-openai-1536-production'
+const ALLOWED_INDEX_NAMES = new Set([PRODUCTION_INDEX_NAME])
 const SUPPORTED_LOCALES = [
   'ja',
   'en',
@@ -1063,10 +1057,10 @@ export function parseArguments(argv, environment = process.env) {
   if (
     !options.dryRun &&
     !options.planOnly &&
-    options.confirmProduction !== options.indexName
+    options.confirmProduction !== PRODUCTION_INDEX_NAME
   ) {
     throw new Error(
-      `Production sync requires --confirm-production ${options.indexName}.`,
+      `Production sync requires --confirm-production ${PRODUCTION_INDEX_NAME}.`,
     )
   }
   delete options.confirmProduction

--- a/tests/ai-contact.test.mjs
+++ b/tests/ai-contact.test.mjs
@@ -1736,7 +1736,7 @@ test('Previewを停止しProductionの確認済み検索だけを有効化する
     'utf8',
   )
   const productionIndexes = [
-    'acecore-net-search-openai-1536-production-v2',
+    'acecore-net-search-openai-1536-production',
     'acecore-systems-search-openai-1536-production',
     'acecore-schools-search-openai-1536-production',
     'aceserver-wiki-search-openai-1536-production',

--- a/tests/vectorize-sync.test.mjs
+++ b/tests/vectorize-sync.test.mjs
@@ -11,9 +11,8 @@ import {
   validateCorpus,
 } from '../scripts/sync-vectorize.mjs'
 
-const CURRENT_PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production-v2'
-const CANONICAL_PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production'
-const PRODUCTION_INDEX = CURRENT_PRODUCTION_INDEX
+const PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production'
+const RETIRED_PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production-v2'
 const LOCALES = ['ja', 'en', 'zh-cn', 'es', 'pt', 'fr', 'ko', 'de', 'ru']
 const temporaryRoots = []
 const embedding = Array.from({ length: 1536 }, () => 0.01)
@@ -51,29 +50,24 @@ test('embeddingのindex・件数・1536次元を検証する', () => {
 })
 
 test('live Production同期は正確なindex名の明示確認を要求する', () => {
-  for (const indexName of [
-    CURRENT_PRODUCTION_INDEX,
-    CANONICAL_PRODUCTION_INDEX,
-  ]) {
-    const environment = { VECTORIZE_INDEX_NAME: indexName }
+  const environment = { VECTORIZE_INDEX_NAME: PRODUCTION_INDEX }
 
-    assert.throws(
-      () => parseArguments([], environment),
-      new RegExp(`--confirm-production ${indexName}`, 'u'),
-    )
-    assert.doesNotThrow(() =>
-      parseArguments(['--confirm-production', indexName], environment),
-    )
-    assert.throws(
-      () =>
-        parseArguments(['--confirm-production', CURRENT_PRODUCTION_INDEX], {
-          VECTORIZE_INDEX_NAME: CANONICAL_PRODUCTION_INDEX,
-        }),
-      new RegExp(`--confirm-production ${CANONICAL_PRODUCTION_INDEX}`, 'u'),
-    )
-    assert.doesNotThrow(() => parseArguments(['--dry-run'], environment))
-    assert.doesNotThrow(() => parseArguments(['--plan'], environment))
-  }
+  assert.throws(
+    () => parseArguments([], environment),
+    /--confirm-production acecore-net-search-openai-1536-production/u,
+  )
+  assert.doesNotThrow(() =>
+    parseArguments(['--confirm-production', PRODUCTION_INDEX], environment),
+  )
+  assert.throws(
+    () =>
+      parseArguments(['--confirm-production', RETIRED_PRODUCTION_INDEX], {
+        VECTORIZE_INDEX_NAME: RETIRED_PRODUCTION_INDEX,
+      }),
+    /--confirm-production acecore-net-search-openai-1536-production/u,
+  )
+  assert.doesNotThrow(() => parseArguments(['--dry-run'], environment))
+  assert.doesNotThrow(() => parseArguments(['--plan'], environment))
 })
 
 test('corpusと既存indexの差分だけをupsert・deleteする', async () => {
@@ -317,7 +311,7 @@ test('削除済みの正規名indexは再作成して同期対象にできる', 
 
   const fetchImpl = async (input, init = {}) => {
     const url = String(input)
-    if (url.endsWith(`/vectorize/v2/indexes/${CANONICAL_PRODUCTION_INDEX}`)) {
+    if (url.endsWith(`/vectorize/v2/indexes/${PRODUCTION_INDEX}`)) {
       return cloudflareResponse(null, 410)
     }
     if (
@@ -326,7 +320,7 @@ test('削除済みの正規名indexは再作成して同期対象にできる', 
     ) {
       createRequests += 1
       assert.deepEqual(JSON.parse(init.body), {
-        name: CANONICAL_PRODUCTION_INDEX,
+        name: PRODUCTION_INDEX,
         description:
           'Acecore site semantic search (OpenAI text-embedding-3-large, 1536 dimensions)',
         config: { dimensions: 1536, metric: 'cosine' },
@@ -345,14 +339,14 @@ test('削除済みの正規名indexは再作成して同期対象にできる', 
   const result = await syncVectorize({
     accountId: 'account',
     apiToken: 'token',
-    indexName: CANONICAL_PRODUCTION_INDEX,
+    indexName: PRODUCTION_INDEX,
     corpusFile,
     fetchImpl,
     logger: silentLogger,
   })
 
   assert.equal(createRequests, 1)
-  assert.equal(result.indexName, CANONICAL_PRODUCTION_INDEX)
+  assert.equal(result.indexName, PRODUCTION_INDEX)
   assert.equal(result.upserted, 0)
   assert.equal(result.deleted, 0)
   assert.equal(result.verified, true)
@@ -375,17 +369,18 @@ test('同期先indexをproductionだけに制限する', async () => {
     syncVectorize({
       corpusFile,
       dryRun: true,
-      indexName: CURRENT_PRODUCTION_INDEX,
+      indexName: PRODUCTION_INDEX,
       logger: silentLogger,
     }),
   )
-  await assert.doesNotReject(
+  await assert.rejects(
     syncVectorize({
       corpusFile,
       dryRun: true,
-      indexName: CANONICAL_PRODUCTION_INDEX,
+      indexName: RETIRED_PRODUCTION_INDEX,
       logger: silentLogger,
     }),
+    /must be one of: acecore-net-search-openai-1536-production/u,
   )
 })
 

--- a/tests/vectorize-workflow.test.mjs
+++ b/tests/vectorize-workflow.test.mjs
@@ -18,20 +18,7 @@ test('Production同期workflowから20%超削除を解除できない', async ()
     ({ name }) => name === 'Sync production Vectorize index',
   )
 
-  assert.deepEqual(workflow.on.workflow_dispatch, {
-    inputs: {
-      index_name: {
-        description: '正規名indexへの移行時だけ選択する同期先',
-        required: false,
-        type: 'choice',
-        default: 'acecore-net-search-openai-1536-production-v2',
-        options: [
-          'acecore-net-search-openai-1536-production-v2',
-          'acecore-net-search-openai-1536-production',
-        ],
-      },
-    },
-  })
+  assert.equal(workflow.on.workflow_dispatch, null)
   assert.equal(
     productionSteps.find(
       ({ name }) => name === 'Validate manual large-delete approval',
@@ -50,7 +37,7 @@ test('Production同期workflowから20%超削除を解除できない', async ()
   assert.match(syncStep.run, /--confirm-production "\$VECTORIZE_INDEX_NAME"/u)
   assert.equal(
     syncStep.env.VECTORIZE_INDEX_NAME,
-    "${{ inputs.index_name || 'acecore-net-search-openai-1536-production-v2' }}",
+    'acecore-net-search-openai-1536-production',
   )
   assert.equal(syncStep.env.OPENAI_API_KEY, '${{ secrets.OPENAI_API_KEY }}')
   assert.match(syncStep.run, /OPENAI_API_KEY is not configured/)
@@ -61,10 +48,7 @@ test('Vectorize同期workflowはProduction専用でPreview credentialを参照�
   const workflow = yaml.load(source)
 
   assert.deepEqual(Object.keys(workflow.jobs), ['sync-production'])
-  assert.deepEqual(workflow.on.workflow_dispatch.inputs.index_name.options, [
-    'acecore-net-search-openai-1536-production-v2',
-    'acecore-net-search-openai-1536-production',
-  ])
+  assert.equal(workflow.on.workflow_dispatch, null)
   assert.match(
     workflow.jobs['sync-production'].if,
     /github\.event_name == 'workflow_dispatch'/,
@@ -75,15 +59,15 @@ test('Vectorize同期workflowはProduction専用でPreview credentialを参照�
   assert.doesNotMatch(source, /acecore-net-search-openai-1536-preview/u)
 })
 
-test('確認済みreplacement indexをProduction bindingへ設定する', async () => {
+test('確認済み正規indexをProduction bindingへ設定する', async () => {
   const config = await readFile(pagesConfigPath, 'utf8')
 
   assert.match(
     config,
-    /"binding": "SEARCH_INDEX",\s+"index_name": "acecore-net-search-openai-1536-production-v2",/u,
+    /"binding": "SEARCH_INDEX",\s+"index_name": "acecore-net-search-openai-1536-production",/u,
   )
   assert.doesNotMatch(
     config,
-    /"binding": "SEARCH_INDEX",\s+"index_name": "acecore-net-search-openai-1536-production",/u,
+    /"binding": "SEARCH_INDEX",\s+"index_name": "acecore-net-search-openai-1536-production-v2",/u,
   )
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -84,7 +84,7 @@
       "vectorize": [
         {
           "binding": "SEARCH_INDEX",
-          "index_name": "acecore-net-search-openai-1536-production-v2",
+          "index_name": "acecore-net-search-openai-1536-production",
         },
         {
           "binding": "SYSTEMS_SEARCH_INDEX",


### PR DESCRIPTION
関連 Issue: なし

## 概要

- Acecore NetのProduction `SEARCH_INDEX`、通常同期workflow、同期スクリプトを `acecore-net-search-openai-1536-production` に統一
- 一時的な `-v2` 同期先の選択肢を撤去し、旧名称を通常同期で受け付けない回帰テストへ変更
- 正規名indexへの305 vectors全量同期、ID集合一致、query canaryの実施内容を運用資料へ記録

## 確認

- `volta run --node 24.18.0 npm run test:search`（45 passed）
- `volta run --node 24.18.0 npm run check:pages-config`
- `volta run --node 24.18.0 npm run types:cloudflare:check`
- `volta run --node 24.18.0 npx prettier --check .github/workflows/sync-vectorize.yml docs/search-vectorize.md scripts/sync-vectorize.mjs tests/ai-contact.test.mjs tests/vectorize-sync.test.mjs tests/vectorize-workflow.test.mjs wrangler.jsonc`
- `volta run --node 24.18.0 npm run build`
- `git diff --check`

## 補足

- PRマージ後に本番Pages bindingと検索応答、通常同期の収束を確認してから旧 `-v2` indexを削除します。