### PR TITLE
fix(search): 承認済み大差分同期を一回だけ許可

### DIFF
--- a/.github/workflows/sync-vectorize.yml
+++ b/.github/workflows/sync-vectorize.yml
@@ -7,6 +7,12 @@ on:
   schedule:
     - cron: '*/15 * * * *'
   workflow_dispatch:
+    inputs:
+      execute_approved_plan:
+        description: 2026-08-01に承認された正規名indexの74件削除planだけを実行する
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -132,6 +138,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           VECTORIZE_INDEX_NAME: acecore-net-search-openai-1536-production
+          EVENT_NAME: ${{ github.event_name }}
+          EXECUTE_APPROVED_PLAN: ${{ inputs.execute_approved_plan }}
         run: |
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
             echo "::error::CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN is not configured."
@@ -142,5 +150,15 @@ jobs:
             exit 1
           fi
 
-          node ../tooling/scripts/sync-vectorize.mjs \
+          args=(
             --confirm-production "$VECTORIZE_INDEX_NAME"
+          )
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$EXECUTE_APPROVED_PLAN" == "true" ]]; then
+            args+=(
+              --allow-large-delete
+              --expected-delete-count 74
+              --expected-plan-id 19e1e130a5bda592d27edb4ecd1f68d19aebb11191723ae369d967331f7dd90b
+            )
+          fi
+
+          node ../tooling/scripts/sync-vectorize.mjs "${args[@]}"

--- a/tests/vectorize-workflow.test.mjs
+++ b/tests/vectorize-workflow.test.mjs
@@ -10,7 +10,7 @@ const workflowPath = new URL(
 )
 const pagesConfigPath = new URL('../wrangler.jsonc', import.meta.url)
 
-test('Production同期workflowから20%超削除を解除できない', async () => {
+test('Production同期workflowは承認済みの固定planだけ20%超削除を実行できる', async () => {
   const source = await readFile(workflowPath, 'utf8')
   const workflow = yaml.load(source)
   const productionSteps = workflow.jobs['sync-production'].steps
@@ -18,26 +18,44 @@ test('Production同期workflowから20%超削除を解除できない', async ()
     ({ name }) => name === 'Sync production Vectorize index',
   )
 
-  assert.equal(workflow.on.workflow_dispatch, null)
-  assert.equal(
-    productionSteps.find(
-      ({ name }) => name === 'Validate manual large-delete approval',
-    ),
-    undefined,
-  )
-  assert.doesNotMatch(source, /allow_large_delete/u)
+  assert.deepEqual(workflow.on.workflow_dispatch, {
+    inputs: {
+      execute_approved_plan: {
+        description:
+          '2026-08-01に承認された正規名indexの74件削除planだけを実行する',
+        required: false,
+        type: 'boolean',
+        default: false,
+      },
+    },
+  })
   assert.doesNotMatch(
     source,
-    /approved_(?:commit|corpus_version|delete_count|plan_id)/u,
+    /inputs\.(?:index_name|expected_delete_count|expected_plan_id)/u,
   )
-  assert.doesNotMatch(syncStep.run, /--allow-large-delete/u)
-  assert.doesNotMatch(syncStep.run, /--expected-delete-count/u)
-  assert.doesNotMatch(syncStep.run, /--expected-plan-id/u)
+  assert.match(
+    syncStep.run,
+    /if \[\[ "\$EVENT_NAME" == "workflow_dispatch" && "\$EXECUTE_APPROVED_PLAN" == "true" \]\]/u,
+  )
+  assert.match(syncStep.run, /--allow-large-delete/u)
+  assert.match(syncStep.run, /--expected-delete-count 74/u)
+  assert.match(
+    syncStep.run,
+    /--expected-plan-id 19e1e130a5bda592d27edb4ecd1f68d19aebb11191723ae369d967331f7dd90b/u,
+  )
   assert.match(syncStep.run, /node \.\.\/tooling\/scripts\/sync-vectorize\.mjs/)
-  assert.match(syncStep.run, /--confirm-production "\$VECTORIZE_INDEX_NAME"/u)
+  assert.match(
+    syncStep.run,
+    /node \.\.\/tooling\/scripts\/sync-vectorize\.mjs "\$\{args\[@\]\}"/u,
+  )
   assert.equal(
     syncStep.env.VECTORIZE_INDEX_NAME,
     'acecore-net-search-openai-1536-production',
+  )
+  assert.equal(syncStep.env.EVENT_NAME, '${{ github.event_name }}')
+  assert.equal(
+    syncStep.env.EXECUTE_APPROVED_PLAN,
+    '${{ inputs.execute_approved_plan }}',
   )
   assert.equal(syncStep.env.OPENAI_API_KEY, '${{ secrets.OPENAI_API_KEY }}')
   assert.match(syncStep.run, /OPENAI_API_KEY is not configured/)
@@ -48,7 +66,7 @@ test('Vectorize同期workflowはProduction専用でPreview credentialを参照�
   const workflow = yaml.load(source)
 
   assert.deepEqual(Object.keys(workflow.jobs), ['sync-production'])
-  assert.equal(workflow.on.workflow_dispatch, null)
+  assert.ok(workflow.on.workflow_dispatch.inputs.execute_approved_plan)
   assert.match(
     workflow.jobs['sync-production'].if,
     /github\.event_name == 'workflow_dispatch'/,


### PR DESCRIPTION
関連 Issue: なし

## 概要

- 手動実行時だけ、承認済みの `74 delete / 77 upsert` planを実行できる固定入力を追加
- `--allow-large-delete` は固定のdelete件数とplan IDが一致した場合だけ渡す
- push・schedule・別のplan IDでは従来どおり20%超削除を拒否する

## 確認

- `volta run --node 24.18.0 npm run test:search`（45 passed）
- `volta run --node 24.18.0 npx prettier --check .github/workflows/sync-vectorize.yml tests/vectorize-workflow.test.mjs`
- `volta run --node 24.18.0 node --experimental-strip-types --test tests/vectorize-workflow.test.mjs`（3 passed）
- `git diff --check`

## 補足

- ユーザー承認済みの `expectedDeleteCount=74` / `expectedPlanId=19e1e130a5bda592d27edb4ecd1f68d19aebb11191723ae369d967331f7dd90b` だけを許可します。
- 同期成功後、この一時入力を削除するfollow-up PRを作成します。