### PR TITLE
iPhoneでチャット入力時の自動拡大を防ぐ

### DIFF
--- a/src/components/AiChatWidget.astro
+++ b/src/components/AiChatWidget.astro
@@ -84,7 +84,7 @@ const phoneParts = SITE.phone.split('-')
           id="ace-ai-chat-input"
           rows="2"
           maxlength="800"
-          class="ac-input min-h-11 flex-1 resize-none text-sm"
+          class="ac-input min-h-11 flex-1 resize-none text-base"
           placeholder={t(locale, 'aiChat.placeholder')}></textarea>
         <button
           type="submit"

--- a/tests/ai-contact.test.mjs
+++ b/tests/ai-contact.test.mjs
@@ -27,6 +27,18 @@ const SOURCE_NAMES = [
 
 let requestSequence = 0
 
+test('チャット入力欄をiPhoneの自動拡大が起きない16pxで表示する', () => {
+  const component = readFileSync(
+    new URL('../src/components/AiChatWidget.astro', import.meta.url),
+    'utf8',
+  )
+
+  assert.match(
+    component,
+    /<textarea[\s\S]*?id="ace-ai-chat-input"[\s\S]*?class="[^"]*\btext-base\b[^"]*"/u,
+  )
+})
+
 async function onRequestPost(context) {
   const env = {
     SEARCH_RATE_LIMIT_DB: createAlwaysAllowRateLimitDatabase(),


### PR DESCRIPTION
関連 Issue: なし

## 概要

- 公式サイトのAIチャット入力欄を `text-sm`（14px）から `text-base`（16px）へ変更
- iPhone Safariで入力フォーカス時にページが自動拡大される条件を解消
- 16px相当のクラスを維持する回帰テストを追加

## 確認

- `npm run test:ai-chat`（95件成功）
- `npx prettier --check src/components/AiChatWidget.astro tests/ai-contact.test.mjs`
- `npm run build`
- Browser: 390×844 / 1280×800でチャットを開き、入力欄へフォーカス
  - computed font-size: 16px
  - visualViewport.scale: 1
  - 横切れ・console error/warn: なし

## 補足

実機iPhone Safariでの操作確認は未実施です。