### PR TITLE
依存脆弱性を解消しWindowsビルドを継続検証する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,23 @@ jobs:
 
       - name: Validate legacy redirects
         run: npm run validate:legacy-redirects
+
+  windows-build:
+    name: Build on Windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -628,9 +628,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260801.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260801.1.tgz",
-      "integrity": "sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
+      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
       "cpu": [
         "x64"
       ],
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260801.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260801.1.tgz",
-      "integrity": "sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
       "cpu": [
         "arm64"
       ],
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260801.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260801.1.tgz",
-      "integrity": "sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
+      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
       "cpu": [
         "x64"
       ],
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260801.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260801.1.tgz",
-      "integrity": "sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
+      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
       "cpu": [
         "arm64"
       ],
@@ -696,9 +696,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260801.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260801.1.tgz",
-      "integrity": "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
+      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
       "cpu": [
         "x64"
       ],
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260804.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260804.1.tgz",
-      "integrity": "sha512-B1dwxpN6e5RZXZkE5zpZj+ooNeNZ1mwavLIyHDYe10ojhlGTwDfe8sAl7R1mMXc1cyIsbr+jKVdvmMEyVcdTdg==",
+      "version": "5.20260814.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260814.1.tgz",
+      "integrity": "sha512-bF5RT5bmxEaHJR2PRrAmcdf09EPxpRXXzPHcOtjX//r84jZNpwslNwx291ofNdBVuqGV129CBJzxiMYsB37DHw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1800,6 +1800,15 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pagefind/darwin-arm64": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
@@ -2014,6 +2023,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2029,6 +2041,9 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2046,6 +2061,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2061,6 +2079,9 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2078,6 +2099,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,6 +2117,9 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5799,16 +5826,16 @@
       "license": "MIT"
     },
     "node_modules/miniflare": {
-      "version": "5.20260801.0-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260801.0-alpha.tgz",
-      "integrity": "sha512-AfMrnQbJg81ESsGkGhOkHBtwTqCG+mosR+3GE+qDrhF1I/ieIvgg3ICxNyBvgHBZ3iapy6cysBQHNPykkzrfgw==",
+      "version": "5.20260811.1-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.1-alpha.tgz",
+      "integrity": "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
-        "undici": "7.28.0",
-        "workerd": "1.20260801.1",
+        "undici": "7.29.0",
+        "workerd": "1.20260811.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -6426,16 +6453,6 @@
         "@img/sharp-win32-x64": "0.35.2"
       }
     },
-    "node_modules/miniflare/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "license": "MIT",
@@ -6450,9 +6467,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -6753,9 +6770,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6772,7 +6789,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7116,15 +7133,6 @@
         "@rolldown/binding-wasm32-wasi": "1.1.5",
         "@rolldown/binding-win32-arm64-msvc": "1.1.5",
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
-      }
-    },
-    "node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/s.color": {
@@ -8001,9 +8009,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260801.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260801.1.tgz",
-      "integrity": "sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==",
+      "version": "1.20260811.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
+      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -8014,17 +8022,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260801.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260801.1",
-        "@cloudflare/workerd-linux-64": "1.20260801.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260801.1",
-        "@cloudflare/workerd-windows-64": "1.20260801.1"
+        "@cloudflare/workerd-darwin-64": "1.20260811.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
+        "@cloudflare/workerd-linux-64": "1.20260811.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
+        "@cloudflare/workerd-windows-64": "1.20260811.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.119.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.119.0.tgz",
-      "integrity": "sha512-ookClf+zly4DTc8pBMNrwGQzZKH8IpIYTXkjDw3XS7ZvBQ5mLYH6eOvfD5BEpk3U63zTbv91WRlo1UeRSKXa0g==",
+      "version": "4.123.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.123.0.tgz",
+      "integrity": "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -8032,10 +8040,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260801.0-alpha",
+        "miniflare": "5.20260811.1-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260801.1"
+        "workerd": "1.20260811.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -8049,7 +8057,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260801.1"
+        "@cloudflare/workers-types": "^5.20260811.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {


### PR DESCRIPTION
関連 Issue: なし

## 概要

- lockfile を安全な互換範囲内で更新し、`npm audit` の5件（moderate 3 / high 2）を0件にしました。
- PostCSS 8.5.26、nanoid 3.3.18、Wrangler 4.123.0、Miniflare / workerd の修正版へ更新し、脆弱な Miniflare 配下の undici 7.28.0 を解消しました。
- 依存更新時の Windows 固有回帰を検知できるよう、`windows-latest` で `npm ci` と `npm run build` を行う CI job を追加しました。
- `package.json` の依存範囲とサイト実装は変更していません。

## 確認

- `volta run --node 24.18.0 npm ci`
- `volta run --node 24.18.0 npm audit --json`
- `volta run --node 24.18.0 npm audit --omit=dev --json`
- `volta run --node 24.18.0 npm run format:check`
- `volta run --node 24.18.0 npm run validate:content`
- `volta run --node 24.18.0 npm run test:blog-freshness`
- `volta run --node 24.18.0 npm run test:cms`
- `volta run --node 24.18.0 npm run test:cms-auth`
- `volta run --node 24.18.0 npm run test:contact`
- `volta run --node 24.18.0 npm run test:site-config`
- `volta run --node 24.18.0 npm run test:ai-chat`
- `volta run --node 24.18.0 npm run test:search`
- `volta run --node 24.18.0 npm run types:cloudflare:check`
- `volta run --node 24.18.0 npm run types:cms-auth:check`
- `volta run --node 24.18.0 npm run check:pages-config`
- `volta run --node 24.18.0 npm run typecheck:functions`
- `volta run --node 24.18.0 npm run typecheck:cms-auth`
- `volta run --node 24.18.0 npm run typecheck:admin`
- `volta run --node 24.18.0 npm run typecheck:translation-merge`
- `volta run --node 24.18.0 npm run typecheck:openai-translation`
- `volta run --node 24.18.0 npm run typecheck:deployment-marker`
- `volta run --node 24.18.0 npm run typecheck:vectorize-sync`
- `volta run --node 24.18.0 npm run build`（Windows、199ページ・Pagefind・検索corpusまで完走）
- `volta run --node 24.18.0 npm run validate:seo`
- `volta run --node 24.18.0 npm run validate:tag-redirects`
- `volta run --node 24.18.0 npm run validate:legacy-redirects`
- `git diff --check`
- in-app Browser（1280×720）でホームと事業カードを確認し、横あふれ・不要な装飾線・表示中ダイアログ・Console error がないことを確認
- GitHub Actions `Build and Format`: 成功
- GitHub Actions `Build on Windows`: 成功
- Cloudflare Pages Preview: commit `2bcea67` のデプロイ成功（https://17bf505f.acecore-net.pages.dev）

## 補足

- `source-map-js: require is not defined` は制限付き実行コンテキストでのみ再現しました。同じ Node 24.18.0 / lockfile を通常の Windows 実行コンテキストで実行すると build は完走するため、Astro / Vite の巻き戻しは行っていません。
- UIソースの変更はありません。アプリ内ブラウザのviewportが固定のため、今回のローカル目視確認はデスクトップのみです。