### PR TITLE
fix: 検索対象外の管理画面とAPIをクロール除外

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:cms-auth": "node --experimental-strip-types --test tests/sveltia-cms-auth.test.ts",
     "test:ai-chat": "node --experimental-strip-types --test tests/ai-contact.test.mjs",
     "test:contact": "node --experimental-strip-types --test tests/contact-api.test.mjs tests/contact-page-turnstile.test.mjs tests/specialist-url.test.mjs",
-    "test:site-config": "node --experimental-strip-types --test --test-isolation=none tests/monetized-blog-path.test.mjs && node --experimental-strip-types --test --test-isolation=none tests/search-modal-spa-style.test.mjs && node --test --test-isolation=none tests/pagefind-headers.test.mjs",
+    "test:site-config": "node --experimental-strip-types --test --test-isolation=none tests/monetized-blog-path.test.mjs && node --experimental-strip-types --test --test-isolation=none tests/search-modal-spa-style.test.mjs && node --test --test-isolation=none tests/pagefind-headers.test.mjs tests/robots-crawl-boundaries.test.mjs",
     "test:deployment-marker": "node --experimental-strip-types --test tests/deployment-marker.test.ts",
     "test:search": "node --experimental-strip-types --test tests/deployment-marker.test.ts tests/search-api.test.mjs tests/network-search-api.test.mjs tests/search-corpus.test.mjs tests/vectorize-sync.test.mjs tests/vectorize-workflow.test.mjs",
     "sync:vectorize": "node --experimental-strip-types scripts/sync-vectorize.ts",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,9 @@
 User-agent: *
 Allow: /
+
+# CMS と API は利用者向けの検索コンテンツではないため、crawl 対象にしない。
+Disallow: /admin/
+Disallow: /api/
 Disallow: /pagefind/
 
 Sitemap: https://acecore.net/sitemap-index.xml

--- a/tests/robots-crawl-boundaries.test.mjs
+++ b/tests/robots-crawl-boundaries.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+
+const ROBOTS_URL = new URL('../public/robots.txt', import.meta.url)
+
+function getUniversalCrawlerDirectives(source) {
+  const directives = new Map()
+  let inUniversalGroup = false
+
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const separator = line.indexOf(':')
+    if (separator === -1) continue
+
+    const name = line.slice(0, separator).trim().toLowerCase()
+    const value = line.slice(separator + 1).trim()
+
+    if (name === 'user-agent') {
+      inUniversalGroup = value === '*'
+      continue
+    }
+
+    if (!inUniversalGroup) continue
+    const values = directives.get(name) ?? []
+    values.push(value)
+    directives.set(name, values)
+  }
+
+  return directives
+}
+
+test('検索対象外の管理画面と API は crawler に公開しない', async () => {
+  const directives = getUniversalCrawlerDirectives(
+    await readFile(ROBOTS_URL, 'utf8'),
+  )
+
+  assert.deepEqual(directives.get('allow'), ['/'])
+  assert.deepEqual([...directives.get('disallow')].sort(), [
+    '/admin/',
+    '/api/',
+    '/pagefind/',
+  ])
+  assert.deepEqual(directives.get('sitemap'), [
+    'https://acecore.net/sitemap-index.xml',
+  ])
+})


### PR DESCRIPTION
関連 Issue: なし

## 概要

- 検索対象外の `/admin/` と `/api/` を robots.txt でクロール除外。
- ルールを固定する回帰テストを site-config テストへ追加。

## 確認

- `npm run test:site-config`
- `npx prettier --check package.json tests/robots-crawl-boundaries.test.mjs`
- `npm run build`
- `npm run validate:seo`
- `git diff --check`

## 補足

- 本番 sitemap の 107 URL はすべて 200 を確認済み。
- Search Console はこの環境で未ログインのため、修正後の検証開始は未実施。