### PR TITLE
fix: サイトタイトルを株式会社Acecoreに統一

### DIFF
--- a/scripts/validate-seo.mjs
+++ b/scripts/validate-seo.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const distDirectory = path.join(root, 'dist')
-const titleRange = { min: 15, max: 70 }
+const titleRange = { min: 10, max: 70 }
 const descriptionRange = { min: 50, max: 160 }
 const localizedPrefixes = new Set([
   'de',

--- a/src/i18n/source/ja/common.json
+++ b/src/i18n/source/ja/common.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "siteTitle": "Acecore | テクノロジーと教育のコーポレートサイト",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "Acecoreは、Acecore Systems、Acecore Schools、Aceserver、Acecore Shopを通じて、事業・学び・コミュニティ・プロダクトを支える企業です。",
     "shortTitleContext": "公式サイト",
     "shortDescriptionContext": "Acecoreの会社情報、事業、企業ニュースをご案内します。"

--- a/src/i18n/translations/de.json
+++ b/src/i18n/translations/de.json
@@ -200,7 +200,7 @@
     "tagListTitle": "Tag-Liste"
   },
   "meta": {
-    "siteTitle": "Acecore | Technologie und Bildung",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "Acecore unterstützt Wirtschaft, Lernen, Gemeinschaft und Produkte durch Acecore Systems, Acecore Schools, Aceserver und Acecore Shop.",
     "shortTitleContext": "Offizielle Website",
     "shortDescriptionContext": "Unternehmensinformationen, Geschäftsbereiche und Neuigkeiten von Acecore."

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -186,7 +186,7 @@
     "commentsSending": "Sending..."
   },
   "meta": {
-    "siteTitle": "Acecore | Technology and Education",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "Acecore supports business, learning, community, and products through Acecore Systems, Acecore Schools, Aceserver, and Acecore Shop.",
     "shortTitleContext": "Official Site",
     "shortDescriptionContext": "Company information, businesses, and news from Acecore."

--- a/src/i18n/translations/es.json
+++ b/src/i18n/translations/es.json
@@ -186,7 +186,7 @@
     "commentsSending": "Enviando..."
   },
   "meta": {
-    "siteTitle": "Acecore | Tecnología y educación",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "Acecore apoya a empresas, aprendizaje, comunidades y productos a través de Acecore Systems, Acecore Schools, Aceserver y Acecore Shop.",
     "shortTitleContext": "Sitio oficial",
     "shortDescriptionContext": "Información corporativa, negocios y noticias de Acecore."

--- a/src/i18n/translations/fr.json
+++ b/src/i18n/translations/fr.json
@@ -186,7 +186,7 @@
     "commentsSending": "Envoi..."
   },
   "meta": {
-    "siteTitle": "Acecore | Technologie et éducation",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "Acecore soutient l'entreprise, l'apprentissage, les communautés et les produits avec Acecore Systems, Acecore Schools, Aceserver et Acecore Shop.",
     "shortTitleContext": "Site officiel",
     "shortDescriptionContext": "Informations sur l'entreprise, ses activités et les actualités d'Acecore."

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -186,7 +186,7 @@
     "commentsSending": "전송 중..."
   },
   "meta": {
-    "siteTitle": "Acecore | 기술과 교육",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "Acecore는 Acecore Systems, Acecore Schools, Aceserver, Acecore Shop을 통해 사업, 배움, 커뮤니티, 프로덕트를 지원합니다.",
     "shortTitleContext": "공식 사이트",
     "shortDescriptionContext": "Acecore의 회사 정보, 사업 및 뉴스를 안내합니다."

--- a/src/i18n/translations/pt.json
+++ b/src/i18n/translations/pt.json
@@ -186,7 +186,7 @@
     "commentsSending": "Enviando..."
   },
   "meta": {
-    "siteTitle": "Acecore | Tecnologia e educação",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "A Acecore apoia empresas, aprendizagem, comunidades e produtos por meio da Acecore Systems, Acecore Schools, Aceserver e Acecore Shop.",
     "shortTitleContext": "Site oficial",
     "shortDescriptionContext": "Informações corporativas, negócios e notícias da Acecore."

--- a/src/i18n/translations/ru.json
+++ b/src/i18n/translations/ru.json
@@ -186,7 +186,7 @@
     "commentsSending": "Отправка..."
   },
   "meta": {
-    "siteTitle": "Acecore | Технологии и образование",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "Acecore поддерживает бизнес, обучение, сообщества и продукты через Acecore Systems, Acecore Schools, Aceserver и Acecore Shop.",
     "shortTitleContext": "Официальный сайт",
     "shortDescriptionContext": "Информация о компании, направлениях и новостях Acecore."

--- a/src/i18n/translations/zh-cn.json
+++ b/src/i18n/translations/zh-cn.json
@@ -186,7 +186,7 @@
     "commentsSending": "发送中..."
   },
   "meta": {
-    "siteTitle": "Acecore | 技术与教育",
+    "siteTitle": "株式会社Acecore",
     "defaultDescription": "Acecore通过Acecore Systems、Acecore Schools、Aceserver和Acecore Shop支持业务、学习、社区与产品。",
     "shortTitleContext": "官方网站",
     "shortDescriptionContext": "Acecore的公司信息、业务与新闻。"

--- a/src/utils/seo-meta.ts
+++ b/src/utils/seo-meta.ts
@@ -147,7 +147,7 @@ export function buildSeoTitle({
     return truncateAtWordBoundary(siteTitle, SEO_TITLE_LENGTH.max, locale)
   }
 
-  const brandSuffix = ' | Acecore'
+  const brandSuffix = ` | ${siteTitle}`
   const titleLimit = SEO_TITLE_LENGTH.max - countCharacters(brandSuffix)
   const normalizedTitle = normalizeWhitespace(title)
   const normalizedTitleContext = titleContext

--- a/src/utils/seo-meta.ts
+++ b/src/utils/seo-meta.ts
@@ -1,6 +1,6 @@
 import type { Locale } from '../i18n'
 
-export const SEO_TITLE_LENGTH = { min: 15, max: 70 } as const
+export const SEO_TITLE_LENGTH = { min: 10, max: 70 } as const
 export const SEO_DESCRIPTION_LENGTH = { min: 50, max: 160 } as const
 
 const localeMap: Record<Locale, string> = {


### PR DESCRIPTION
関連 Issue: なし

## 概要

- 全言語のホームページタイトルを「株式会社Acecore」に統一しました。
- 下層ページのタイトル末尾を `Acecore` から `株式会社Acecore` に変更しました。
- タイトル長の品質基準を、生成ロジックとCI検証の両方で15文字から10文字へ統一しました。
- UI のブランド表示、Open Graph の `site_name`、構造化データのブランド `name` は維持しています。

## 確認

- `volta run --node 24.18.0 npm exec -- prettier --check src/i18n/source/ja/common.json src/i18n/translations/de.json src/i18n/translations/en.json src/i18n/translations/es.json src/i18n/translations/fr.json src/i18n/translations/ko.json src/i18n/translations/pt.json src/i18n/translations/ru.json src/i18n/translations/zh-cn.json src/utils/seo-meta.ts scripts/validate-seo.mjs`
- `volta run --node 24.18.0 npm run validate:content`
- `volta run --node 24.18.0 node --experimental-strip-types --input-type=module -e '…'`（タイトル最小値 10、ホームタイトル `株式会社Acecore` を確認）
- `git diff --check`
- プレビューで `/` のタイトルが `株式会社Acecore`、ヘッダーの「会社概要」リンク遷移後のタイトルが `会社概要 – 会社情報・理念・事業 | 株式会社Acecore` になることを確認
- GitHub Actions「Build and Format」成功、Cloudflare Pages成功

## 補足

- ローカルの `npm run build` は、環境依存の `source-map-js/lib/source-map-generator.js` における `require is not defined` によりAstro設定の読み込み段階で停止します。GitHub ActionsではビルドとSEO検証が成功しています。