### PR TITLE
Vectorize replacement indexを構築する

### DIFF
--- a/.github/workflows/sync-vectorize.yml
+++ b/.github/workflows/sync-vectorize.yml
@@ -137,7 +137,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: db9b62f409f463da7acbcc374b8385d0
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          VECTORIZE_INDEX_NAME: acecore-net-search-openai-1536-production
+          VECTORIZE_INDEX_NAME: acecore-net-search-openai-1536-production-v3
         run: |
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
             echo "::error::CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN is not configured."

--- a/docs/04_運用設計/02_Vectorize検索・AI横断検索運用.md
+++ b/docs/04_運用設計/02_Vectorize検索・AI横断検索運用.md
@@ -62,9 +62,11 @@ World Foundation owner repositoryでは、公開corpusの生成、Production同�
 | Preview    | 未接続                                      | 未適用                                                  |
 | Production | `acecore-net-search-openai-1536-production` | `ja`, `en`, `zh-cn`, `es`, `pt`, `fr`, `ko`, `de`, `ru` |
 
-Production indexは `text-embedding-3-large` の短縮embeddingに合わせて `dimensions: 1536`、`metric: cosine` で作成します。横断検索先も同じmodelと次元を契約とします。旧BGE-M3用1024次元indexへ混在させず、新indexの全corpus同期と代表的な日本語queryの確認が終わってからbindingを切り替えます。2026-08-01に正規名 `acecore-net-search-openai-1536-production` へ305 vectorsを全量同期し、ID集合一致とquery canaryを確認しました。同日の公開corpus差分は、明示承認済みの固定planに限定して77 upsert・74 delete（24.3%）を適用し、308 vectorsへのID集合一致とquery canaryを再確認しています。Productionの通常同期とbindingはこの正規名だけを使います。
+Production indexは `text-embedding-3-large` の短縮embeddingに合わせて `dimensions: 1536`、`metric: cosine` で作成します。横断検索先も同じmodelと次元を契約とします。旧BGE-M3用1024次元indexへ混在させず、新indexの全corpus同期と代表的な日本語queryの確認が終わってからbindingを切り替えます。2026-08-01に正規名 `acecore-net-search-openai-1536-production` へ305 vectorsを全量同期し、ID集合一致とquery canaryを確認しました。同日の公開corpus差分は、明示承認済みの固定planに限定して77 upsert・74 delete（24.3%）を適用し、308 vectorsへのID集合一致とquery canaryを再確認しています。Productionの現在のbindingはこの正規名です。
 
 2026-07-31の監査では、旧 `acecore-net-search-openai-1536-production` は164 vectors、公開corpusとの差分は42 upsert・35 delete（21.3%）でした。大量削除の安全gateに従い、旧indexに対する35件の直接deleteは実行せず、同じ1536次元・cosine設定の `acecore-net-search-openai-1536-production-v2` をreplacementとして作成しました。v2の全量同期、ID集合の完全一致、query canaryがProduction workflowで成功したことを確認して一時的にbindingを切り替え、旧indexを削除しました。2026-08-01に正規名indexを再作成・全量同期して通常同期とbindingを戻し、収束確認後にv2も削除しました。以後の復旧は、別のreplacement indexを新規作成して公開corpusを全量同期する手順とします。top-level／Previewはbindingを持たず `SEARCH_ENABLED=false`、Productionだけを `true` とします。Preview用indexは運用せず、接続・利用しません。
+
+2026-08-14の公開corpusは341 vectorsで、正規名indexの330 vectorsに対して106 upsert・95 delete（28.8%）となり、20%の安全gateがmutation前に停止しました。既存indexへ大量deleteを適用せず、承認済みのreplacement `acecore-net-search-openai-1536-production-v3` へ全corpusを同期します。v3のID集合一致とquery canaryを確認するまではProduction bindingを正規名へ維持し、正規名indexもロールバック用に保持します。再構築中の同期workflowとscriptはv3だけをmutation許可対象に固定します。
 
 検索API、横断検索、AIチャットのrate limitは、Pagesで正式対応されているD1 bindingを使い、PreviewとProductionで本番D1を共有します。Previewは検索を無効のまま維持し、同じtable内では自サイト検索を `client:` / `global`、横断検索を `network-search:{caller}:client:` / `network-search:global`、AIチャットを `ai-chat:client:` / `ai-chat:global` prefixで分離します。
 
@@ -90,7 +92,7 @@ npm run typecheck:functions
 - 15分ごとのreconciler: 現在公開中のbuild markerを読み、40文字のGit SHAであり、`origin/main` のancestorであることを検証してproduction indexを再同期する。concurrencyで待機中のrunが置換された場合も、次回のreconcilerが公開状態へ収束させる。
 - 手動production: 現在公開中のmain由来corpusをproduction indexへ再同期する。
 
-このworkflowの同期先は正規名の `acecore-net-search-openai-1536-production` です。2026-08-01に空の正規名indexへ公開corpusを305 vectors全量upsertし、その後の明示承認済み固定planで77 upsert・74 deleteを適用して308 vectorsへ収束させました。いずれもID集合の完全一致とquery canaryを確認済みで、通常同期のゼロ差分収束も確認しています。以後のupsertが発生したrunは、mutation完了とID集合の完全一致に加え、今回upsertしたvectorをREST queryして結果にそのIDが含まれることを確認します。
+2026-08-14のreplacement再構築中は、workflowの同期先を固定名 `acecore-net-search-openai-1536-production-v3` とします。存在しない場合は1536次元・cosineで作成し、公開corpusを全量upsertしてID集合の完全一致とquery canaryを確認します。確認が完了するまでProduction bindingは正規名indexのままとし、別のレビュー済み変更だけでv3へ切り替えます。以後のupsertが発生したrunは、mutation完了とID集合の完全一致に加え、今回upsertしたvectorをREST queryして結果にそのIDが含まれることを確認します。
 
 push、schedule、手動実行のいずれも `refs/heads/main` 以外ではjobを実行しません。workflow用のcheckoutは常にprotected `main` を `tooling/` へ固定し、同期scriptもこのcheckoutから実行します。公開対象のsite commitは別の `site/` へcheckoutしてbuildするため、build markerが指す過去のmain commitを復旧同期する場合も、secretを扱う同期ロジックはprotected `main` のものです。
 
@@ -99,9 +101,9 @@ Productionのlive同期は、index名と同じ値を`--confirm-production`へ明
 
 GitHub Actionsには次のGitHub Environmentとenvironment secretが必要です。
 
-| GitHub Environment             | environment secrets                                        | Cloudflare account token                | 同期先                                      |
-| ------------------------------ | ---------------------------------------------------------- | --------------------------------------- | ------------------------------------------- |
-| `cloudflare-search-production` | `CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN`, `OPENAI_API_KEY` | `acecore-net-vectorize-production-sync` | `acecore-net-search-openai-1536-production` |
+| GitHub Environment             | environment secrets                                        | Cloudflare account token                | 同期先                                         |
+| ------------------------------ | ---------------------------------------------------------- | --------------------------------------- | ---------------------------------------------- |
+| `cloudflare-search-production` | `CLOUDFLARE_SEARCH_PRODUCTION_API_TOKEN`, `OPENAI_API_KEY` | `acecore-net-vectorize-production-sync` | `acecore-net-search-openai-1536-production-v3` |
 
 EnvironmentのDeployment branches and tagsは `Selected branches and tags` を選び、branch ruleには `main` だけを登録します。workflow側にもmain判定がありますが、Environment側のmain-only protectionをsecret払い出しの独立した必須条件として設定してください。任意refから起動されたworkflowは、そのref上のworkflow定義自体が変更されている可能性があるため、このEnvironment設定なしでは運用を開始しません。
 
@@ -124,7 +126,7 @@ npm run sync:vectorize:dry-run
 credentialを使って現行indexとの差分だけを確認し、mutationしない場合:
 
 ```powershell
-$env:VECTORIZE_INDEX_NAME = 'acecore-net-search-openai-1536-production'
+$env:VECTORIZE_INDEX_NAME = 'acecore-net-search-openai-1536-production-v3'
 $env:CLOUDFLARE_ACCOUNT_ID = '<account-id>'
 $env:CLOUDFLARE_API_TOKEN = '<scoped-token>'
 node --experimental-strip-types scripts/sync-vectorize.ts --plan
@@ -135,7 +137,7 @@ node --experimental-strip-types scripts/sync-vectorize.ts --plan
 Productionへ同期する場合:
 
 ```powershell
-$env:VECTORIZE_INDEX_NAME = 'acecore-net-search-openai-1536-production'
+$env:VECTORIZE_INDEX_NAME = 'acecore-net-search-openai-1536-production-v3'
 $env:CLOUDFLARE_ACCOUNT_ID = '<account-id>'
 $env:CLOUDFLARE_API_TOKEN = '<scoped-token>'
 $env:OPENAI_API_KEY = '<project-api-key>'

--- a/scripts/sync-vectorize.ts
+++ b/scripts/sync-vectorize.ts
@@ -164,7 +164,7 @@ const MIN_LOCALE_VECTOR_COUNTS: Readonly<LocaleCounts> = Object.freeze({
   ru: 18,
 })
 const MANAGED_VECTOR_ID_PATTERN = /^v1-[0-9a-f]{48}$/
-const PRODUCTION_INDEX_NAME = 'acecore-net-search-openai-1536-production'
+const PRODUCTION_INDEX_NAME = 'acecore-net-search-openai-1536-production-v3'
 const ALLOWED_INDEX_NAMES = new Set<string>([PRODUCTION_INDEX_NAME])
 const SUPPORTED_LOCALES = [
   'ja',

--- a/tests/vectorize-sync.test.mjs
+++ b/tests/vectorize-sync.test.mjs
@@ -14,7 +14,8 @@ import {
   validateCorpus,
 } from '../scripts/sync-vectorize.ts'
 
-const PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production'
+const PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production-v3'
+const PREVIOUS_PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production'
 const RETIRED_PRODUCTION_INDEX = 'acecore-net-search-openai-1536-production-v2'
 const LOCALES = ['ja', 'en', 'zh-cn', 'es', 'pt', 'fr', 'ko', 'de', 'ru']
 const temporaryRoots = []
@@ -57,17 +58,17 @@ test('live Production同期は正確なindex名の明示確認を要求する', 
 
   assert.throws(
     () => parseArguments([], environment),
-    /--confirm-production acecore-net-search-openai-1536-production/u,
+    /--confirm-production acecore-net-search-openai-1536-production-v3/u,
   )
   assert.doesNotThrow(() =>
     parseArguments(['--confirm-production', PRODUCTION_INDEX], environment),
   )
   assert.throws(
     () =>
-      parseArguments(['--confirm-production', RETIRED_PRODUCTION_INDEX], {
-        VECTORIZE_INDEX_NAME: RETIRED_PRODUCTION_INDEX,
+      parseArguments(['--confirm-production', PREVIOUS_PRODUCTION_INDEX], {
+        VECTORIZE_INDEX_NAME: PREVIOUS_PRODUCTION_INDEX,
       }),
-    /--confirm-production acecore-net-search-openai-1536-production/u,
+    /--confirm-production acecore-net-search-openai-1536-production-v3/u,
   )
   assert.doesNotThrow(() => parseArguments(['--dry-run'], environment))
   assert.doesNotThrow(() => parseArguments(['--plan'], environment))
@@ -371,7 +372,7 @@ test('planは不存在indexを作成せずfail closedする', async () => {
   assert.equal(createRequests, 0)
 })
 
-test('削除済みの正規名indexは再作成して同期対象にできる', async () => {
+test('不存在の承認済みreplacement indexは作成して同期対象にできる', async () => {
   const corpus = createCorpus()
   const corpusFile = await writeCorpus(corpus)
   let createRequests = 0
@@ -419,7 +420,7 @@ test('削除済みの正規名indexは再作成して同期対象にできる', 
   assert.equal(result.verified, true)
 })
 
-test('同期先indexをproductionだけに制限する', async () => {
+test('同期先indexを承認済みreplacementだけに制限する', async () => {
   const corpusFile = await writeCorpus(createCorpus())
 
   await assert.rejects(
@@ -444,10 +445,19 @@ test('同期先indexをproductionだけに制限する', async () => {
     syncVectorize({
       corpusFile,
       dryRun: true,
+      indexName: PREVIOUS_PRODUCTION_INDEX,
+      logger: silentLogger,
+    }),
+    /must be one of: acecore-net-search-openai-1536-production-v3/u,
+  )
+  await assert.rejects(
+    syncVectorize({
+      corpusFile,
+      dryRun: true,
       indexName: RETIRED_PRODUCTION_INDEX,
       logger: silentLogger,
     }),
-    /must be one of: acecore-net-search-openai-1536-production/u,
+    /must be one of: acecore-net-search-openai-1536-production-v3/u,
   )
 })
 

--- a/tests/vectorize-workflow.test.mjs
+++ b/tests/vectorize-workflow.test.mjs
@@ -40,7 +40,7 @@ test('Production同期workflowから20%超削除を解除できない', async ()
   assert.match(syncStep.run, /--confirm-production "\$VECTORIZE_INDEX_NAME"/u)
   assert.equal(
     syncStep.env.VECTORIZE_INDEX_NAME,
-    'acecore-net-search-openai-1536-production',
+    'acecore-net-search-openai-1536-production-v3',
   )
   assert.equal(syncStep.env.OPENAI_API_KEY, '${{ secrets.OPENAI_API_KEY }}')
   assert.match(syncStep.run, /OPENAI_API_KEY is not configured/)
@@ -89,7 +89,7 @@ test('配置待機ゲートを型検査済みのTypeScriptとして実行する'
   assert.doesNotMatch(source, /wait-for-deployment\.mjs/u)
 })
 
-test('確認済み正規indexをProduction bindingへ設定する', async () => {
+test('replacement構築中も確認済み正規indexをProduction bindingへ維持する', async () => {
   const config = await readFile(pagesConfigPath, 'utf8')
 
   assert.match(
@@ -99,5 +99,9 @@ test('確認済み正規indexをProduction bindingへ設定する', async () => 
   assert.doesNotMatch(
     config,
     /"binding": "SEARCH_INDEX",\s+"index_name": "acecore-net-search-openai-1536-production-v2",/u,
+  )
+  assert.doesNotMatch(
+    config,
+    /"binding": "SEARCH_INDEX",\s+"index_name": "acecore-net-search-openai-1536-production-v3",/u,
   )
 })


### PR DESCRIPTION
関連 Issue: なし

## 概要

- 公開corpus 341 vectorsに対し、現行indexから95/330 vectors（28.8%）を削除する計画が20%安全gateで停止したため、既存indexへの大量deleteを行わずreplacement indexを構築します。
- Production同期workflowと同期scriptのmutation許可先を固定名 `acecore-net-search-openai-1536-production-v3` だけに変更します。
- v3の全量同期・ID集合一致・query canaryが完了するまで、Production `SEARCH_INDEX` bindingは現行の正規名indexへ維持します。
- 現行indexと削除済みv2を同期対象として拒否する回帰テスト、移行中の運用状態を追加します。

## 確認

- `volta run --node 24.18.0 npm ci`
- `volta run --node 24.18.0 npm run typecheck:vectorize-sync`
- `volta run --node 24.18.0 npm run test:search`（51件成功）
- `volta run --node 24.18.0 npm run check:pages-config`
- `volta run --node 24.18.0 npm run types:cloudflare:check`
- `volta run --node 24.18.0 npm run typecheck:functions`
- `volta run --node 24.18.0 npm run validate:content`
- `volta run --node 24.18.0 npm run format:check`
- `volta run --node 24.18.0 npm run build`（199ページ、99 sources・341 vectors、corpus version `fb4719c375f8cc38ab7d`）
- `volta run --node 24.18.0 npm run validate:seo`（108 URL成功）
- `git diff --check`

## 補足

このPRのmerge後、protected mainのProduction workflowがv3を1536次元・cosineで作成し、公開corpusを全量同期します。v3のID集合一致とquery canaryを確認してから、別のレビュー済みPRでProduction bindingを切り替えます。現行indexはロールバック用に保持し、このPRでは削除しません。