### PR TITLE
夜間翻訳をWorkers AI Batchへ移行（本番対象外）

### DIFF
--- a/.github/workflows/collect-openai-translation-batch.yml
+++ b/.github/workflows/collect-openai-translation-batch.yml
@@ -1,4 +1,4 @@
-name: Collect OpenAI Translation Batch
+name: Collect Workers AI Translation Batch
 
 on:
   schedule:
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Type-check OpenAI translation automation
+      - name: Type-check Workers AI translation automation
         run: npm run typecheck:openai-translation
 
       - name: Find processed batches
@@ -38,21 +38,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ids="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | .name' | sed -n 's/^openai-translation-processed-//p' | paste -sd, - || true)"
+          ids="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | .name' | sed -n 's/^workers-ai-translation-processed-//p' | paste -sd, - || true)"
+          echo "ids=${ids}" >> "$GITHUB_OUTPUT"
+
+      - name: Find pending batches
+        id: pending
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ids="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.expired == false) | .name' | sed -n 's/^workers-ai-translation-pending-//p' | paste -sd, - || true)"
           echo "ids=${ids}" >> "$GITHUB_OUTPUT"
 
       - name: Collect one completed batch
         id: collector
         env:
-          OPENAI_TRANSLATION_API_KEY: ${{ secrets.OPENAI_TRANSLATION_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_WORKERS_AI_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_AI_API_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          if [ -z "$OPENAI_TRANSLATION_API_KEY" ]; then
-            echo "::warning::OPENAI_TRANSLATION_API_KEY is not configured; no Batch was collected."
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ] || [ -z "$CLOUDFLARE_WORKERS_AI_API_TOKEN" ]; then
+            echo "::warning::CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_WORKERS_AI_API_TOKEN are not configured; no Batch was collected."
             exit 0
           fi
-          node --experimental-strip-types scripts/openai-translation-batch.ts collect --processed-batches="${{ steps.processed.outputs.ids }}"
+          node --experimental-strip-types scripts/openai-translation-batch.ts collect --pending-batches="${{ steps.pending.outputs.ids }}" --processed-batches="${{ steps.processed.outputs.ids }}"
 
       - name: Format collected translation files
         if: steps.collector.outputs.has_changes == 'true'
@@ -91,7 +100,7 @@ jobs:
           TRANSLATION_BOT_TOKEN: ${{ steps.app-token.outputs.token }}
           BATCH_ID: ${{ steps.collector.outputs.batch_id }}
         run: |
-          branch="translation/openai/${BATCH_ID}"
+          branch="translation/workers-ai/${BATCH_ID}"
           git switch -c "$branch"
           git config user.name "Acecore Translation Bot"
           git config user.email "translation-bot@users.noreply.github.com"
@@ -115,7 +124,7 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --draft \
-            --title "[translation] OpenAI Batch ${BATCH_ID}" \
+            --title "[translation] Workers AI Batch ${BATCH_ID}" \
             --body-file "$BODY_PATH"
 
       - name: Mark batch as processed
@@ -125,6 +134,6 @@ jobs:
           (steps.collector.outputs.has_changes != 'true' || steps.bot.outputs.ready == 'true')
         uses: actions/upload-artifact@v7
         with:
-          name: openai-translation-processed-${{ steps.collector.outputs.processed_batch_id }}
+          name: workers-ai-translation-processed-${{ steps.collector.outputs.processed_batch_id }}
           path: ${{ steps.collector.outputs.marker_path }}
           retention-days: 30

--- a/.github/workflows/merge-translation-pr.yml
+++ b/.github/workflows/merge-translation-pr.yml
@@ -37,7 +37,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             numbers="${{ inputs.pr_number }}"
           elif [ "${{ github.event_name }}" = "push" ]; then
-            numbers="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/pulls?state=open&base=main&per_page=100" --jq '.[] | select(.head.ref | startswith("translation/openai/")) | .number')"
+            numbers="$(gh api --paginate "/repos/${GITHUB_REPOSITORY}/pulls?state=open&base=main&per_page=100" --jq '.[] | select(.head.ref | startswith("translation/openai/") or startswith("translation/workers-ai/")) | .number')"
           else
             numbers="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
             if [ -z "$numbers" ]; then

--- a/.github/workflows/submit-openai-translation-batch.yml
+++ b/.github/workflows/submit-openai-translation-batch.yml
@@ -1,4 +1,4 @@
-name: Submit OpenAI Translation Batch
+name: Submit Workers AI Translation Batch
 
 on:
   push:
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Type-check OpenAI translation automation
+      - name: Type-check Workers AI translation automation
         run: npm run typecheck:openai-translation
 
       - name: Wait for follow-up edits to the same source
@@ -51,14 +51,16 @@ jobs:
         run: git fetch origin main:refs/remotes/origin/main --depth=1
 
       - name: Submit current translation requests
+        id: submitter
         env:
-          OPENAI_TRANSLATION_API_KEY: ${{ secrets.OPENAI_TRANSLATION_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_WORKERS_AI_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_AI_API_TOKEN }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          if [ -z "$OPENAI_TRANSLATION_API_KEY" ]; then
-            echo "::warning::OPENAI_TRANSLATION_API_KEY is not configured; no translation Batch was submitted."
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ] || [ -z "$CLOUDFLARE_WORKERS_AI_API_TOKEN" ]; then
+            echo "::warning::CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_WORKERS_AI_API_TOKEN are not configured; no translation Batch was submitted."
             exit 0
           fi
 
@@ -72,3 +74,11 @@ jobs:
           args+=("--current-ref=origin/main")
 
           node --experimental-strip-types scripts/openai-translation-batch.ts "${args[@]}"
+
+      - name: Preserve pending Workers AI batch ID
+        if: steps.submitter.outputs.batch_id != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: workers-ai-translation-pending-${{ steps.submitter.outputs.batch_id }}
+          path: ${{ steps.submitter.outputs.pending_marker_path }}
+          retention-days: 30

--- a/.github/workflows/translation-pr-build.yml
+++ b/.github/workflows/translation-pr-build.yml
@@ -23,8 +23,10 @@ jobs:
   build:
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      ((startsWith(github.event.pull_request.head.ref, 'translation/workers-ai/') &&
+      startsWith(github.event.pull_request.title, '[translation] Workers AI Batch ')) ||
       (startsWith(github.event.pull_request.head.ref, 'translation/openai/') &&
-      startsWith(github.event.pull_request.title, '[translation] OpenAI Batch '))
+      startsWith(github.event.pull_request.title, '[translation] OpenAI Batch ')))
     runs-on: ubuntu-latest
     steps:
       - name: Resolve pull request metadata
@@ -48,8 +50,10 @@ jobs:
       - name: Stop if manual target is not an eligible translation PR
         if: >-
           github.event_name == 'workflow_dispatch' &&
-          (!startsWith(steps.pr.outputs.head_ref, 'translation/openai/') ||
-          !startsWith(steps.pr.outputs.title, '[translation] OpenAI Batch '))
+          !((startsWith(steps.pr.outputs.head_ref, 'translation/workers-ai/') &&
+          startsWith(steps.pr.outputs.title, '[translation] Workers AI Batch ')) ||
+          (startsWith(steps.pr.outputs.head_ref, 'translation/openai/') &&
+          startsWith(steps.pr.outputs.title, '[translation] OpenAI Batch ')))
         run: |
           echo "The specified PR is not an eligible translation PR."
           exit 1

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Acecore（エースコア）公式Webサイト。
 - その他のロケールは `/{locale}/blog/...` のパスで配信
 - ブログ記事の翻訳は `src/content/blog/{locale}/` に配置
 - Sveltia CMS では日本語ソース記事、日本語ページ文言、著者、タグを管理
-- 日本語の記事・ページ文言の更新はOpenAI Batchで8ロケールへ翻訳
+- 日本語の記事・ページ文言の更新はWorkers AI Batchで8ロケールへ翻訳
 - UI・固定ページ文字列は日本語ソースを `src/i18n/source/ja/`、翻訳先を `src/i18n/translations/` で管理し、Sveltia CMS の「ページ・サイト文言」からページ/用途別に編集
 
 ## 開発
@@ -107,7 +107,7 @@ src/
 5. 「ページ・サイト文言」からナビ、フッター、SEO、固定ページの日本語テキストをページ/用途別に編集
 6. 「告知・キャンペーン」からトップ告知バナーやページ内キャンペーン通知を編集
 7. 著者・タグは「著者」「タグ」から編集
-8. 日本語ソースの更新はOpenAI Batchで翻訳へ反映
+8. 日本語ソースの更新はWorkers AI Batchで翻訳へ反映
 
 #### 本番 CMS の保存と自動公開
 
@@ -160,25 +160,26 @@ author: 'author-id'
 
 ## 翻訳ワークフロー
 
-Sveltia CMSまたは通常のGit commitで日本語の記事・固定ページ文言が`main`へ反映されると、OpenAI Batchを使って8ロケールの翻訳を更新します。
+Sveltia CMSまたは通常のGit commitで日本語の記事・固定ページ文言が`main`へ反映されると、Workers AI Batchを使って8ロケールの翻訳を更新します。
 
 1. `.github/workflows/submit-openai-translation-batch.yml` が日本語sourceの更新を検出する
-2. 同じsourceへの続けての修正をまとめるため15分待ち、最新の`main`と一致する変更だけをOpenAI Batchへ投入する
+2. 同じsourceへの続けての修正をまとめるため15分待ち、最新の`main`と一致する変更だけをWorkers AI Batchへ投入する
 3. `.github/workflows/collect-openai-translation-batch.yml` が完了済みBatchを15分間隔で回収する
-4. 専用GitHub Appが`translation/openai/{batchId}` branchとDraft PRを作成する
+4. 専用GitHub Appが`translation/workers-ai/{requestId}` branchとDraft PRを作成する
 5. `Translation PR Build`が成功し、source hashが現在の日本語sourceと一致する場合だけDraftを解除してGitHubのAuto-mergeを予約する
 6. behindの場合は検証したHEAD SHAを指定して最新の`main`を取り込み、required checkの`Build and Format`が成功した時点でGitHubがsquash mergeする
 
 翻訳記事は日本語ソースの`articleId`をそのまま引き継ぎます。Batch投入後に同じsourceが再編集された場合は、古い結果と古い翻訳PRを取り込まず破棄します。
 
-### OpenAI Batch workflow
+### Workers AI Batch workflow
 
 - Workflow: `.github/workflows/submit-openai-translation-batch.yml`
 - Workflow: `.github/workflows/collect-openai-translation-batch.yml`
 - Script: `scripts/openai-translation-batch.ts`
-- Model: `gpt-5.6-luna`、reasoning effort `max`
+- Model: `@cf/zai-org/glm-5.3-flash`、reasoning effort `high`
 - Trigger: `src/content/blog/*.md` または `src/i18n/source/ja/**/*.json` の`main`反映時
-- API secret: `OPENAI_TRANSLATION_API_KEY`
+- Cloudflare account variable: `CLOUDFLARE_ACCOUNT_ID`
+- API secret: `CLOUDFLARE_WORKERS_AI_API_TOKEN`（Workers AIを実行できる最小権限のtoken）
 - PR作成用GitHub App secrets: `TRANSLATION_BOT_CLIENT_ID`、`TRANSLATION_BOT_APP_PRIVATE_KEY`
 
 ### 翻訳PRの検証と自動マージ
@@ -186,7 +187,7 @@ Sveltia CMSまたは通常のGit commitで日本語の記事・固定ページ�
 - Workflow: `.github/workflows/translation-pr-build.yml`
 - Workflow: `.github/workflows/merge-translation-pr.yml`
 - Script: `scripts/merge-translation-pr.ts`
-- 対象は専用Translation Botが同一repositoryの`translation/openai/` branchから作成し、1件以上の有効なsource markerを持つ`[translation] OpenAI Batch ...` PRだけ
+- 対象は専用Translation Botが同一repositoryの`translation/workers-ai/` branchから作成し、1件以上の有効なsource markerを持つ`[translation] Workers AI Batch ...` PRだけ。移行前に投入済みの旧OpenAI Batch PRだけは互換対象として受け付ける
 - 変更できるpathは8ロケールの`src/content/blog/{locale}/*.md`と`src/i18n/translations/{locale}.json`だけ
 - Batch回収時に変更・追加された翻訳ファイルだけをPrettierで整形してからcommitする
 - `Translation PR Build`の成功と現在のsource hashを再確認してからDraftを解除し、GitHubのAuto-mergeをsquashで予約する

--- a/docs/04_運用設計/01_CMS保存・自動公開運用.md
+++ b/docs/04_運用設計/01_CMS保存・自動公開運用.md
@@ -75,13 +75,13 @@ direct publishには、一般のコード変更に対する保護を維持しな
 
 ## 翻訳workflow
 
-direct commitのsubjectは`cms: create|update|delete|upload ...`形式を維持します。`.github/workflows/submit-openai-translation-batch.yml`は日本語sourceの`main`更新を検出し、続けての修正をまとめるため15分待ってから、最新の`main`と一致する変更だけをOpenAI Batchへ投入します。
+direct commitのsubjectは`cms: create|update|delete|upload ...`形式を維持します。`.github/workflows/submit-openai-translation-batch.yml`は日本語sourceの`main`更新を検出し、続けての修正をまとめるため15分待ってから、最新の`main`と一致する変更だけをWorkers AI Batchへ投入します。
 
 専用GitHub App installation tokenによるpushはGitHub Actionsを起動します。`GITHUB_TOKEN`による保存へ置き換えると後続workflowが抑止されるため使用しません。
 
-翻訳記事は日本語sourceと同じslug・`articleId`を維持します。日本語sourceのslug変更はCMSで旧path削除と新path追加を1 commitで行い、OpenAI Batchの結果を回収する際に全localeの旧path削除・新path追加・`articleId`維持を同じ翻訳PRへ反映します。source hashが現在の日本語sourceと異なる古い結果やPRは取り込みません。
+翻訳記事は日本語sourceと同じslug・`articleId`を維持します。日本語sourceのslug変更はCMSで旧path削除と新path追加を1 commitで行い、Workers AI Batchの結果を回収する際に全localeの旧path削除・新path追加・`articleId`維持を同じ翻訳PRへ反映します。source hashが現在の日本語sourceと異なる古い結果やPRは取り込みません。
 
-Batch回収時は変更・追加された翻訳ファイルだけをPrettierで整形してからcommitします。自動マージ対象は専用Translation Botが同一repositoryの`translation/openai/` branchと所定タイトルを使って作成し、1件以上の有効なsource markerを持つ翻訳PRだけです。変更pathも8ロケールの翻訳Markdownと翻訳JSONだけに限定します。`Translation PR Build`の成功とsource hashを再確認し、behindなら検証したHEAD SHAと専用GitHub App tokenを使ってupdate branch APIで`main`を取り込み、後続CIを起動します。追従後にDraftを解除してGitHubのAuto-mergeを予約し、required checkの`Build and Format`とbranch protectionを満たした時点でsquash mergeします。`main`更新時にも未完了の翻訳PRを再評価します。repository設定ではAuto-mergeとhead branchの自動削除を有効にしておきます。
+Batch回収時は変更・追加された翻訳ファイルだけをPrettierで整形してからcommitします。自動マージ対象は専用Translation Botが同一repositoryの`translation/workers-ai/` branchと所定タイトルを使って作成し、1件以上の有効なsource markerを持つ翻訳PRだけです。移行前に投入済みの`translation/openai/` PRは互換対象として回収できます。変更pathも8ロケールの翻訳Markdownと翻訳JSONだけに限定します。`Translation PR Build`の成功とsource hashを再確認し、behindなら検証したHEAD SHAと専用GitHub App tokenを使ってupdate branch APIで`main`を取り込み、後続CIを起動します。追従後にDraftを解除してGitHubのAuto-mergeを予約し、required checkの`Build and Format`とbranch protectionを満たした時点でsquash mergeします。`main`更新時にも未完了の翻訳PRを再評価します。repository設定ではAuto-mergeとhead branchの自動削除を有効にしておきます。
 
 ## 検証
 

--- a/docs/04_運用設計/02_Vectorize検索・AI横断検索運用.md
+++ b/docs/04_運用設計/02_Vectorize検索・AI横断検索運用.md
@@ -205,7 +205,7 @@ indexを作り直す場合は、現在のindexを停止・削除する前に別�
 - [text-embedding-3-large](https://developers.openai.com/api/docs/models/text-embedding-3-large)
 - [Embeddings guide](https://developers.openai.com/api/docs/guides/embeddings)
 - [GLM 5.3 Flash](https://developers.cloudflare.com/workers-ai/models/glm-5.3-flash/)
-- [Workers AI](https://developers.cloudflare.com/workers-ai/)
+- [Workers AI Batch REST API](https://developers.cloudflare.com/workers-ai/features/batch-api/rest-api/)
 - [Pages Functions bindings](https://developers.cloudflare.com/pages/functions/bindings/)
 - [Pages Wrangler configuration](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)
 - [D1](https://developers.cloudflare.com/d1/)

--- a/scripts/merge-translation-pr.ts
+++ b/scripts/merge-translation-pr.ts
@@ -74,7 +74,14 @@ interface MergeAutomationOptions {
 
 const GITHUB_API_URL = 'https://api.github.com'
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/i
-const OPENAI_TRANSLATION_TITLE_PREFIX = '[translation] OpenAI Batch '
+const TRANSLATION_TITLE_PREFIXES = [
+  '[translation] Workers AI Batch ',
+  '[translation] OpenAI Batch ',
+] as const
+const TRANSLATION_BRANCH_PREFIXES = [
+  'translation/workers-ai/',
+  'translation/openai/',
+] as const
 const OPENAI_TRANSLATION_BOT_LOGIN = 'acecore-translation-bot[bot]'
 const TRANSLATION_CONTENT_PATH_PATTERN =
   /^src\/content\/blog\/(?:en|zh-cn|es|pt|fr|ko|de|ru)\/.+\.md$/u
@@ -449,8 +456,12 @@ export function isEligibleTranslationPullRequest(
     pullRequest.authorLogin === OPENAI_TRANSLATION_BOT_LOGIN &&
     pullRequest.headRepositoryFullName?.toLowerCase() ===
       repository.repository.toLowerCase() &&
-    pullRequest.headRef?.startsWith('translation/openai/') === true &&
-    pullRequest.title.startsWith(OPENAI_TRANSLATION_TITLE_PREFIX)
+    TRANSLATION_BRANCH_PREFIXES.some((prefix) =>
+      pullRequest.headRef?.startsWith(prefix),
+    ) &&
+    TRANSLATION_TITLE_PREFIXES.some((prefix) =>
+      pullRequest.title.startsWith(prefix),
+    )
   )
 }
 
@@ -464,7 +475,7 @@ async function closePullRequest(
     `/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/pulls/${pullRequest.number}`,
     { method: 'PATCH', body: { state: 'closed' } },
   )
-  logger.log(`Closed stale OpenAI translation PR #${pullRequest.number}.`)
+  logger.log(`Closed stale translation PR #${pullRequest.number}.`)
 }
 
 export function hasSuccessfulTranslationBuild(

--- a/scripts/openai-translation-batch.ts
+++ b/scripts/openai-translation-batch.ts
@@ -11,11 +11,10 @@ import {
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const API_BASE_URL = 'https://api.openai.com/v1'
-const BATCH_MODEL = 'gpt-5.6-luna'
-const BATCH_ENDPOINT = '/v1/responses'
-const BATCH_METADATA_KEY = 'translation_system'
-const BATCH_METADATA_VALUE = 'acecore-net-v1'
+const API_BASE_URL = 'https://api.cloudflare.com/client/v4'
+const BATCH_MODEL = '@cf/zai-org/glm-5.3-flash'
+const BATCH_REASONING_EFFORT = 'high'
+const MAX_BATCH_PAYLOAD_BYTES = 10 * 1024 * 1024
 const CUSTOM_ID_PREFIX = 'acecore-net:'
 const SOURCE_MARKER_PREFIX = '<!-- openai-translation-source:'
 const SOURCE_MARKER_SUFFIX = ' -->'
@@ -30,16 +29,6 @@ interface JsonRecord {
   [key: string]: JsonValue
 }
 type JsonValue = JsonPrimitive | JsonValue[] | JsonRecord
-type BatchStatus =
-  | 'validating'
-  | 'failed'
-  | 'in_progress'
-  | 'finalizing'
-  | 'completed'
-  | 'expired'
-  | 'cancelling'
-  | 'cancelled'
-
 type ChangeStatus = 'A' | 'C' | 'D' | 'M' | 'R' | string
 type TranslationKind = 'blog' | 'blog-delete' | 'site' | 'site-delete'
 
@@ -59,39 +48,31 @@ interface RequestMetadata {
 }
 
 interface BatchInputLine {
-  custom_id: string
-  method: 'POST'
-  url: typeof BATCH_ENDPOINT
-  body: JsonRecord
-}
-
-interface OpenAiFile {
-  id: string
-}
-
-interface OpenAiBatch {
-  id: string
-  status: BatchStatus
-  output_file_id: string | null
-  metadata: Record<string, string> | null
-  created_at: number
-  completed_at?: number | null
-}
-
-interface OpenAiBatchList {
-  data: OpenAiBatch[]
+  external_reference: string
+  messages: Array<{ role: 'system' | 'user'; content: string }>
+  reasoning_effort: typeof BATCH_REASONING_EFFORT
+  max_completion_tokens: number
+  response_format: JsonRecord
+  store: false
 }
 
 interface BatchOutputLine {
-  custom_id: string
-  response: {
-    status_code: number
-    body: JsonRecord
-  } | null
-  error: {
-    code?: string | null
-    message?: string | null
-  } | null
+  external_reference: string
+  result?: JsonRecord
+  success: boolean
+}
+
+interface CloudflareBatchResult {
+  model?: string
+  request_id?: string
+  responses?: BatchOutputLine[]
+  status?: string
+}
+
+interface CloudflareBatchEnvelope {
+  errors?: Array<{ code?: number; message?: string }>
+  result?: CloudflareBatchResult
+  success: boolean
 }
 
 interface TranslationEntry {
@@ -124,6 +105,7 @@ interface ParsedArgs {
   headSha: string | null
   currentRef: string | null
   processedBatchIds: Set<string>
+  pendingBatchIds: string[]
   prNumber: number | null
 }
 
@@ -183,6 +165,7 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
     headSha: null,
     currentRef: null,
     processedBatchIds: new Set(),
+    pendingBatchIds: [],
     prNumber: null,
   }
 
@@ -209,6 +192,15 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
         .map((value) => value.trim())
         .filter(Boolean)
       parsed.processedBatchIds = new Set(values)
+      continue
+    }
+
+    if (argument.startsWith('--pending-batches=')) {
+      parsed.pendingBatchIds = argument
+        .slice('--pending-batches='.length)
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
       continue
     }
 
@@ -825,9 +817,11 @@ function parseSourceMarkers(
 function createResponseFormat(name: string, schema: JsonRecord): JsonRecord {
   return {
     type: 'json_schema',
-    name,
-    strict: true,
-    schema,
+    json_schema: {
+      name,
+      strict: true,
+      schema,
+    },
   }
 }
 
@@ -886,37 +880,45 @@ function createBlogBatchRequest(
   }
 
   return {
-    custom_id: encodeMetadata(metadata),
-    method: 'POST',
-    url: BATCH_ENDPOINT,
-    body: {
-      model: BATCH_MODEL,
-      reasoning: { effort: 'max' },
-      max_output_tokens: 32768,
-      instructions:
-        'Translate the supplied Japanese Acecore blog content into the requested locale. Return JSON only. Translate title, description, and Markdown body. Keep description between 50 and 160 Unicode characters so it can be used as a meta description. Preserve external URLs, placeholders such as {count}, code fences, image references, factual names, and Markdown structure. Do not include YAML frontmatter.',
-      input: JSON.stringify({
-        targetLocale: metadata.locale,
-        source: {
-          title: sourceTitle,
-          description: sourceDescription,
-          body: sourceDocument.body,
-        },
-        current: currentDocument
-          ? {
-              title: getFrontmatterString(currentDocument.frontmatter, 'title'),
-              description: getFrontmatterString(
-                currentDocument.frontmatter,
-                'description',
-              ),
-              body: currentDocument.body,
-            }
-          : null,
-      }),
-      text: {
-        format: createResponseFormat('blog_translation', BLOG_RESPONSE_SCHEMA),
+    external_reference: encodeMetadata(metadata),
+    messages: [
+      {
+        role: 'system',
+        content:
+          'Translate the supplied Japanese Acecore blog content into the requested locale. Return JSON only. Translate title, description, and Markdown body. Keep description between 50 and 160 Unicode characters so it can be used as a meta description. Preserve external URLs, placeholders such as {count}, code fences, image references, factual names, and Markdown structure. Do not include YAML frontmatter.',
       },
-    },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          targetLocale: metadata.locale,
+          source: {
+            title: sourceTitle,
+            description: sourceDescription,
+            body: sourceDocument.body,
+          },
+          current: currentDocument
+            ? {
+                title: getFrontmatterString(
+                  currentDocument.frontmatter,
+                  'title',
+                ),
+                description: getFrontmatterString(
+                  currentDocument.frontmatter,
+                  'description',
+                ),
+                body: currentDocument.body,
+              }
+            : null,
+        }),
+      },
+    ],
+    reasoning_effort: BATCH_REASONING_EFFORT,
+    max_completion_tokens: 32768,
+    response_format: createResponseFormat(
+      'blog_translation',
+      BLOG_RESPONSE_SCHEMA,
+    ),
+    store: false,
   }
 }
 
@@ -934,111 +936,97 @@ function createSiteBatchRequest(
   }
 
   return {
-    custom_id: encodeMetadata(metadata),
-    method: 'POST',
-    url: BATCH_ENDPOINT,
-    body: {
-      model: BATCH_MODEL,
-      reasoning: { effort: 'max' },
-      max_output_tokens: 32768,
-      instructions:
-        'Translate each Japanese string into the requested locale. Return JSON only. Keep each id unchanged. For SEO metadata ids /description, /indexDescription, /pageDescription, /tagListDescription, and /archiveListDescription, keep the translation between 50 and 160 Unicode characters. Preserve placeholders such as {count}, URLs embedded in a string, product names, route paths, and code-like tokens exactly. Use the current translation as terminology context, but return one translation for every supplied id.',
-      input: JSON.stringify({
-        targetLocale: metadata.locale,
-        sourcePath: metadata.sourcePath,
-        entries,
-      }),
-      text: {
-        format: createResponseFormat('site_translation', SITE_RESPONSE_SCHEMA),
+    external_reference: encodeMetadata(metadata),
+    messages: [
+      {
+        role: 'system',
+        content:
+          'Translate each Japanese string into the requested locale. Return JSON only. Keep each id unchanged. For SEO metadata ids /description, /indexDescription, /pageDescription, /tagListDescription, and /archiveListDescription, keep the translation between 50 and 160 Unicode characters. Preserve placeholders such as {count}, URLs embedded in a string, product names, route paths, and code-like tokens exactly. Use the current translation as terminology context, but return one translation for every supplied id.',
       },
-    },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          targetLocale: metadata.locale,
+          sourcePath: metadata.sourcePath,
+          entries,
+        }),
+      },
+    ],
+    reasoning_effort: BATCH_REASONING_EFFORT,
+    max_completion_tokens: 32768,
+    response_format: createResponseFormat(
+      'site_translation',
+      SITE_RESPONSE_SCHEMA,
+    ),
+    store: false,
   }
 }
 
 function createDeleteBatchRequest(metadata: RequestMetadata): BatchInputLine {
   return {
-    custom_id: encodeMetadata(metadata),
-    method: 'POST',
-    url: BATCH_ENDPOINT,
-    body: {
-      model: BATCH_MODEL,
-      reasoning: { effort: 'max' },
-      instructions: 'Return the requested JSON object without additional text.',
-      input: 'Confirm this translation source deletion.',
-      text: {
-        format: createResponseFormat(
-          'translation_delete',
-          DELETE_RESPONSE_SCHEMA,
-        ),
+    external_reference: encodeMetadata(metadata),
+    messages: [
+      {
+        role: 'system',
+        content: 'Return the requested JSON object without additional text.',
       },
-    },
+      {
+        role: 'user',
+        content: 'Confirm this translation source deletion.',
+      },
+    ],
+    reasoning_effort: BATCH_REASONING_EFFORT,
+    max_completion_tokens: 256,
+    response_format: createResponseFormat(
+      'translation_delete',
+      DELETE_RESPONSE_SCHEMA,
+    ),
+    store: false,
   }
 }
 
-function requireApiKey(): string {
-  const key = process.env.OPENAI_TRANSLATION_API_KEY
-  if (!key) throw new Error('OPENAI_TRANSLATION_API_KEY is required')
-  return key
+function requireCloudflareAccountId(): string {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
+  if (!accountId) throw new Error('CLOUDFLARE_ACCOUNT_ID is required')
+  return accountId
 }
 
-async function openAiFetch(
-  pathName: string,
-  init: RequestInit = {},
-): Promise<Response> {
-  const response = await fetch(`${API_BASE_URL}${pathName}`, {
-    ...init,
+function requireCloudflareApiToken(): string {
+  const token = process.env.CLOUDFLARE_WORKERS_AI_API_TOKEN?.trim()
+  if (!token) {
+    throw new Error('CLOUDFLARE_WORKERS_AI_API_TOKEN is required')
+  }
+  return token
+}
+
+function getWorkersAiBatchUrl(): string {
+  return `${API_BASE_URL}/accounts/${requireCloudflareAccountId()}/ai/run/${BATCH_MODEL}?queueRequest=true`
+}
+
+async function workersAiBatchRequest(
+  body: JsonRecord,
+): Promise<CloudflareBatchResult> {
+  const response = await fetch(getWorkersAiBatchUrl(), {
+    method: 'POST',
     headers: {
-      Authorization: `Bearer ${requireApiKey()}`,
-      ...(init.headers ?? {}),
+      Accept: 'application/json',
+      Authorization: `Bearer ${requireCloudflareApiToken()}`,
+      'Content-Type': 'application/json',
     },
+    body: JSON.stringify(body),
   })
   if (!response.ok) {
     throw new Error(
-      `OpenAI API ${init.method ?? 'GET'} ${pathName} failed: ${response.status} ${await response.text()}`,
+      `Workers AI Batch API failed: ${response.status} ${await response.text()}`,
     )
   }
-  return response
-}
-
-async function openAiJson<T>(
-  pathName: string,
-  init: RequestInit = {},
-): Promise<T> {
-  const response = await openAiFetch(pathName, init)
-  return (await response.json()) as T
-}
-
-async function uploadBatchInput(jsonl: string): Promise<OpenAiFile> {
-  const form = new FormData()
-  form.set('purpose', 'batch')
-  form.set(
-    'file',
-    new Blob([jsonl], { type: 'application/jsonl' }),
-    'acecore-net-translation.jsonl',
-  )
-  const response = await openAiFetch('/files', { method: 'POST', body: form })
-  return (await response.json()) as OpenAiFile
-}
-
-async function createBatch(
-  inputFileId: string,
-  headSha: string,
-): Promise<OpenAiBatch> {
-  return openAiJson<OpenAiBatch>('/batches', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      input_file_id: inputFileId,
-      endpoint: BATCH_ENDPOINT,
-      completion_window: '24h',
-      metadata: {
-        [BATCH_METADATA_KEY]: BATCH_METADATA_VALUE,
-        repository:
-          process.env.GITHUB_REPOSITORY ?? 'acecore-systems/acecore-net',
-        source_commit: headSha,
-      },
-    }),
-  })
+  const envelope = (await response.json()) as CloudflareBatchEnvelope
+  if (!envelope.success || !envelope.result) {
+    throw new Error(
+      `Workers AI Batch API rejected the request: ${JSON.stringify(envelope.errors ?? [])}`,
+    )
+  }
+  return envelope.result
 }
 
 function sourceAtCurrentRefMatches(
@@ -1151,34 +1139,51 @@ async function submitBatch(args: ParsedArgs): Promise<void> {
     return
   }
 
-  const inputFile = await uploadBatchInput(
-    `${inputs.map((input) => JSON.stringify(input)).join('\n')}\n`,
-  )
-  const batch = await createBatch(inputFile.id, headSha)
+  const requestBody: JsonRecord = { requests: inputs as unknown as JsonValue[] }
+  const requestBytes = Buffer.byteLength(JSON.stringify(requestBody), 'utf8')
+  if (requestBytes >= MAX_BATCH_PAYLOAD_BYTES) {
+    throw new Error(
+      `Workers AI Batch payload must be under 10 MB; received ${requestBytes} bytes`,
+    )
+  }
+  const batch = await workersAiBatchRequest(requestBody)
+  if (batch.status !== 'queued' || !batch.request_id) {
+    throw new Error('Workers AI Batch submission returned no queued request_id')
+  }
   console.log(
-    `Submitted OpenAI translation batch ${batch.id} (${inputs.length} requests).`,
+    `Submitted Workers AI translation batch ${batch.request_id} (${inputs.length} requests).`,
   )
-  writeOutput('batch_id', batch.id)
+  writeOutput('batch_id', batch.request_id)
+  writeOutput('pending_marker_path', writePendingMarker(batch.request_id))
 }
 
 function getResponseText(body: JsonRecord): string {
-  if (typeof body.output_text === 'string') return body.output_text
-  const output = body.output
-  if (!Array.isArray(output)) throw new Error('Responses output is missing')
-  const parts: string[] = []
-  for (const item of output) {
-    if (!isJsonRecord(item) || !Array.isArray(item.content)) continue
-    for (const content of item.content) {
-      if (isJsonRecord(content) && typeof content.text === 'string') {
-        parts.push(content.text)
-      }
-    }
+  if (!Array.isArray(body.choices) || body.choices.length !== 1) {
+    throw new Error('Chat Completions output must contain exactly one choice')
   }
-  if (parts.length === 0) throw new Error('Responses output text is missing')
-  return parts.join('')
+  const choice = body.choices[0]
+  if (
+    !isJsonRecord(choice) ||
+    choice.index !== 0 ||
+    choice.finish_reason !== 'stop' ||
+    !isJsonRecord(choice.message)
+  ) {
+    throw new Error('Chat Completions output is incomplete or malformed')
+  }
+  if (
+    typeof choice.message.refusal === 'string' &&
+    choice.message.refusal.trim()
+  ) {
+    throw new Error('Chat Completions output was refused')
+  }
+  const content = choice.message.content
+  if (typeof content !== 'string' || !content.trim()) {
+    throw new Error('Chat Completions output text is missing')
+  }
+  return content
 }
 
-function parseJsonResponse(body: JsonRecord): JsonRecord {
+export function parseJsonResponse(body: JsonRecord): JsonRecord {
   const parsed = JSON.parse(getResponseText(body)) as unknown
   if (!isJsonRecord(parsed))
     throw new Error('Translation response must be a JSON object')
@@ -1364,45 +1369,19 @@ function applySiteDeletion(metadata: RequestMetadata): boolean {
   return changed
 }
 
-function parseOutputLines(source: string): BatchOutputLine[] {
-  return source
-    .split(/\r?\n/)
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as BatchOutputLine)
-}
-
-async function listBatches(): Promise<OpenAiBatch[]> {
-  const response = await openAiJson<OpenAiBatchList>('/batches?limit=100')
-  return response.data
-}
-
-async function getBatchOutput(batch: OpenAiBatch): Promise<BatchOutputLine[]> {
-  if (!batch.output_file_id)
-    throw new Error(`Batch ${batch.id} has no output file`)
-  const response = await openAiFetch(
-    `/files/${encodeURIComponent(batch.output_file_id)}/content`,
-  )
-  return parseOutputLines(await response.text())
-}
-
-function isTranslationBatch(batch: OpenAiBatch): boolean {
-  return batch.metadata?.[BATCH_METADATA_KEY] === BATCH_METADATA_VALUE
-}
-
-function selectCompletedBatch(
-  batches: readonly OpenAiBatch[],
+export async function findCompletedPendingBatch(
+  pending: readonly string[],
   processed: ReadonlySet<string>,
-): OpenAiBatch | null {
-  return (
-    [...batches]
-      .filter(
-        (batch) =>
-          isTranslationBatch(batch) &&
-          batch.status === 'completed' &&
-          !processed.has(batch.id),
-      )
-      .sort((left, right) => left.created_at - right.created_at)[0] ?? null
-  )
+  request: (
+    body: JsonRecord,
+  ) => Promise<CloudflareBatchResult> = workersAiBatchRequest,
+): Promise<{ batchId: string; batch: CloudflareBatchResult } | null> {
+  for (const batchId of pending) {
+    if (processed.has(batchId)) continue
+    const batch = await request({ request_id: batchId })
+    if (Array.isArray(batch.responses)) return { batchId, batch }
+  }
+  return null
 }
 
 function makePrBody(
@@ -1419,7 +1398,7 @@ function makePrBody(
     ...[...uniqueMarkers.values()].map(sourceMarker),
     '',
     '## 概要',
-    '- OpenAI Batch（gpt-5.6-luna / reasoning max）で最新の日本語sourceを翻訳しました。',
+    '- Cloudflare Workers AI Batch（GLM 5.3 Flash / reasoning high）で最新の日本語sourceを翻訳しました。',
     '- sourceHash が現在の日本語sourceと一致する結果だけを含めています。',
     '',
     '## 確認',
@@ -1455,6 +1434,17 @@ function writeProcessedMarker(batchId: string): string {
   return outputPath
 }
 
+function writePendingMarker(batchId: string): string {
+  const outputDirectory = process.env.RUNNER_TEMP ?? '.tmp'
+  mkdirSync(outputDirectory, { recursive: true })
+  const outputPath = path.join(
+    outputDirectory,
+    `workers-ai-translation-pending-${batchId}.txt`,
+  )
+  writeFileSync(outputPath, `${batchId}\n`)
+  return outputPath
+}
+
 function writeOutput(key: string, value: string): void {
   if (process.env.GITHUB_OUTPUT) {
     writeFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`, { flag: 'a' })
@@ -1473,12 +1463,14 @@ function writeCollectedOutputs(result: CollectedResult): void {
 
 async function collectBatch(args: ParsedArgs): Promise<void> {
   await closeStaleOpenAiTranslationPullRequests()
-  const batch = selectCompletedBatch(
-    await listBatches(),
+  const completed = await findCompletedPendingBatch(
+    args.pendingBatchIds,
     args.processedBatchIds,
   )
-  if (!batch) {
-    console.log('No unprocessed completed OpenAI translation batches found.')
+  if (!completed) {
+    console.log(
+      'No unprocessed completed Workers AI translation batches found.',
+    )
     writeCollectedOutputs({
       processedBatchId: null,
       hasChanges: false,
@@ -1488,12 +1480,16 @@ async function collectBatch(args: ParsedArgs): Promise<void> {
     return
   }
 
-  const outputs = await getBatchOutput(batch)
+  const { batchId, batch } = completed
+
+  const outputs = batch.responses ?? []
   let hasChanges = false
   const appliedMarkers: RequestMetadata[] = []
   for (const output of outputs) {
-    if (!output.response || output.response.status_code !== 200) continue
-    const metadata = decodeMetadata(output.custom_id)
+    if (!output.success || !isJsonRecord(output.result)) {
+      throw new Error(`Workers AI Batch ${batchId} contains a failed request`)
+    }
+    const metadata = decodeMetadata(output.external_reference)
     if (getCurrentSourceHash(metadata) !== metadata.sourceHash) {
       console.log(
         `Discarded stale translation result for ${metadata.sourcePath}`,
@@ -1501,7 +1497,7 @@ async function collectBatch(args: ParsedArgs): Promise<void> {
       continue
     }
 
-    const response = parseJsonResponse(output.response.body)
+    const response = parseJsonResponse(output.result)
     const changed =
       metadata.kind === 'blog'
         ? applyBlogTranslation(metadata, response)
@@ -1514,17 +1510,17 @@ async function collectBatch(args: ParsedArgs): Promise<void> {
     appliedMarkers.push(metadata)
   }
 
-  const bodyPath = hasChanges ? writePrBody(batch.id, appliedMarkers) : null
+  const bodyPath = hasChanges ? writePrBody(batchId, appliedMarkers) : null
   writeCollectedOutputs({
-    processedBatchId: batch.id,
+    processedBatchId: batchId,
     hasChanges,
     bodyPath,
-    batchId: batch.id,
+    batchId,
   })
   console.log(
     hasChanges
-      ? `Applied current results from ${batch.id}.`
-      : `No current file changes from ${batch.id}.`,
+      ? `Applied current results from ${batchId}.`
+      : `No current file changes from ${batchId}.`,
   )
 }
 
@@ -1587,7 +1583,8 @@ async function closeStaleOpenAiTranslationPullRequests(): Promise<void> {
     if (
       typeof pull.number !== 'number' ||
       typeof pull.head?.ref !== 'string' ||
-      !pull.head.ref.startsWith('translation/openai/')
+      (!pull.head.ref.startsWith('translation/openai/') &&
+        !pull.head.ref.startsWith('translation/workers-ai/'))
     ) {
       continue
     }
@@ -1609,7 +1606,7 @@ async function closeStaleOpenAiTranslationPullRequests(): Promise<void> {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ state: 'closed' }),
     })
-    console.log(`Closed stale OpenAI translation PR #${pull.number}.`)
+    console.log(`Closed stale translation PR #${pull.number}.`)
   }
 }
 

--- a/tests/openai-translation-batch.test.ts
+++ b/tests/openai-translation-batch.test.ts
@@ -6,8 +6,10 @@ import { test } from 'node:test'
 import {
   areOpenAiTranslationMarkersCurrent,
   decodeMetadata,
+  findCompletedPendingBatch,
   getSiteFragment,
   hashSource,
+  parseJsonResponse,
 } from '../scripts/openai-translation-batch.ts'
 
 test('sourceHashは改行コード差を同じ版として扱う', () => {
@@ -33,6 +35,62 @@ test('ページsourceは対応する翻訳JSONのpages配下だけを更新す�
     getSiteFragment('src/i18n/source/ja/pages/home.json').targetPath,
     ['pages', 'home'],
   )
+})
+
+test('queuedの新しいBatchを飛ばして完了済みBatchを回収する', async () => {
+  const requested: string[] = []
+  const completed = await findCompletedPendingBatch(
+    ['new-queued', 'old-completed', 'already-processed'],
+    new Set(['already-processed']),
+    async (body) => {
+      const requestId = String(body.request_id)
+      requested.push(requestId)
+      return requestId === 'old-completed'
+        ? { responses: [], status: 'complete' }
+        : { status: 'queued' }
+    },
+  )
+
+  assert.deepEqual(requested, ['new-queued', 'old-completed'])
+  assert.equal(completed?.batchId, 'old-completed')
+})
+
+test('Batchの部分完了・refusal・複数choiceを翻訳へ適用しない', () => {
+  assert.deepEqual(
+    parseJsonResponse({
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'stop',
+          message: { content: '{"translated":true}', refusal: null },
+        },
+      ],
+    }),
+    { translated: true },
+  )
+  for (const response of [
+    {
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'length',
+          message: { content: '{"partial":true}' },
+        },
+      ],
+    },
+    {
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'stop',
+          message: { content: '{}', refusal: 'blocked' },
+        },
+      ],
+    },
+    { choices: [] },
+  ]) {
+    assert.throws(() => parseJsonResponse(response))
+  }
 })
 
 test('PRはsource markerを必須とし、sourceHashが異なる場合は古い版として扱う', () => {
@@ -69,7 +127,7 @@ test('PRはsource markerを必須とし、sourceHashが異なる場合は古い�
   assert.equal(areOpenAiTranslationMarkersCurrent('markerなし'), false)
 })
 
-test('WorkflowはLuna/maxをBatchへ投入し、回収後にBot PRを作る', async () => {
+test('WorkflowはGLM 5.3 Flash/highをWorkers AI Batchへ投入し、回収後にBot PRを作る', async () => {
   const submitWorkflow = await readFile(
     '.github/workflows/submit-openai-translation-batch.yml',
     'utf8',
@@ -79,17 +137,18 @@ test('WorkflowはLuna/maxをBatchへ投入し、回収後にBot PRを作る', as
     'utf8',
   )
 
-  assert.match(submitWorkflow, /OPENAI_TRANSLATION_API_KEY/u)
+  assert.match(submitWorkflow, /CLOUDFLARE_WORKERS_AI_API_TOKEN/u)
+  assert.match(submitWorkflow, /workers-ai-translation-pending-/u)
   assert.match(submitWorkflow, /sleep 900/u)
   assert.doesNotMatch(submitWorkflow, /cms_only|cms-only/u)
-  assert.match(collectWorkflow, /translation\/openai\//u)
+  assert.match(collectWorkflow, /translation\/workers-ai\//u)
   assert.match(
     collectWorkflow,
     /client-id:\s+\$\{\{ secrets\.TRANSLATION_BOT_CLIENT_ID \}\}/u,
   )
   assert.doesNotMatch(collectWorkflow, /TRANSLATION_BOT_APP_ID/u)
   assert.doesNotMatch(collectWorkflow, /^\s+app-id:/mu)
-  assert.match(collectWorkflow, /openai-translation-processed-/u)
+  assert.match(collectWorkflow, /workers-ai-translation-processed-/u)
   assert.match(collectWorkflow, /Format collected translation files/u)
   assert.match(collectWorkflow, /git diff --name-only --diff-filter=ACMRT -z/u)
   assert.match(collectWorkflow, /npx prettier --write --/u)
@@ -102,5 +161,9 @@ test('WorkflowはLuna/maxをBatchへ投入し、回収後にBot PRを作る', as
     'utf8',
   )
   assert.match(batchScript, /closeStaleOpenAiTranslationPullRequests/u)
+  assert.match(batchScript, /@cf\/zai-org\/glm-5\.3-flash/u)
+  assert.match(batchScript, /BATCH_REASONING_EFFORT = 'high'/u)
+  assert.match(batchScript, /queueRequest=true/u)
+  assert.doesNotMatch(batchScript, /api\.openai\.com\/v1/u)
   assert.match(batchScript, /between 50 and 160 Unicode characters/u)
 })

--- a/tests/translation-merge.test.ts
+++ b/tests/translation-merge.test.ts
@@ -31,10 +31,10 @@ function createPullRequest(
     number: 42,
     state: 'open',
     baseRef: 'main',
-    headRef: 'translation/openai/batch_example',
+    headRef: 'translation/workers-ai/batch_example',
     headSha: HEAD_SHA,
     headRepositoryFullName: REPOSITORY.repository,
-    title: '[translation] OpenAI Batch batch_example',
+    title: '[translation] Workers AI Batch batch_example',
     body: null,
     authorLogin: 'acecore-translation-bot[bot]',
     draft: true,
@@ -80,6 +80,16 @@ test('PR番号は安全な正整数だけを受け入れ、未知の引数で停
 })
 
 test('対象外のPRは翻訳自動マージ対象にしない', () => {
+  assert.equal(
+    isEligibleTranslationPullRequest(
+      createPullRequest({
+        headRef: 'translation/openai/batch_legacy',
+        title: '[translation] OpenAI Batch batch_legacy',
+      }),
+      REPOSITORY,
+    ),
+    true,
+  )
   assert.equal(
     isEligibleTranslationPullRequest(createPullRequest(), REPOSITORY),
     true,
@@ -228,7 +238,7 @@ test('検証済みhead SHAとsquash方式を固定してGitHub Auto-mergeを予�
   assert.deepEqual(graphqlCalls[0]?.variables, {
     pullRequestId: 'PR_kwDORlSgas123',
     expectedHeadOid: HEAD_SHA,
-    commitHeadline: '[translation] OpenAI Batch batch_example',
+    commitHeadline: '[translation] Workers AI Batch batch_example',
   })
 })
 


### PR DESCRIPTION
## 概要

- 夜間自動翻訳だけをWorkers AI Batch / `@cf/zai-org/glm-5.3-flash`へ移行する隔離PR
- AI問い合わせの本番移行とは分離し、現在のmainを基点に翻訳workflow・script・test・運用文書だけを収録

## 状態

- ユーザー指定により本番対象外
- `CLOUDFLARE_WORKERS_AI_API_TOKEN`を設定せず、workflowを有効化しない
- shadow評価、Batch API実データ検証、翻訳品質確認が完了するまでDraftのまま維持

## 差分範囲

- 翻訳workflow 4件
- 翻訳Batch submit/collectおよびmerge script
- 翻訳回帰テスト
- 翻訳運用README / docs
