### PR TITLE
翻訳Botの廃止予定 App ID 入力を解消

### DIFF
--- a/.github/workflows/collect-openai-translation-batch.yml
+++ b/.github/workflows/collect-openai-translation-batch.yml
@@ -66,11 +66,11 @@ jobs:
         id: bot
         if: steps.collector.outputs.has_changes == 'true'
         env:
-          APP_ID: ${{ secrets.TRANSLATION_BOT_APP_ID }}
+          CLIENT_ID: ${{ secrets.TRANSLATION_BOT_CLIENT_ID }}
           PRIVATE_KEY: ${{ secrets.TRANSLATION_BOT_APP_PRIVATE_KEY }}
         run: |
-          if [ -z "$APP_ID" ] || [ -z "$PRIVATE_KEY" ]; then
-            echo "::warning::TRANSLATION_BOT_APP_ID and TRANSLATION_BOT_APP_PRIVATE_KEY are required before a translation PR can be created."
+          if [ -z "$CLIENT_ID" ] || [ -z "$PRIVATE_KEY" ]; then
+            echo "::warning::TRANSLATION_BOT_CLIENT_ID and TRANSLATION_BOT_APP_PRIVATE_KEY are required before a translation PR can be created."
             echo "ready=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -81,7 +81,7 @@ jobs:
         if: steps.bot.outputs.ready == 'true'
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.TRANSLATION_BOT_APP_ID }}
+          client-id: ${{ secrets.TRANSLATION_BOT_CLIENT_ID }}
           private-key: ${{ secrets.TRANSLATION_BOT_APP_PRIVATE_KEY }}
 
       - name: Commit current translation results

--- a/.github/workflows/merge-translation-pr.yml
+++ b/.github/workflows/merge-translation-pr.yml
@@ -62,7 +62,7 @@ jobs:
         if: steps.pr.outputs.numbers != ''
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.TRANSLATION_BOT_APP_ID }}
+          client-id: ${{ secrets.TRANSLATION_BOT_CLIENT_ID }}
           private-key: ${{ secrets.TRANSLATION_BOT_APP_PRIVATE_KEY }}
 
       - name: Set up Node.js

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Sveltia CMSまたは通常のGit commitで日本語の記事・固定ページ�
 - Model: `gpt-5.6-luna`、reasoning effort `max`
 - Trigger: `src/content/blog/*.md` または `src/i18n/source/ja/**/*.json` の`main`反映時
 - API secret: `OPENAI_TRANSLATION_API_KEY`
-- PR作成用GitHub App secrets: `TRANSLATION_BOT_APP_ID`、`TRANSLATION_BOT_APP_PRIVATE_KEY`
+- PR作成用GitHub App secrets: `TRANSLATION_BOT_CLIENT_ID`、`TRANSLATION_BOT_APP_PRIVATE_KEY`
 
 ### 翻訳PRの検証と自動マージ
 

--- a/tests/openai-translation-batch.test.ts
+++ b/tests/openai-translation-batch.test.ts
@@ -83,7 +83,12 @@ test('WorkflowはLuna/maxをBatchへ投入し、回収後にBot PRを作る', as
   assert.match(submitWorkflow, /sleep 900/u)
   assert.doesNotMatch(submitWorkflow, /cms_only|cms-only/u)
   assert.match(collectWorkflow, /translation\/openai\//u)
-  assert.match(collectWorkflow, /TRANSLATION_BOT_APP_ID/u)
+  assert.match(
+    collectWorkflow,
+    /client-id:\s+\$\{\{ secrets\.TRANSLATION_BOT_CLIENT_ID \}\}/u,
+  )
+  assert.doesNotMatch(collectWorkflow, /TRANSLATION_BOT_APP_ID/u)
+  assert.doesNotMatch(collectWorkflow, /^\s+app-id:/mu)
   assert.match(collectWorkflow, /openai-translation-processed-/u)
   assert.match(collectWorkflow, /Format collected translation files/u)
   assert.match(collectWorkflow, /git diff --name-only --diff-filter=ACMRT -z/u)

--- a/tests/translation-merge.test.ts
+++ b/tests/translation-merge.test.ts
@@ -414,6 +414,12 @@ test('成功した翻訳buildとmain更新の両方で翻訳PRを再評価する
   assert.match(workflow, /actions\/create-github-app-token@v3/u)
   assert.match(
     workflow,
+    /client-id:\s+\$\{\{ secrets\.TRANSLATION_BOT_CLIENT_ID \}\}/u,
+  )
+  assert.doesNotMatch(workflow, /TRANSLATION_BOT_APP_ID/u)
+  assert.doesNotMatch(workflow, /^\s+app-id:/mu)
+  assert.match(
+    workflow,
     /GITHUB_TOKEN: \$\{\{ steps\.app-token\.outputs\.token \}\}/u,
   )
   assert.match(workflow, /Enable auto-merge for eligible translation PR/u)


### PR DESCRIPTION
関連 Issue: なし

## 概要

- `actions/create-github-app-token@v3` の廃止予定 `app-id` 入力を `client-id` へ移行
- 翻訳PR作成と自動マージの両方を `TRANSLATION_BOT_CLIENT_ID` に統一
- README のsecret案内と、旧入力への回帰を防ぐテストを更新

Action v3 は `app-id` に `Use 'client-id' instead.` のdeprecation warningを設定しており、2つの翻訳workflowが旧入力を使っていたことが原因です。App、秘密鍵、権限、翻訳PRの作成・自動マージ条件は変更しません。

## 確認

- `volta run --node 24.18.0 npm run test:translation-merge`（12件成功）
- `volta run --node 24.18.0 npm run test:openai-translation`（5件成功）
- `tsc --project tsconfig.translation-merge.json`
- `tsc --project tsconfig.openai-translation.json`
- 対象5ファイルのPrettier check
- `git diff --check`
- `TRANSLATION_BOT_CLIENT_ID` のActions secret登録を確認
- `npm run build` は未実施（workflow、テスト、READMEだけの変更でサイト出力に影響しないため）

## 補足

既存の `TRANSLATION_BOT_APP_ID` secret はロールバック用に残しています。
