### PR TITLE
SEO: 検索対象外アセットを除外

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -34,14 +34,30 @@
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
 
+/_astro/*.js
+  X-Robots-Tag: noindex
+
+/_astro/*.css
+  X-Robots-Tag: noindex
+
+/_astro/*.map
+  X-Robots-Tag: noindex
+
 # 静的アセット（画像・フォント等）
 /favicon.svg
   Cache-Control: public, max-age=86400
+  X-Robots-Tag: noindex
 
 /uploads/*
   Cache-Control: public, max-age=604800, stale-while-revalidate=86400
 
+/uploads/og-default.svg
+  X-Robots-Tag: noindex
+
 # Pagefind の content hash 付き chunk（root の bootstrap / UI は /* で常に再検証）
+/pagefind/*
+  X-Robots-Tag: noindex
+
 /pagefind/filter/*
   ! Cache-Control
   Cache-Control: public, max-age=31536000, immutable

--- a/tests/pagefind-headers.test.mjs
+++ b/tests/pagefind-headers.test.mjs
@@ -83,12 +83,14 @@ function assertCacheControl(rules, pathname, expected) {
 
 test('Pagefind rootは再検証し、content hash付きchunkだけimmutableにする', async () => {
   const rules = parseHeaderRules(await readFile(HEADERS_URL, 'utf8'))
-  const pagefindRules = rules.filter((rule) =>
-    rule.pattern.startsWith('/pagefind/'),
+  const pagefindCacheRules = rules.filter(
+    (rule) =>
+      rule.pattern.startsWith('/pagefind/') &&
+      rule.directives.some((directive) => directive.name === 'cache-control'),
   )
 
   assert.deepEqual(
-    pagefindRules.map((rule) => rule.pattern),
+    pagefindCacheRules.map((rule) => rule.pattern),
     CHUNK_DIRECTORIES.map((directory) => `/pagefind/${directory}/*`),
   )
 
@@ -111,6 +113,19 @@ test('Pagefind rootは再検証し、content hash付きchunkだけimmutableに�
       `/pagefind/${directory}/en_deadbee.pf_${directory}`,
       IMMUTABLE,
     )
+  }
+})
+
+test('Pagefindの検索用ファイルは検索結果へ載せない', async () => {
+  const rules = parseHeaderRules(await readFile(HEADERS_URL, 'utf8'))
+
+  for (const pathname of [
+    '/pagefind/pagefind.js',
+    '/pagefind/index/en_deadbee.pf_index',
+  ]) {
+    assert.deepEqual(effectiveHeaderValues(rules, pathname, 'X-Robots-Tag'), [
+      'noindex',
+    ])
   }
 })
 


### PR DESCRIPTION
関連 Issue: なし

## 概要

- Bing Webmasterで検出されたPagefind・ビルド済みJS/CSS/source map・favicon・既定OG SVGを、本文ページと分けて検索結果から除外します。
- アップロード画像は検索対象のまま維持し、Pagefindのキャッシュ契約とnoindexをテストで固定します。

## 確認

- `volta run --node 24.18.0 npm run format:check`
- `volta run --node 24.18.0 npm run test:site-config`
- `volta run --node 24.18.0 npm run validate:content`
- `git diff --check`
- `npm run build` は依存モジュールの実行時エラー（`require is not defined`）で未通過。変更箇所と無関係の既存環境要因として別途確認します。

## 補足

- 画像検索を損なわないよう、`/uploads/*` 全体へのnoindexは設定していません。