### PR TITLE
chore(search): 一時大差分承認経路を撤去

### DIFF
--- a/.github/workflows/sync-vectorize.yml
+++ b/.github/workflows/sync-vectorize.yml
@@ -7,12 +7,6 @@ on:
   schedule:
     - cron: '*/15 * * * *'
   workflow_dispatch:
-    inputs:
-      execute_approved_plan:
-        description: 2026-08-01に承認された正規名indexの74件削除planだけを実行する
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -138,8 +132,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           VECTORIZE_INDEX_NAME: acecore-net-search-openai-1536-production
-          EVENT_NAME: ${{ github.event_name }}
-          EXECUTE_APPROVED_PLAN: ${{ inputs.execute_approved_plan }}
         run: |
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
             echo "::error::CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN is not configured."
@@ -150,15 +142,5 @@ jobs:
             exit 1
           fi
 
-          args=(
+          node ../tooling/scripts/sync-vectorize.mjs \
             --confirm-production "$VECTORIZE_INDEX_NAME"
-          )
-          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$EXECUTE_APPROVED_PLAN" == "true" ]]; then
-            args+=(
-              --allow-large-delete
-              --expected-delete-count 74
-              --expected-plan-id 19e1e130a5bda592d27edb4ecd1f68d19aebb11191723ae369d967331f7dd90b
-            )
-          fi
-
-          node ../tooling/scripts/sync-vectorize.mjs "${args[@]}"

--- a/tests/vectorize-workflow.test.mjs
+++ b/tests/vectorize-workflow.test.mjs
@@ -10,7 +10,7 @@ const workflowPath = new URL(
 )
 const pagesConfigPath = new URL('../wrangler.jsonc', import.meta.url)
 
-test('Production同期workflowは承認済みの固定planだけ20%超削除を実行できる', async () => {
+test('Production同期workflowから20%超削除を解除できない', async () => {
   const source = await readFile(workflowPath, 'utf8')
   const workflow = yaml.load(source)
   const productionSteps = workflow.jobs['sync-production'].steps
@@ -18,44 +18,26 @@ test('Production同期workflowは承認済みの固定planだけ20%超削除を�
     ({ name }) => name === 'Sync production Vectorize index',
   )
 
-  assert.deepEqual(workflow.on.workflow_dispatch, {
-    inputs: {
-      execute_approved_plan: {
-        description:
-          '2026-08-01に承認された正規名indexの74件削除planだけを実行する',
-        required: false,
-        type: 'boolean',
-        default: false,
-      },
-    },
-  })
+  assert.equal(workflow.on.workflow_dispatch, null)
+  assert.equal(
+    productionSteps.find(
+      ({ name }) => name === 'Validate manual large-delete approval',
+    ),
+    undefined,
+  )
+  assert.doesNotMatch(source, /allow_large_delete/u)
   assert.doesNotMatch(
     source,
-    /inputs\.(?:index_name|expected_delete_count|expected_plan_id)/u,
+    /approved_(?:commit|corpus_version|delete_count|plan_id)/u,
   )
-  assert.match(
-    syncStep.run,
-    /if \[\[ "\$EVENT_NAME" == "workflow_dispatch" && "\$EXECUTE_APPROVED_PLAN" == "true" \]\]/u,
-  )
-  assert.match(syncStep.run, /--allow-large-delete/u)
-  assert.match(syncStep.run, /--expected-delete-count 74/u)
-  assert.match(
-    syncStep.run,
-    /--expected-plan-id 19e1e130a5bda592d27edb4ecd1f68d19aebb11191723ae369d967331f7dd90b/u,
-  )
+  assert.doesNotMatch(syncStep.run, /--allow-large-delete/u)
+  assert.doesNotMatch(syncStep.run, /--expected-delete-count/u)
+  assert.doesNotMatch(syncStep.run, /--expected-plan-id/u)
   assert.match(syncStep.run, /node \.\.\/tooling\/scripts\/sync-vectorize\.mjs/)
-  assert.match(
-    syncStep.run,
-    /node \.\.\/tooling\/scripts\/sync-vectorize\.mjs "\$\{args\[@\]\}"/u,
-  )
+  assert.match(syncStep.run, /--confirm-production "\$VECTORIZE_INDEX_NAME"/u)
   assert.equal(
     syncStep.env.VECTORIZE_INDEX_NAME,
     'acecore-net-search-openai-1536-production',
-  )
-  assert.equal(syncStep.env.EVENT_NAME, '${{ github.event_name }}')
-  assert.equal(
-    syncStep.env.EXECUTE_APPROVED_PLAN,
-    '${{ inputs.execute_approved_plan }}',
   )
   assert.equal(syncStep.env.OPENAI_API_KEY, '${{ secrets.OPENAI_API_KEY }}')
   assert.match(syncStep.run, /OPENAI_API_KEY is not configured/)
@@ -66,7 +48,7 @@ test('Vectorize同期workflowはProduction専用でPreview credentialを参照�
   const workflow = yaml.load(source)
 
   assert.deepEqual(Object.keys(workflow.jobs), ['sync-production'])
-  assert.ok(workflow.on.workflow_dispatch.inputs.execute_approved_plan)
+  assert.equal(workflow.on.workflow_dispatch, null)
   assert.match(
     workflow.jobs['sync-production'].if,
     /github\.event_name == 'workflow_dispatch'/,


### PR DESCRIPTION
関連 Issue: なし

## 概要

- 承認済みの `77 upsert / 74 delete` 同期が成功したため、固定plan用のworkflow dispatch入力を撤去
- Production同期を通常の20%大削除fail-closed運用へ戻す
- 通常workflowが大削除overrideを受け付けない回帰テストを復元

## 確認

- `volta run --node 24.18.0 npm run test:search`（45 passed）
- `volta run --node 24.18.0 npx prettier --check .github/workflows/sync-vectorize.yml tests/vectorize-workflow.test.mjs`
- `git diff --check`

## 補足

- 承認済みrun #30692973687は `upserted=77`、`deleted=74`、`verified=true`、`queryVerified=true` で成功済みです。
- このPRのmain反映後、通常同期のゼロ差分収束を確認してから旧 `-v2` indexを削除します。